### PR TITLE
fix game hang on sorting items by name

### DIFF
--- a/engine/switch_items.asm
+++ b/engine/switch_items.asm
@@ -293,6 +293,9 @@ GetSortingItemIndex:
 	dec a
 	jr z, .done
 	ld c, [hl]
+	inc c
+	jr z, .done
+	dec c
 	ld b, 0
 	ld hl, ItemNameOrder
 	add hl, bc


### PR DESCRIPTION
Fixes #298 - the reason the sort crashes is because Cancel ($FF) gets its sort item index (arbitrary value) before any checks for whether $FF is selected takes place. Ensuring that GetSortingItemIndex returns a = $FF when Cancel comes up means the sort can exit successfully. I presume this came about due to item_constants.asm no longer making constants for unused indexes, so we'll have to keep an eye out for similar issues going forward.