### PR TITLE
Fix issue #264: white sprites in Pokecenter town map

### DIFF
--- a/engine/pokegear.asm
+++ b/engine/pokegear.asm
@@ -1760,6 +1760,7 @@ _TownMap: ; 9191c
 	call ClearTileMap
 	call ClearSprites
 	call DisableLCD
+	farcall InitPokegearPalettes
 	call Pokegear_LoadGFX
 	farcall ClearSpriteAnims
 	ld a, 8


### PR DESCRIPTION
Sprite palettes were never initialized after FadeToWhite set all wUnknOBPals values to $FF