### PR TITLE
fix substitute issue/remove unnecessary frame delay

### DIFF
--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -4935,11 +4935,11 @@ SelfInflictDamageToSubstitute: ; 35de0
 	ld hl, SubTookDamageText
 	call StdBattleTextBox
 
-	ld de, wEnemySubstituteHP
+	ld de, wEnemySubstituteHP+1 ; hp is big-endian
 	ld a, [hBattleTurn]
 	and a
 	jr z, .got_hp
-	ld de, wPlayerSubstituteHP
+	ld de, wPlayerSubstituteHP+1
 .got_hp
 
 	ld hl, wCurDamage

--- a/engine/selectmenu.asm
+++ b/engine/selectmenu.asm
@@ -151,7 +151,6 @@ GetRegisteredItem:
 	farcall ReanchorBGMap_NoOAMUpdate
 	call SafeUpdateSprites
 	call BGMapAnchorTopLeft
-	call DelayFrame
 	call LoadStandardOpaqueFont
 	ld hl, InvertedTextPalette
 	ld de, wUnknBGPals palette PAL_BG_TEXT


### PR DESCRIPTION
Substitutes will always break after one hit because HP is stored as big-endian but treated (for substitutes) as little-endian. This code fixes that. Arguably, it's debatable if we even need two bytes for substitute, given the maximum substitute HP possible is 178 (from Blissey's max HP of 714), which can be stored in one byte, but since HP is otherwise stored as two bytes I'll just leave it alone. Important to note is that making that change would require getting rid of these +1 I just added as they'll lead to trouble.

Also, there's an unnecessary call to DelayFrame I left behind from the select menu fix, so this will just clean that up.