### PR TITLE
fix arbitrary jump with egg in party and implement unused pursuit anim

### DIFF
--- a/contents/bank_ends.txt
+++ b/contents/bank_ends.txt
@@ -5,7 +5,7 @@
 > -- Morimoto, Pokémon Ultra Sun/Ultra Moon
 > <https://www.serebii.net/ultrasunultramoon/virtualconsole.shtml>
 
-Free space: 280212/2097152 (13.36%)
+Free space: 280197/2097152 (13.36%)
 
 bank	end	free
 $00	$3dee	$0212
@@ -114,11 +114,11 @@ $66	$8000	$0000
 $67	$8000	$0000
 $68	$8000	$0000
 $69	$8000	$0000
-$6a	$7fff	$0001
-$6b	$7ffe	$0002
+$6a	$8000	$0000
+$6b	$8000	$0000
 $6c	$8000	$0000
-$6d	$7ffd	$0003
-$6e	$7b91	$046f
+$6d	$8000	$0000
+$6e	$7b9a	$0466
 $6f	$4000	$4000
 $70	$4000	$4000
 $71	$4000	$4000

--- a/data/moves/effects.asm
+++ b/data/moves/effects.asm
@@ -1889,6 +1889,7 @@ BatonPass:
 
 Pursuit:
 	checkobedience
+	pursuit
 	usedmovetext
 	doturn
 	hastarget
@@ -1897,8 +1898,8 @@ Pursuit:
 	damagecalc
 	stab
 	damagevariation
-	pursuit
 	checkhit
+	conditionalboost
 	moveanim
 	failuretext
 	applydamage

--- a/engine/battle/abilities.asm
+++ b/engine/battle/abilities.asm
@@ -1760,14 +1760,14 @@ RunPostBattleAbilities::
 
 	ld [wCurPartyMon], a
 
-	push bc
-	ld a, MON_SPECIES
-	call GetPartyParamLocation
-	ld c, [hl]
 	ld a, MON_IS_EGG
 	call GetPartyParamLocation
 	bit MON_IS_EGG_F, [hl]
 	jr nz, .loop
+	push bc
+	ld a, MON_SPECIES
+	call GetPartyParamLocation
+	ld c, [hl]
 	assert MON_PERSONALITY == MON_IS_EGG - 1
 	dec hl
 

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -2094,6 +2094,8 @@ BattleCommand_moveanimnosub:
 	ld [wNumHits], a
 	ld a, BATTLE_VARS_MOVE_EFFECT
 	call GetBattleVar
+	cp EFFECT_PURSUIT
+	jr z, .pursuit
 	cp EFFECT_MULTI_HIT
 	jr z, .multihit
 	cp EFFECT_FURY_STRIKES
@@ -2106,6 +2108,7 @@ BattleCommand_moveanimnosub:
 .normal_move
 	xor a
 	ld [wKickCounter], a
+.pursuit
 	ld a, BATTLE_VARS_MOVE_ANIM
 	call GetBattleVar
 	ld e, a
@@ -5904,6 +5907,7 @@ BoostJumptable:
 	dbw HEX,        DoHex
 	dbw VENOSHOCK,  DoVenoshock
 	dbw KNOCK_OFF,  DoKnockOff
+	dbw PURSUIT,    DoPursuit
 	dbw -1, -1
 
 BattleCommand_conditionalboost:
@@ -5944,6 +5948,11 @@ DoVenoshock:
 	ld a, BATTLE_VARS_STATUS_OPP
 	call GetBattleVar
 	bit PSN, a
+	jr DoubleDamageIfNZ
+
+DoPursuit:
+	ld a, [wDeferredSwitch]
+	and a
 	jr DoubleDamageIfNZ
 
 BattleCommand_doubleflyingdamage:

--- a/engine/battle/move_effects/pursuit.asm
+++ b/engine/battle/move_effects/pursuit.asm
@@ -1,17 +1,13 @@
 BattleCommand_pursuit:
-; Double damage if the opponent is switching.
+; Sets up the alternate animation branch and plays the withdrawal animation
 
 	ld a, [wDeferredSwitch]
 	and a
 	ret z
 
-	ld hl, wCurDamage + 1
-	sla [hl]
-	dec hl
-	rl [hl]
-	ret nc
-
-	ld a, $ff
-	ld [hli], a
-	ld [hl], a
-	ret
+	ld a, 1
+	ld [wBattleAnimParam], a
+	call CallOpponentTurn
+.Function:
+	ld de, ANIM_RETURN_MON
+	farjp Call_PlayBattleAnim

--- a/engine/menus/intro_menu.asm
+++ b/engine/menus/intro_menu.asm
@@ -110,8 +110,8 @@ ResetWRAM:
 	ld bc, wMoney - wGameData
 	xor a
 	rst ByteFill
-	ld hl, MoneyEnd
-	ld bc, wCurBox - MoneyEnd
+	ld hl, wMoneyEnd
+	ld bc, wCurBox - wMoneyEnd
 	xor a
 	rst ByteFill
 	ld hl, wBoxNamesEnd

--- a/ram/wramx.asm
+++ b/ram/wramx.asm
@@ -896,7 +896,7 @@ wStatusFlags2::
 
 wMoney:: ds 3
 wMomsMoney:: ds 3
-MoneyEnd::
+wMoneyEnd::
 wMomSavingMoney:: db
 
 wCoins:: dw

--- a/roms.md5
+++ b/roms.md5
@@ -1,1 +1,1 @@
-e9a6c2da1a81f54f8e4e70b311e14fa1 *polishedcrystal-3.0.0-beta.gbc
+6b18dcd42c44b81239af8e7baee4c655 *polishedcrystal-3.0.0-beta.gbc


### PR DESCRIPTION
**Fixes arbitrary post-battle jump with egg in party -** Having an egg in the party would cause `RunPostBattleAbilities` to continue its party checking loop with a `push bc` without reaching its subsequent `pop bc`, leading to an arbitrary jump and a possible game crash.

**Implements unused Pursuit animation -** I said earlier in Discord that Beat Up is the most interesting move in Gen 2, but I changed my mind, it's definitely Pursuit. At least Beat Up works in Gen 4. Did you know that Pursuit (in most cases, but mysteriously not all) doesn't do anything at all in spaceworld? Like, it doesn't even reduce its own PP upon use? At least Beat Up has the excuse of being a last minute implementation of an unusual mechanic. Anyway, to implement this I just moved the Pursuit damage doubling stuff to `conditionalboost` and have the `pursuit` command just focus on playing the withdraw animation before `usedmovetext` if `wDeferredSwitch` is nonzero.

**Relabels MoneyEnd to wMoneyEnd -** Gonna keep an eye out for labels like this going forward.