### PR TITLE
fix when EV-lowering berries fail

### DIFF
--- a/engine/events/happiness_egg.asm
+++ b/engine/events/happiness_egg.asm
@@ -32,7 +32,7 @@ CheckFirstMonIsEgg: ; 71ac
 
 ChangeHappiness: ; 71c2
 ; Perform happiness action c on wCurPartyMon
-
+; Returns non-carry if happiness changed, carry otherwise
 	ld a, [wCurPartyMon]
 	inc a
 	ld e, a
@@ -41,11 +41,16 @@ ChangeHappiness: ; 71c2
 	add hl, de
 	ld a, [hl]
 	cp EGG
+	scf
 	ret z
 
 	ld hl, wPartyMon1Happiness
 	ld a, [wCurPartyMon]
 	call GetPartyLocation
+	ld a, [hl]
+	inc a ; cp 255
+	scf
+	ret z
 
 	ld d, h
 	ld e, l
@@ -100,6 +105,7 @@ ChangeHappiness: ; 71c2
 	ret nz
 	ld a, [de]
 	ld [wBattleMonHappiness], a
+	xor a
 	ret
 
 INCLUDE "data/events/happiness_changes.asm"

--- a/engine/events/happiness_egg.asm
+++ b/engine/events/happiness_egg.asm
@@ -32,7 +32,7 @@ CheckFirstMonIsEgg: ; 71ac
 
 ChangeHappiness: ; 71c2
 ; Perform happiness action c on wCurPartyMon
-; Returns non-carry if happiness changed, carry otherwise
+
 	ld a, [wCurPartyMon]
 	inc a
 	ld e, a
@@ -41,16 +41,11 @@ ChangeHappiness: ; 71c2
 	add hl, de
 	ld a, [hl]
 	cp EGG
-	scf
 	ret z
 
 	ld hl, wPartyMon1Happiness
 	ld a, [wCurPartyMon]
 	call GetPartyLocation
-	ld a, [hl]
-	inc a ; cp 255
-	scf
-	ret z
 
 	ld d, h
 	ld e, l
@@ -105,7 +100,6 @@ ChangeHappiness: ; 71c2
 	ret nz
 	ld a, [de]
 	ld [wBattleMonHappiness], a
-	xor a
 	ret
 
 INCLUDE "data/events/happiness_changes.asm"

--- a/engine/item_effects.asm
+++ b/engine/item_effects.asm
@@ -125,12 +125,12 @@ ItemEffects: ; e73c
 	dw HealStatusEffect ; LUM_BERRY
 	dw RestoreHPEffect  ; SITRUS_BERRY
 	dw RestoreHPEffect  ; FIGY_BERRY
-	dw LowerEVEffect    ; POMEG_BERRY
-	dw LowerEVEffect    ; KELPSY_BERRY
-	dw LowerEVEffect    ; QUALOT_BERRY
-	dw LowerEVEffect    ; HONDEW_BERRY
-	dw LowerEVEffect    ; GREPA_BERRY
-	dw LowerEVEffect    ; TAMATO_BERRY
+	dw LowerEVBerry     ; POMEG_BERRY
+	dw LowerEVBerry     ; KELPSY_BERRY
+	dw LowerEVBerry     ; QUALOT_BERRY
+	dw LowerEVBerry     ; HONDEW_BERRY
+	dw LowerEVBerry     ; GREPA_BERRY
+	dw LowerEVBerry     ; TAMATO_BERRY
 	dw NoEffect         ; LIECHI_BERRY
 	dw NoEffect         ; GANLON_BERRY
 	dw NoEffect         ; SALAC_BERRY
@@ -1495,7 +1495,7 @@ EvoStoneEffect:
 	jp WontHaveAnyEffectMessage
 ; ee3d
 
-LowerEVEffect:
+LowerEVBerry:
 	ld b, PARTYMENUACTION_HEALING_ITEM
 	call UseItem_SelectMon
 	jp c, ItemNotUsed_ExitMenu
@@ -1516,15 +1516,19 @@ LowerEVEffect:
 	farcall UpdatePkmnStats
 
 .check_happiness
-	ld c, HAPPINESS_USEDEVBERRY
-	farcall ChangeHappiness
-	jr nc, .happiness_changed
+	ld a, MON_HAPPINESS
+	call GetPartyParamLocation
+	ld a, [hl]
+	inc a
+	jr nz, .happiness_changed
 	pop af
 	jr nz, .ev_changed
 	jp WontHaveAnyEffectMessage
 
 .happiness_changed
 	pop af
+	ld c, HAPPINESS_USEDEVBERRY
+	farcall ChangeHappiness
 .ev_changed
 	call GetStatStringAndPlayFullHealSFX
 	ld hl, ItemHappinessRoseButStatFellText

--- a/engine/item_effects.asm
+++ b/engine/item_effects.asm
@@ -1504,7 +1504,8 @@ LowerEVEffect:
 	add hl, bc
 	ld a, [hl]
 	and a
-	jp z, WontHaveAnyEffectMessage
+	push af
+	jr z, .check_happiness
 
 	sub 10
 	jr nc, .ev_value_ok
@@ -1514,12 +1515,20 @@ LowerEVEffect:
 	ld [hl], a
 	farcall UpdatePkmnStats
 
+.check_happiness
+	ld c, HAPPINESS_USEDEVBERRY
+	farcall ChangeHappiness
+	jr nc, .happiness_changed
+	pop af
+	jr nz, .ev_changed
+	jp WontHaveAnyEffectMessage
+
+.happiness_changed
+	pop af
+.ev_changed
 	call GetStatStringAndPlayFullHealSFX
 	ld hl, ItemHappinessRoseButStatFellText
 	call PrintText
-
-	ld c, HAPPINESS_USEDEVBERRY
-	farcall ChangeHappiness
 	jp UseDisposableItem
 
 ItemHappinessRoseButStatFellText:


### PR DESCRIPTION
Previous commit had EV-lowering berries fail if the EV was already zero before use, but in actuality it should only fail if EV is already zero _and_ happiness is already maxed. This PR fixes that. ~~No other functions that called `ChangeHappiness` care about whatever value returns in `a` as far as I can tell, though I do want you to be aware that `a` is now always 0 upon return regardless of success.~~

