### PR TITLE
fix off-by-one error for key item ball

### DIFF
--- a/engine/events/itemball.asm
+++ b/engine/events/itemball.asm
@@ -65,6 +65,7 @@ FindKeyItemInBallScript::
 	xor a
 	ld [wScriptVar], a
 	ld a, [wCurItemBallContents]
+	inc a
 	ld [wNamedObjectIndexBuffer], a
 	call GetKeyItemName
 	ld hl, wStringBuffer3

--- a/home.asm
+++ b/home.asm
@@ -480,7 +480,6 @@ GetName:: ; 33c3
 	jr .done
 
 .NotPokeName:
-	ld a, [wNamedObjectTypeBuffer]
 	dec a
 	ld e, a
 	ld d, 0


### PR DESCRIPTION
Fixes #301 

Not really much to say. I did delete an unnecessary `ld a, [wNamedObjectTypeBuffer]` that gamefreak was kind enough to leave for us, though. I have to wonder if it might be a good idea to refactor how key item names are fetched by having the `inc a` simply occur in `GetKeyItemName` instead of all these disparate areas, but I'll leave that up to you since I may not be taking everything into account here.