### PR TITLE
fix game crash on opening bag

### DIFF
--- a/gfx/items.asm
+++ b/gfx/items.asm
@@ -19,7 +19,11 @@ UpdateItemIconAndDescriptionAndBagQuantity::
 	farcall UpdateItemDescriptionAndBagQuantity
 UpdateItemIcon::
 	ld hl, ItemIconPointers
-	ld a, [wCurSpecies]
+	ld a, [wCurItem]
+	inc a
+	jr z, .cancel
+	dec a
+.cancel
 	ld e, a
 	ld d, 0
 	add hl, de

--- a/main.asm
+++ b/main.asm
@@ -476,9 +476,9 @@ UpdateKeyItemDescription:
 	hlcoord 0, 12
 	lb bc, 4, SCREEN_WIDTH - 2
 	call TextBox
-	ld a, [wMenuSelection]
-	cp -1
-	ret z
+	; ld a, [wMenuSelection]
+	; cp -1
+	; ret z
 	decoord 1, 14
 	farjp PrintKeyItemDescription
 


### PR DESCRIPTION
Fixes #293 - this wasn't specific to faithful, the issue is that all pointers to NoItemIcon for items past index $EA (including $FF) were removed, so arbitrary code was being executed upon decompressing that sprite. There was a few ways I could've done this but for now I decided to just have it where $FF is checked for in wCurItem, and if it's found then the item icon at pointer $00 is used, which is NoItemIcon. Note that any glitch items $EB to $FE will still crash the game upon opening their icon, so if that's undesirable then use the following code:

`    ld a, [wCurItem]`
`    cp MIRAGE_MAIL + 1`
`    jr c, .has_icon`
`    xor a`
`.has_icon`

in place of the code I used. Note that this will cease to work if an item has an index higher than Mirage Mail ($EA as of this writing). This issue does not occur with Key Items, which handles the cancel option differently.

I also fixed a minor bug where key item descriptions would not show up in the bag.