### PR TITLE
Allowing Toolchain to work properly on OSX

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,10 +74,10 @@ make [faithful] [nortc] [hgss|monochrome|noir] [debug]
 
 ## Mac OS X
 
-In **Terminal**, run:
-
 `md5sum` is required.  
 To install it: ```brew install md5sha1sum```
+
+In **Terminal**, run:
 
 ```bash
 xcode-select --install

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -76,6 +76,9 @@ make [faithful] [nortc] [hgss|monochrome|noir] [debug]
 
 In **Terminal**, run:
 
+`md5sum` is required.  
+To install it: ```brew install md5sha1sum```
+
 ```bash
 xcode-select --install
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,7 +74,7 @@ make [faithful] [nortc] [hgss|monochrome|noir] [debug]
 
 ## Mac OS X
 
-`md5sum`, `ghead` and `gtail` are required required.  
+`md5sum`, `ghead` and `gtail` are required.  
 To install it: ```brew install coreutils```
 
 In **Terminal**, run:

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -74,8 +74,8 @@ make [faithful] [nortc] [hgss|monochrome|noir] [debug]
 
 ## Mac OS X
 
-`md5sum` is required.  
-To install it: ```brew install md5sha1sum```
+`md5sum`, `ghead` and `gtail` are required required.  
+To install it: ```brew install coreutils```
 
 In **Terminal**, run:
 

--- a/tools/collision_asm2bin.sh
+++ b/tools/collision_asm2bin.sh
@@ -3,15 +3,15 @@
 
 TEMP_ASM=$(mktemp collision.asm.XXX)
 TEMP_O=$(mktemp collision.o.XXX)
-OS=$(uname -s)
 
 HEAD=head
-tail=tail
+TAIL=tail
 
-if [ $OS = "Darwin" ]
-then
-    HEAD=ghead
-    TAIL=gtail
+if ! type ghead > /dev/null; then
+  HEAD=ghead
+fi
+if ! type gtail > /dev/null; then
+  TAIL=gtail
 fi
 
 echo 'INCLUDE "constants/collision_constants.asm"' > "$TEMP_ASM"

--- a/tools/collision_asm2bin.sh
+++ b/tools/collision_asm2bin.sh
@@ -7,10 +7,10 @@ TEMP_O=$(mktemp collision.o.XXX)
 HEAD=head
 TAIL=tail
 
-if ! type ghead > /dev/null; then
+if type ghead > /dev/null; then
   HEAD=ghead
 fi
-if ! type gtail > /dev/null; then
+if type gtail > /dev/null; then
   TAIL=gtail
 fi
 

--- a/tools/collision_asm2bin.sh
+++ b/tools/collision_asm2bin.sh
@@ -3,6 +3,16 @@
 
 TEMP_ASM=$(mktemp collision.asm.XXX)
 TEMP_O=$(mktemp collision.o.XXX)
+OS=$(uname -s)
+
+HEAD=head
+tail=tail
+
+if [ $OS = "Darwin" ]
+then
+    HEAD=ghead
+    TAIL=gtail
+fi
 
 echo 'INCLUDE "constants/collision_constants.asm"' > "$TEMP_ASM"
 echo 'INCLUDE "macros/collision.asm"' >> "$TEMP_ASM"
@@ -10,5 +20,5 @@ echo 'SECTION "C", ROM0[$0]' >> "$TEMP_ASM"
 echo "INCLUDE \"$1\"" >> "$TEMP_ASM"
 
 ${RGBDS_DIR}rgbasm -o "$TEMP_O" "$TEMP_ASM"
-tail -c +37 "$TEMP_O" | head -c -8 > $2
+$TAIL -c +37 "$TEMP_O" | $HEAD -c -8 > $2
 rm -f "$TEMP_ASM" "$TEMP_O"


### PR DESCRIPTION
MacOSX doesnt come with md5sum (it has a pre-installed md5 utility but it hasnt -c option required for `make compare`)

Since md5sum is required to `make` and `make compare`, this PR add instructions to install it on OSX.

Moreover the script tools/collision_asm2bin.sh uses `tail` and `head` with negative -c param, which is not supported by embeded head and tail binaries, causing buggy/missing collisions ig.
`head: illegal byte count -- -8` are visible in `make` logs.

ref:
https://unix.stackexchange.com/questions/169079/negative-arguments-to-head-tail
https://www.garron.me/en/bits/how-to-md5sum-mac-os-x.html
https://raamdev.com/2008/howto-install-md5sum-sha1sum-on-mac-os-x/