### PR TITLE
fix slow_jump_step_* movements

### DIFF
--- a/data/pokemon/evos_attacks.asm
+++ b/data/pokemon/evos_attacks.asm
@@ -1469,8 +1469,8 @@ SlowpokeEvosAttacks:
 	db EVOLVE_HOLDING, KINGS_ROCK, SLOWKING
 	db EVOLVE_LEVEL, 37, SLOWBRO
 	db 0 ; no more evolutions
-	db 1, CURSE
 	db 1, TACKLE
+	db 1, CURSE
 	db 5, GROWL
 	db 9, WATER_GUN
 	db 14, CONFUSION

--- a/engine/map_objects.asm
+++ b/engine/map_objects.asm
@@ -1771,12 +1771,18 @@ SkyfallTop: ; 4f83
 
 UpdateJumpPosition: ; 4fd5
 	call GetStepVector
+	push af
 	ld a, h
 	ld hl, OBJECT_31
 	add hl, bc
 	ld e, [hl]
 	add e
 	ld [hl], a
+	pop af
+	cp 32 ; is duration slow jump?
+	jr nz, .not_slow_jump
+	srl e
+.not_slow_jump
 	srl e
 	ld d, 0
 	ld hl, .y


### PR DESCRIPTION
Fixes #283 - this wasn't a script issue, it was an engine issue regarding an interaction between movement speed and duration from StepVectors and the Y-offset table from UpdateJumpPosition. Structurally, a jump is two parts - .Jump and .Land, both of which have the same max number of frames for each movement type. A slow movement takes 32 frames, so .Jump = 32 frames and .Land = 32 frames for a total of 64 frames per jump. Speed, as it relates to jumps, determines the rate at which the Y-offset changes for a sprite per frame. It's calculated as n/2 updates per frame. A slow jump has a speed of 1, so the Y-offset will update once every two frames. UpdateJumpPosition contains a table of 16 Y-offsets that a jump can take in total from start to finish. For a fast jump (2 updates per frame) it would go through every other Y-offset per frame (-4 -> -8 -> -11...) but for a slow jump (update every 2 frames) it will go to the next offset every other frame (-2 -> -2 -> -4 -> -4 -> ...).

So basically, a slow jump takes 64 total frames, and updates a Y-offset once every other frame for a total of 32 Y-offset updates. This is a problem as there are only 16 total Y-offsets in the table, so the .Jump portion looks like a complete jump while the .Land portion is taking in arbitrary Y-offsets and looking like a mess. Only expanding the Y-offset table would be problematic as well since normal jumps (duration: 16, speed: 1) would only make it through half the table before finishing, meaning the player would be stuck with a Y-offset of -12 (obviously not desirable). Similarly, simply modifying the StepVectors table so that speed = 32 / duration wouldn't work either, since a fast jump (duration: 4, speed: 8) would not end on a Y-offset of 0, and I couldn't even predict what other problems could arise from modifying StepVectors like that. Therefore the quick and dirty solution I went with was just to add a special check if the movement is slow, since only slow movement has a duration of 32. If the movement is slow, an extra srl e is done to keep slow jumps within the table.

Also, I changed Slowpoke's moveset slightly so that if it gets its hidden move, Growth, from Slowpoke Well, it'll still have an attacking move (Curse can be taught through TM anyway and TMs are infinite in this game).