### PR TITLE
fix Battle Tower glitchy parties

### DIFF
--- a/data/battle_tower/parties.asm
+++ b/data/battle_tower/parties.asm
@@ -6,6 +6,7 @@ BattleTowerPokemon1:
 	db PERFECT_DVS
 	db HIDDEN_ABILITY | CALM, MALE ; Thick Fat, +SpDef -Atk
 
+BattleTowerPokemon2:
 	db VENUSAUR, LIFE_ORB
 	db GROWTH, SLUDGE_BOMB, GIGA_DRAIN, HIDDEN_POWER
 	db BTDVS_HP_FIRE
@@ -42,7 +43,6 @@ BattleTowerPokemon1:
 	db $bd, $db, $dd ; DVs
 	db ABILITY_1 | QUIRKY, MALE ; Personality
 
-BattleTowerPokemon2:
 	db ESPEON
 	db LEFTOVERS
 	db MUD_SLAP, PSYCHIC_M, CALM_MIND, TOXIC


### PR DESCRIPTION
Battle Tower parties will not load properly since the BattleTowerPokemon2 label is misplaced, and that label is used to determine the size of the Battle Tower Pokemon set. Putting this where it needs to be fixes that issue.