### PR TITLE
fix toxic spikes and glitched opponent switch-out

### DIFF
--- a/contents/bank_ends.txt
+++ b/contents/bank_ends.txt
@@ -5,7 +5,7 @@
 > -- Morimoto, Pokémon Ultra Sun/Ultra Moon
 > <https://www.serebii.net/ultrasunultramoon/virtualconsole.shtml>
 
-Free space: 300356/2097152 (14.32%)
+Free space: 300354/2097152 (14.32%)
 
 bank	end	free
 $00	$3dc8	$0238
@@ -117,7 +117,7 @@ $69	$7fff	$0001
 $6a	$7fff	$0001
 $6b	$8000	$0000
 $6c	$8000	$0000
-$6d	$6d00	$1300
+$6d	$6d02	$12fe
 $6e	$4000	$4000
 $6f	$4000	$4000
 $70	$4000	$4000

--- a/engine/battle/ai/switch.asm
+++ b/engine/battle/ai/switch.asm
@@ -203,11 +203,12 @@ AICheckMatchupForEnemyMon:
 	call SetEnemyTurn
 	call UpdateMoveData
 	pop bc
-	ld a, b
 
 	; Reset whose turn it is
 	pop af
 	ldh [hBattleTurn], a
+
+	ld a, b
 	ret
 
 .check_matchups

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -1170,6 +1170,8 @@ endr
 	ld [hli], a
 	ld [hl], a
 
+	ld a, $10
+	ld [wTypeModifier], a
 	ld bc, NUM_LEVEL_STATS
 	ldh a, [hBattleTurn]
 	and a
@@ -2923,7 +2925,6 @@ SendOutPlayerMon:
 	ldh [hGraphicStartTile], a
 	ld [wBattleMenuCursorBuffer], a
 	ld [wCurMoveNum], a
-	ld [wTypeModifier], a
 	ld [wPlayerMoveStruct + MOVE_ANIM], a
 	ld [wPlayerSelectedMove], a
 	ld [wLastPlayerCounterMove], a

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -1522,7 +1522,7 @@ BattleCommand_resettypematchup:
 	ret
 
 .reset
-	ld [wTypeMatchup], a
+	ld [wTypeModifier], a
 	ret
 
 BattleCommand_damagevariation:

--- a/roms.md5
+++ b/roms.md5
@@ -1,1 +1,1 @@
-d3857532197f143d91e537d1527f3445 *polishedcrystal-3.0.0-beta.gbc
+fdd606a76c0b5a107c379e0c8e3b4b8d *polishedcrystal-3.0.0-beta.gbc


### PR DESCRIPTION
Fixes #439 - `wTypeModifier` simply was not reset properly upon switching in a new Pokemon, only being xor'd by `SendOutPlayerMon` and untouched when an opponent sent in a new Pokemon. I basically just made sure $10 was loaded into `wTypeModifier` in `SendInUserPkmn` which handles both player and opponent Pokemon anyway, and subsequently removed the load in `SendOutPlayerMon`. Also, `BattleCommand_resettypematchup` would improperly set `wTypeMatchup` to $10 instead of resetting `wTypeModifier` so I fixed that, though I'm not sure if that ever caused a problem of its own.

Fixes #466 - It's not clear to me if this ties in with fainting from burning at all, but in `AICheckMatchupForEnemyMon` basically the opponent AI would improperly score all potential switches to $0 or $1, depending on whose turn it is, because resetting the battle turn overwrites `a` which would otherwise hold the score value. Ensuring that `ld a, b` (where b is containing the score) is the last modification to `a` before returning from `AICheckMatchupForEnemyMon` means the correct score is returned as expected, and the AI does not try to send out the first Pokemon in the party that has already fainted.