### PR TITLE
fix crash on using FailText_CheckOpponentProtect

### DIFF
--- a/constants/battle_constants.asm
+++ b/constants/battle_constants.asm
@@ -154,13 +154,13 @@ endc
 
 ; attack failure modes, higher gives priority
 ; TODO: complete this functionality
-	const_def 1
+	const_def
+	const ATKFAIL_CUSTOM  ; custom message
 	const ATKFAIL_MISSED  ; "<USER>'s attack missed!"
 	const ATKFAIL_PROTECT ; "<TARGET> is protecting itself!"
 	const ATKFAIL_ABILITY ; ability immunity, might have side effects
 	const ATKFAIL_GENERIC ; "But it failed!"
 	const ATKFAIL_IMMUNE  ; "It doesn't affect <TARGET>!"
-	const ATKFAIL_CUSTOM  ; custom message
 
 ; battle variables
 	const_def

--- a/constants/battle_constants.asm
+++ b/constants/battle_constants.asm
@@ -154,13 +154,13 @@ endc
 
 ; attack failure modes, higher gives priority
 ; TODO: complete this functionality
-	const_def
-	const ATKFAIL_CUSTOM  ; custom message
+	const_def 1
 	const ATKFAIL_MISSED  ; "<USER>'s attack missed!"
 	const ATKFAIL_PROTECT ; "<TARGET> is protecting itself!"
 	const ATKFAIL_ABILITY ; ability immunity, might have side effects
 	const ATKFAIL_GENERIC ; "But it failed!"
 	const ATKFAIL_IMMUNE  ; "It doesn't affect <TARGET>!"
+	const ATKFAIL_CUSTOM  ; custom message
 
 ; battle variables
 	const_def

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -2629,10 +2629,14 @@ FailText_CheckOpponentProtect: ; 35157
 ; An wAttackMissed value of something other than 1 can override
 ; the message, used for Protect and some abilities.
 ; Important: To ensure proper message order, wAttackMissed=3
-; has side effects -- it triggers the ability.
+; has side effects -- it triggers the ability. Also,
+; cp ATKFAIL_CUSTOM is used first since ATKFAIL_CUSTOM!=1 and
+; hl is otherwise overwritten.
 ; TODO: use this function more extensively
 	ld a, [wAttackMissed]
 	and a
+	ret z
+	cp ATKFAIL_CUSTOM
 	jr z, .printmsg
 	dec a
 	ld hl, AttackMissedText

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -2635,6 +2635,7 @@ FailText_CheckOpponentProtect: ; 35157
 	and a
 	jr z, .printmsg
 	dec a
+	ld hl, AttackMissedText
 	jr z, .printmsg
 	dec a
 	ld hl, ProtectingItselfText


### PR DESCRIPTION
Fixes #266 - game would (sometimes) crash when using Roar on a flying/digging mon because text wasn't properly loading text when wAttackMissed = 1. Also, the constant ATKFAIL_CUSTOM should actually have a value of zero, not six to match up with the jump table set up. I know there's a TODO to use it more often and I believe it is now correctly set up. I do think it should use a more generic name, but I can't immediately think of one, sorry.