### PR TITLE
Fix #272 - perfect DV stat calcs

### DIFF
--- a/engine/move_mon.asm
+++ b/engine/move_mon.asm
@@ -1697,7 +1697,7 @@ CalcPkmnStatC: ; e17b
 	bit PERFECT_IVS_OPT, a
 	ld a, $f
 	jr nz, .GotDV
-	ld a, b
+	ld a, d
 	push bc
 .hyper_training_loop
 	rlca


### PR DESCRIPTION
Line 1700 in engine/move_mon.asm should be ld a, d not ld a, b

Register b by this point is the Pokemon's EVs, not the bit array for which stat to hyper train. That had been copied into register d though, so loading the correct register fixed this. This also properly fixed the other issue I pointed out with hyper training, so barring anything unforeseen I think it's safe to call request #272 closed.

As a side note, if it's desired to skip the hyper training loop for whatever reason, the code
`and $fc`
`jr z, .not_hyper_trained`
can be inserted at line 1701, but I didn't feel it was necessary to take up four extra bytes just to save the cycles as there's otherwise no harm in going through the loop anyway.