### PR TITLE
a few bug fixes, including a save "corruption" and a crash

### DIFF
--- a/contents/bank_ends.txt
+++ b/contents/bank_ends.txt
@@ -5,7 +5,7 @@
 > -- Morimoto, Pokémon Ultra Sun/Ultra Moon
 > <https://www.serebii.net/ultrasunultramoon/virtualconsole.shtml>
 
-Free space: 280255/2097152 (13.36%)
+Free space: 280264/2097152 (13.36%)
 
 bank	end	free
 $00	$3dfd	$0203
@@ -107,7 +107,7 @@ $5f	$8000	$0000
 $60	$7fff	$0001
 $61	$8000	$0000
 $62	$7fff	$0001
-$63	$8000	$0000
+$63	$7fff	$0001
 $64	$8000	$0000
 $65	$8000	$0000
 $66	$8000	$0000
@@ -118,7 +118,7 @@ $6a	$8000	$0000
 $6b	$7fff	$0001
 $6c	$8000	$0000
 $6d	$8000	$0000
-$6e	$7b54	$04ac
+$6e	$7b4c	$04b4
 $6f	$4000	$4000
 $70	$4000	$4000
 $71	$4000	$4000

--- a/engine/battle/move_effects/attract.asm
+++ b/engine/battle/move_effects/attract.asm
@@ -10,6 +10,7 @@ BattleCommand_attract:
 	ld a, BATTLE_VARS_SUBSTATUS1_OPP
 	call GetBattleVarAddr
 	bit SUBSTATUS_IN_LOVE, [hl]
+	jr nz, .failed
 	call GetOpponentAbilityAfterMoldBreaker
 	cp OBLIVIOUS
 	jr nz, .no_ability_protection

--- a/engine/events/overworld.asm
+++ b/engine/events/overworld.asm
@@ -871,13 +871,13 @@ Script_AskWaterfall:
 EscapeRopeFunction:
 	call FieldMoveJumptableReset
 	ld a, $1
-	jr dig_incave
+	jr EscapeRopeOrDig
 
 DigFunction:
 	call FieldMoveJumptableReset
 	ld a, $2
 
-dig_incave
+EscapeRopeOrDig:
 	ld [wBuffer2], a
 .loop
 	ld hl, .DigTable
@@ -921,10 +921,10 @@ dig_incave
 	ld de, wNextWarp
 	ld bc, 3
 	rst CopyBytes
-	call GetPartyNick
 	ld a, [wBuffer2]
 	cp $2
 	jr nz, .escaperope
+	call GetPartyNick
 	ld hl, .UsedDigScript
 	call QueueScript
 	ld a, $81

--- a/engine/movie/init_hof_credits.asm
+++ b/engine/movie/init_hof_credits.asm
@@ -15,23 +15,6 @@ InitDisplayForHallOfFame:
 
 InitDisplayForLeafCredits:
 	call ClearDisplayForEndgame
-	ld hl, wBGPals1
-	ld c, 4 tiles
-if !DEF(MONOCHROME)
-	ld a, $ff ; RGB 31, 31, 31
-endc
-.load_white_palettes
-if !DEF(MONOCHROME)
-	ld [hli], a
-	ld [hli], a
-else
-	ld a, LOW(PAL_MONOCHROME_WHITE)
-	ld [hli], a
-	ld a, HIGH(PAL_MONOCHROME_WHITE)
-	ld [hli], a
-endc
-	dec c
-	jr nz, .load_white_palettes
 	xor a
 	ldh [hSCY], a
 	ldh [hSCX], a

--- a/engine/pokedex/pokedex.asm
+++ b/engine/pokedex/pokedex.asm
@@ -1063,9 +1063,9 @@ PlaceFrontpicAtHL:
 	ret
 
 String_SEEN:
-	db "Seen", $ff
+	rawchar "Seen", $ff
 String_OWN:
-	db "Own", $ff
+	rawchar "Own", $ff
 String_SELECT_OPTION:
 ;	db $3b, $48, $49, $4a, $44, $45, $46, $47 ; SELECT > OPTION
 	db $3b, $41, $42, $43, $44, $45, $46, $47

--- a/engine/pokemon/bills_pc.asm
+++ b/engine/pokemon/bills_pc.asm
@@ -699,7 +699,7 @@ BillsPC_InitRAM:
 	call ClearTileMap
 	call BillsPC_InitGFX
 	ld hl, wBillsPCData
-	ld bc, $338
+	ld bc, wBillsPCDataEnd - wBillsPCData
 	xor a
 	rst ByteFill
 	xor a

--- a/engine/pokemon/breeding.asm
+++ b/engine/pokemon/breeding.asm
@@ -673,7 +673,7 @@ GetHatchlingFrontpic:
 	ld bc, PARTYMON_STRUCT_LENGTH
 	rst AddNTimes
 	predef GetVariant
-	ld [wCurPartySpecies], a
+	ld a, [wCurPartySpecies]
 	ld [wCurSpecies], a
 	call GetBaseData
 	pop de

--- a/roms.md5
+++ b/roms.md5
@@ -1,1 +1,1 @@
-2723c2296637312e827e8c21b8f6e896 *polishedcrystal-3.0.0-beta.gbc
+8fcaf4e6c28d49b9267fd573308337f4 *polishedcrystal-3.0.0-beta.gbc


### PR DESCRIPTION
**Addresses (maybe part of?) #457** - In `InitDisplayForLeafCredit` the game attempts to fill `wBGPals1` and `wOBPals1` with white palettes. However, there is never a wram bank switch to the correct bank first, so instead of overwriting those addresses in bank 5 it overwrites those addresses in bank 1 instead. This causes it to overwrite the first byte of `wPlayerID`, and when the player attempts to save the game will assume the player is playing on a new save file due to this new TID and will wipe the old save info if the player picks yes. _Note that this bug also exists in vanilla Crystal for Red's endgame credits._ However, since `wBGPals1` and `wOBPals1` have different physical locations in vanilla, they're just overwriting some temporary buffers. All that said, since the code did nothing in vanilla it does nothing here, so I decided to just remove it.

**Fixes #471** - Due to an n-gram, "Escape Rope@" now takes up 11 bytes in memory (and for the purposes of this explanation, in `wStringBuffer1`), not 12. That happens to be the same max length as a Pokemon nickname, so when `EscapeRopeOrDig` calls `GetPartyNick` for an invalid `wCurPartyMon` (in the case of escape rope) it is essentially writing 11 bytes of $00 into `wStringBuffer1`, overwriting the terminating character left from "Escape Rope@". Thus when the game attempts to copy this "nickname" to other string buffers, unless the dungeon name is longer than 11 bytes in memory (i.e. Slowpoke Well). This is _not_ a bug in vanilla because while it still pulls up an invalid nickname, it has a sanity check (`CorrectNickErrors`) to replace a nickname of all $00 with "?@?????????". Instead of reincorporating that function I just moved the check for if an escape rope is being used to be before the call to `GetPartyNick` since that's what should've been done in the first place :V

**Fixes attract "succeeding" after target is already attracted** - `SUBSTATUS_IN_LOVE` was checked by the battle engine, but nothing was done with that information

**Fixes "Seen" string in Pokedex page being displayed improperly** - `Pokedex_PlaceString` does not factor in n-grams, but "Seen" was stored as a `db` so "en" would've been stored as an n-gram. Thus, it was parsed literally as char $27 (which is part of frontpic data in this case), leading to the inaccurate display.

**Fixes hatchling frontpic showing the wrong mon** - not much more to say other than a `ld` was backwards

**Fixes possible issue with `BillsPC_InitRAM` going out of bounds** - instead of a hardcoded loop counter of $338, a more dynamic counter of `wBillsPCDataEnd - wBillsPCData` is used. Unclear if this ever caused any problems in the first place