### PR TITLE
preserve wCurPartyMon/wCurPartySpecies variables while learning move, and other fixes

### DIFF
--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -5253,6 +5253,7 @@ BattleMenuPKMN_Loop:
 
 .Moves:
 	farcall ManagePokemonMoves
+	call GetMonBackpic
 
 .Cancel:
 	jr BattleMenuPKMN_Loop

--- a/engine/evolve.asm
+++ b/engine/evolve.asm
@@ -364,8 +364,10 @@ endr
 	ld a, [wTempMonSpecies]
 	ld [hl], a
 	push hl
+	push de
 	call LearnEvolutionMove
 	call LearnLevelMoves
+	pop de
 	ld l, e
 	ld h, d
 	jp EvolveAfterBattle_MasterLoop

--- a/engine/evolve.asm
+++ b/engine/evolve.asm
@@ -348,10 +348,6 @@ endr
 	xor a
 	ld [wMonType], a
 	ld a, [wd265]
-	push af
-	call LearnEvolutionMove
-	call LearnLevelMoves
-	pop af
 	ld [wd265], a
 	dec a
 	call SetSeenAndCaughtMon
@@ -370,6 +366,10 @@ endr
 	ld a, [wTempMonSpecies]
 	ld [hl], a
 	push hl
+	push af
+	call LearnEvolutionMove
+	call LearnLevelMoves
+	pop af
 	ld l, e
 	ld h, d
 	jp EvolveAfterBattle_MasterLoop
@@ -506,8 +506,11 @@ LearnEvolutionMove:
 	ld [wd265], a
 	call GetMoveName
 	call CopyName1
-	predef LearnMove
 	ld a, [wCurPartySpecies]
+	push af
+	predef LearnMove
+	pop af
+	ld [wCurPartySpecies], a
 	ld [wd265], a
 
 .has_move
@@ -536,7 +539,7 @@ LearnLevelMoves: ; 42487
 .find_move
 	ld a, [hli]
 	and a
-	jr z, .done
+	ret z
 
 	ld b, a
 	ld a, [wCurPartyLevel]
@@ -570,14 +573,14 @@ LearnLevelMoves: ; 42487
 	ld [wd265], a
 	call GetMoveName
 	call CopyName1
+	ld a, [wCurPartySpecies]
+    push af
 	predef LearnMove
+	pop af
+	ld [wCurPartySpecies], a
+	ld [wd265], a
 	pop hl
 	jr .find_move
-
-.done
-	ld a, [wCurPartySpecies]
-	ld [wd265], a
-	ret
 ; 424e1
 
 

--- a/engine/item_effects.asm
+++ b/engine/item_effects.asm
@@ -2047,7 +2047,6 @@ RestoreHealth: ; f2d1 (3:72d1)
 	ld [hl], a
 	jr c, .full_hp
 	call LoadCurHPIntoBuffer5
-	inc hl
 	ld d, h
 	ld e, l
 	call UseItem_GetMaxHPParameter

--- a/engine/startmenu.asm
+++ b/engine/startmenu.asm
@@ -1303,11 +1303,11 @@ ChooseMoveToForget:
 	jr .done
 
 .tm_tutor
-	farcall LoadPartyMenuGFX
-	farcall InitPartyMenuWithCancel
-	farcall InitPartyMenuGFX
-	farcall WritePartyMenuTilemap
-	farcall PrintPartyMenuText
+	ld a, [wCurPartyMon]
+	push af
+	farcall InitPartyMenuLayout
+	pop af
+	ld [wCurPartyMon], a
 	call SpeechTextBox
 .done
 	call ApplyTilemapInVBlank
@@ -1333,11 +1333,7 @@ ChooseMoveToRelearn:
 	call ClearBGPalettes
 	ld a, [wCurPartyMon]
 	push af
-	farcall LoadPartyMenuGFX
-	farcall InitPartyMenuWithCancel
-	farcall InitPartyMenuGFX
-	farcall WritePartyMenuTilemap
-	farcall PrintPartyMenuText
+	farcall InitPartyMenuLayout
 	pop af
 	ld [wCurPartyMon], a
 	pop af


### PR DESCRIPTION
Fixes #250 and fixes #260

Both these issues have the same source:
- have a Pokemon trying to learn a move in the overworld
- open up that Pokemon's forget a move screen
- close that screen

You'll be back in the party menu, and if the Pokemon isn't 6th in your party you'll enter a glitchy state. This is because wCurPartyMon and wCurPartySpecies aren't preserved after redrawing the party menu, so they end up having the values correlating to the last Pokemon in your party. Since that's never reset, it'll lead to problems like the two issues listed above. Preserving those variables solves those problems and also solves an issue where Yanma will not evolve if it learns Ancient Power in the overworld via leveling up.

Also has some minor bugfixes - namely, all HP items restore full health due to the refactor I did, so I removed the offending line, and if the move menu is opened and closed then you switch out from a Pokemon the leaving Pokemon's backpic is messed up, so I called GetMonBackpic after closing the moves menu.