### PR TITLE
set of bug fixes, including switch/predict bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,16 +85,12 @@ crystal: FILLER = 0x00
 crystal: ROM_NAME = $(NAME)-$(VERSION)
 crystal: $(NAME)-$(VERSION).gbc
 
-faithful: ROM_NAME = $(NAME)-$(VERSION)-faithful
-faithful: $(NAME)-$(VERSION)-faithful.gbc
-
+faithful: crystal
 nortc: crystal
 monochrome: crystal
 noir: crystal
 hgss: crystal
-
-debug: ROM_NAME = $(NAME)-$(VERSION)-debug
-debug: $(NAME)-$(VERSION)-debug.gbc
+debug: crystal
 
 bankfree: FILLER = 0xff
 bankfree: ROM_NAME = $(NAME)-$(VERSION)-0xff

--- a/Makefile
+++ b/Makefile
@@ -85,12 +85,16 @@ crystal: FILLER = 0x00
 crystal: ROM_NAME = $(NAME)-$(VERSION)
 crystal: $(NAME)-$(VERSION).gbc
 
-faithful: crystal
+faithful: ROM_NAME = $(NAME)-$(VERSION)-faithful
+faithful: $(NAME)-$(VERSION)-faithful.gbc
+
 nortc: crystal
 monochrome: crystal
 noir: crystal
 hgss: crystal
-debug: crystal
+
+debug: ROM_NAME = $(NAME)-$(VERSION)-debug
+debug: $(NAME)-$(VERSION)-debug.gbc
 
 bankfree: FILLER = 0xff
 bankfree: ROM_NAME = $(NAME)-$(VERSION)-0xff

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -3241,6 +3241,8 @@ EnemySwitch: ; 3d4e1
 	inc a
 	ld [wEnemyIsSwitching], a
 	call LoadTileMapToTempTileMap
+	ld a, [wCurBattleMon]
+	ld [wCurPartyMon], a
 	jp PlayerSwitch
 ; 3d517
 
@@ -3484,8 +3486,6 @@ OfferSwitch: ; 3d74b
 	call SetUpBattlePartyMenu_NoLoop
 	call PickSwitchMonInBattle
 	jr c, .canceled_switch
-	ld a, [wCurBattleMon]
-	ld [wLastPlayerMon], a
 	ld a, [wCurPartyMon]
 	ld [wCurBattleMon], a
 	call ClearPalettes
@@ -4208,8 +4208,7 @@ PursuitSwitch: ; 3dc5b
 	ld a, [hBattleTurn]
 	and a
 	jr z, .check_enemy_fainted
-	ld a, [wCurBattleMon]
-	call UpdateBattleMon
+	call UpdateBattleMonInParty
 	call HasPlayerFainted
 	jr nz, PursuitSwitch_done
 	jr .done_fainted
@@ -5177,7 +5176,10 @@ BattleMenu_SafariBall:
 	farcall CheckItemPocket
 	ld a, [wItemAttributeParamBuffer]
 	cp BALL
+	push af
 	call nz, ClearBGPalettes
+	pop af
+	call nz, ClearTileMap
 	xor a
 	ld [hBGMapMode], a
 	call _LoadBattleFontsHPBar
@@ -5553,8 +5555,6 @@ BattleMonEntrance: ; 3e40b
 	lb bc, 5, 11
 	call ClearBox
 
-	ld a, [wCurBattleMon]
-	ld [wLastPlayerMon], a
 	ld a, [wCurPartyMon]
 	ld [wCurBattleMon], a
 	call AddBattleParticipant

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -5176,10 +5176,10 @@ BattleMenu_SafariBall:
 	farcall CheckItemPocket
 	ld a, [wItemAttributeParamBuffer]
 	cp BALL
-	push af
-	call nz, ClearBGPalettes
-	pop af
-	call nz, ClearTileMap
+	jr z, .ball
+	call ClearBGPalettes
+	call ClearTileMap
+.ball
 	xor a
 	ld [hBGMapMode], a
 	call _LoadBattleFontsHPBar

--- a/engine/evolve.asm
+++ b/engine/evolve.asm
@@ -242,6 +242,9 @@ endr
 .proceed
 	ld a, [wTempMonLevel]
 	ld [wCurPartyLevel], a
+	ld a, [wTempMonForm]
+	and FORM_MASK
+	ld [wCurForm], a
 	ld a, $1
 	ld [wMonTriedToEvolve], a
 


### PR DESCRIPTION
Fixes #287 - this one was entirely my bad, when I removed a ton of code from PursuitSwitch to remove the reliance on wLastPlayerMon, I didn't realize that I'd unwittingly removed a bit of code that properly sets which Pokemon we switch into. Loading wCurBattleMon back into wCurPartyMon (since wCurBattleMon is exclusive to the player mon) before calling PlayerSwitch would seem to fix that problem.

Fixes #277 and refactors item_effects.asm - item_effects.asm honestly needed to be cleaned up a bit, and based on my testing the modifications I've made have preserved the exact functionality of the original file, just with a bit more efficiency. The issue with crashing upon evolution is better resolved just by setting wCurForm during the evolution script, since it's only otherwise needed for rare candies and evolution stones and isn't otherwise necessary for any item effects, and is more efficient to insert in evolve.asm rather than fetching it twice in item_effects.asm

Fixes a minor visual bug with the party menu after using an item in battle - because the tilemap wasn't cleared after using an item (such as a potion) on a pokemon in battle, there is a brief moment where the party menu opens up with the palettes of the enemy pokemon before we see the normal battle screen, so adding a conditional call to ClearTileMap addresses that.

Modifies makefile - now, `make` and `make faithful` will create roms with different filenames, so you can build both the faithful and nonfaithful versions without needing to mess around with directories. Same for debug, and arguably we can just extrapolate this to the other options as well.