### PR TITLE
Update CHANGELOG with more v3.0.0-beta features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,39 +1,82 @@
 # Changelog
 
-These changes have been made since the current 2.2.0 release. If you build the project as-is, it will include all of them.
+These changes have been made since the 2.2.0 release. If you build the project as-is, it will include all of them.
 
 > What's the point of going through all the trouble of the debug process if you're going to go and fiddle with the game afterwards…?
 >
 > — Satoru Iwata, "[Iwata Asks – Pokémon HeartGold Version & SoulSilver Version](https://www.nintendo.co.uk/Iwata-Asks/Iwata-Asks-Pokemon-HeartGold-Version-SoulSilver-Version/Iwata-Asks-Pokemon-HeartGold-Version-SoulSilver-Version/1-Just-Making-The-Last-Train/1-Just-Making-The-Last-Train-225842.html)"
 
 
+* Add: Modernize Pokémon Storage System with a total of 16 boxes.
+* Add: Gift Pokémon without mails held can go to Box directly when the party is full.
 * Add: Medicine and Berry pockets in the Bag.
+* Add: Orange Ticket to visit Shamouti Island.
 * Add: Store up to 30 phone numbers in Pokégear.
 * Add: Always keep the option to Teleport away from Indigo Plateau.
 * Add: Portrait for the meteorite in Pewter Museum.
 * Add: Special sprite for Red's Pikachu.
 * Add: Johto and Kanto forms for Arbok.
 * Add: Drain Kiss drains 75% HP.
-* Add: Update Pokémon, move, and item attributes to Gen VII:
+* Add: Update Pokémon, move, and item attributes to Gen VII, partly to Gen VIII:
    * Super Potion heals 60 HP.
    * Hyper Potion heals 120 HP and costs ¥1500.
    * Fresh Water heals 30 HP.
    * Soda Pop heals 50 HP.
    * Lemonade heals 70 HP and costs ¥400.
    * X items sharply raise stats and cost twice as much.
+   * Gen 3+ Berry species.
+   * Gen 4+ Fast Ball.
+   * Rare Candies can evolve Lv. 100 Pokémon.
    * Tackle has 40 power.
    * Sucker Punch has 70 power.
    * Leech Life has 80 power and 10 PP.
    * Thunder Wave has 90% accuracy.
    * Swagger has 85% accuracy.
+   * Roar always fails against an opponent of higher level in general wild battles.
    * Paralysis halves (not quarters) Speed.
    * Burn does 1/16 (not 1/8) damage per turn.
    * Confusion has a 33% chance (not 50%) to hit self.
-   * Gengar has the ability Cursed Body. (Can also have Levitate in non-Faithful.)
-   * Raikou, Entei, and Suicune have the hidden ability Inner Focus. (Faithful only.)
-   * New item: Protect Pads (abbreviated "Protective Pads"). "Protect the holder from effects caused by making direct contact with the target."
-   * Timer Ball catch rate multiplier is 1 + (turns passed × 3) / 10.
-   * Nest Ball catch rate multiplier is (41 − enemy mon level) / 5.
+   * Gengar has Cursed Body as its normal Ability. (Can also have Levitate in non-Faithful.)
+   * Raikou, Entei, and Suicune have Inner Focus as their Hidden Ability (Faithful).
+   * Balls' catch rate multipliers:
+      * Timer Ball: 1 + (turns passed × 3) / 10.
+      * Nest Ball: (41 − enemy mon level) / 5.
+      * Lure Ball: ×5.
+      * Net Ball: ×3.5.
+      * Dusk Ball: ×3.
+   * Critical capture.
+   * Non-roaming wild Pokémon no longer flee.
+   * Friendship increases more on walks, haircuts, level-ups, and special matches such as Gym Leaders.
+   * Diploma can decorate the player's bedroom.
+   * More Gen 3–8 items:
+      * Nest, Net, Dive, Luxury, Heal, Dream, Premier, and Cherish Balls.
+      * Dawn and Ice Stones.
+      * Soothe Bell, Zinc, PP Max, Macho Brace and Power items.
+      * Choice items, Assault Vest, Expert Belt, Life Orb, Metronome, and Wide and Zoom Lens.
+      * Destiny Knot with its effect on breeding.
+      * Ability Capsule and Patch.
+      * Quick Powder.
+      * Mental, Power, and White Herbs.
+      * Flame and Toxic Orbs.
+      * Iron Ball, Lagging Tail, and Room Service.
+      * Weakness and Blunder Policies.
+      * Absorb Bulb, Cell Battery, Luminous Moss, and Snowball.
+      * Icy, Smooth, Heat, and Damp Rocks.
+      * Eject Button and Pack, Red Card, Ring Target, and Rocky Helmet.
+      * Big Root, Binding Band, Black Sludge, Grip Claw, Light Clay, and Throat Spray.
+      * Air Ballon, Focus Sash, Heavy-Dusty Boots, Protective Pads, Safety Goggles, Shed Shell, and Utility Umbrella.
+      * Big Nugget, Balm Mushroom, Pearl String, and Rare Bone.
+      * Pewter Crunchies.
+* Add: Overworld prompt for Flash.
+* Add: Earl gives Type Chart as he showed in Pokémon Stadium 2.
+* Add: "Odd Souvenir" (Strange Souvenir of Alola) as an Evolution item.
+* Add: Utility Umbrella as an all-weather (instead of sunlight and rain) protection.
+* Add: Ability Capsule helps breeding for a higher chance of Hidden Ability.
+* Add: Judge Machine in Goldenrod PCC, with IV/EV charts like Gen 7+.
+* Add: Hyper Training for full-EV (instead of Lv. 100) Pokémon, with icons to show up in the stat screen and the Judge Machine.
+* Add: Roamers' Roar always succeeds regardless of level differences.
+* Add: Strengthen wild Unown and those at routes between Tohjo Falls and Pokémon League.
+* Add: More diverse Abilities, including backporting Mega's for Hidden Abilities.
 * Add: Flash is required to return Falkner to the Gym.
 * Add: Replace Spike Cannon with Icicle Spear.
 * Add: Replace Twineedle with U-turn.
@@ -54,9 +97,15 @@ These changes have been made since the current 2.2.0 release. If you build the p
 * Add: Replace Triple Kick with Drain Punch.
 * Add: Replace Lock-On with Power Whip.
 * Add: Replace Flail with Gyro Ball.
+* Add: Replace Selfdestruct to Trick Room.
+* Add: Replace Pound with Acrobatics.
+* Add: Replace Slam with Volt Switch.
+* Add: Replace Sludge with Venoshock.
 * Add: Replace Flame Wheel with Flame Charge.
 * Add: Replace Moonlight and Morning Sun with Knock Off and "HealingLight".
-* Add: Replace Fury Attack and Fury Cutter with Trick and "Fury Strikes".
+* Add: Replace Fury Attack and Fury Swipes with Trick and "Fury Strikes".
+* Add: Replace Milk Drink and Softboiled with Shell Smash and "Fresh Snack".
+* Add: Replace Rock Smash with Brick Break (non-Faithful).
 * Add: Giga Impact.
 * Add: NPC trainers can have nicknamed Pokémon.
 * Add: NPC trainers can have custom EVs.
@@ -64,7 +113,11 @@ These changes have been made since the current 2.2.0 release. If you build the p
 * Add: Substitute blocks sound-based moves.
 * Add: Gen III critical hit mechanics (ignore -Atk and +Def stat changes, don't ignore burn).
 * Add: Grass-type Pokémon are immune to PoisonPowder, Stun Spore, Sleep Powder, and Spore.
-* Add: Marowak is Ground/Ghost.
+* Add: Shuckle is back, leading to a total of 254 species.
+* Add: Regional forms:
+   * Alola: Rattata/Raticate, Raichu, Sandshrew/Sandslash, Vulpix/Ninetales, Diglett/Dugtrio, Meowth/Persian, Geodude/Graveler/Golem, Grimer/Muk, Exeggutor, and Marowak.
+   * Galar: Ponyta/Rapidash, Slowpoke/Slowbro/Slowking, Weezing, Articuno, Zapdos, and Moltres.
+* ~~Add: Marowak is Ground/Ghost.~~
 * Add: Charizard is Fire/Dragon.
 * Add: Yanmega is Bug/Dragon.
 * Add: Ampharos is Electric/Dragon.
@@ -73,24 +126,32 @@ These changes have been made since the current 2.2.0 release. If you build the p
 * Add: Celebi is Grass/Fairy.
 * Add: Rapidash is Fire/Fairy.
 * Add: Octillery is Water/Fire.
+* Add: Ariados is Bug/Dark.
+* Add: Revert the following type changes:
+   * Kantonian Meowth/Persian to Normal.
+   * Kantonian Marowak to Ground.
+   * Kantonian Grimer/Muk to Poison.
+* Add: A new interaction with Mewtwo.
 * Add: Politoed can learn Energy Ball.
 * Add: Pidgeot can learn Focus Blast.
 * Add: Misdreavus can learn Disarm Voice.
 * Add: Espeon can learn Power Gem.
 * Add: Dig has 90 BP.
+* Add: Flash and Rock Smash / Brick Break are TMs instead of HMs.
+* Add: More TMs (up to TM75) and Move Tutors (up to \#31).
 * Add: Give in-game trades good natures.
 * Add: TM prices from OR/AS.
 * Add: Show quantity in Bag in marts.
 * Add: Fancier Bag interface with color-coded pockets.
 * Add: Get a free Premier Ball with every 10 Balls bought.
 * Add: Show Pokémon portraits when using field moves (thanks to TPP:AC).
-* Add: Time boundaries from HG/SS (day lasts until 8 PM, not 6 PM).
+* ~~Add: Time boundaries from HG/SS (day lasts until 8 PM, not 6 PM).~~
 * Add: Use DVs to vary Pokémon colors like in Stadium.
 * Add: Update random Wonder Trade OT names.
 * Add: Teleport switches in trainer battles, like Let's Go.
-* Add: Rock Smash has 60 power (non-Faithful).
+* ~~Add: Rock Smash has 60 power (non-Faithful).~~
 * Add: Strength is Fighting-type (non-Faithful).
-* Add: Submission has 120 power (non-Faithful).
+* ~~Add: Submission has 120 power (non-Faithful).~~
 * Add: Trainers have max happiness for Return.
 * Add: 1/2048 chance for Wonder Traded Pokémon to have Pokérus.
 * Add: Buy 12 Moomoo Milk at once.
@@ -111,15 +172,17 @@ These changes have been made since the current 2.2.0 release. If you build the p
 * Add: Choose a typeface/font.
 * Add: X/Y Bicycle music for Cycling Road.
 * Add: Prof.Oak gives you the Oval Charm for seeing all 254 Pokémon, and the Shiny Charm for catching all 254.
+* Add: Oval Charm halves Eggs' hatching time, stackable with Flame Body etc.
 * Add: Prof.Elm is in the intro.
 * Add: Cosplayer, Bug Maniac, Ruin Maniac, Lady, Baker, Tamer, Artist, Aroma Lady, Sightseer♂, and Sightseer♀ trainer classes.
 * Add: New Trainer Card based on the Name Cards from the Mobile Adapter system.
 * Add: Show PC box quantity.
 * Add: Pokémon stats show caught Poké Ball.
-* Add: Nest, Net, Dive, Luxury, and Heal Balls.
 * Add: Cerulean Bike Shop from HG/SS.
 * Add: Elite 4 rooms have floor arenas.
 * Add: Confirm gender selection.
+* Add: Colored emote icons.
+* Add: Colored in-battle stat-change animations.
 * Add: Colored party Pokémon icons.
 * Add: Magikarp Jump patterns.
 * Add: Headbutt trees to get Silver and Gold Leaves.
@@ -127,6 +190,7 @@ These changes have been made since the current 2.2.0 release. If you build the p
 * Add: Item maniacs from B/W.
 * Add: Fish to get items based on the Rod (Bottle Caps with Super Rod).
 * Add: Mulch regrows Berries.
+* Add: Itemfinder gives direction and closeness like R/S/E.
 * Add: Three battle styles: set, switch, and predict.
 * Add: Battle Scene → Battle Effects.
 * Add: Final Lyra battle.
@@ -164,21 +228,28 @@ These changes have been made since the current 2.2.0 release. If you build the p
 * Add: Evolution moves from Gen VII.
 * Add: Move Reminder supports pre-evolution and evolution moves.
 * Add: Dark battle intro at night.
-* Add: Evening as a time of day (shares wild Pokémon with night).
+* Add: Evening as a time of day.
+   * 5–9 AM for morning, 9AM – 5PM for day, 5–9 PM for evening, and 9 PM – 5 AM for night.
+   * Evening shares wild Pokémon with day and night (60% : 40%).
 * Add: Trainer battles can be forfeited.
 * Add: Show genders in party menu.
 * Add: Show weather icons during battle like Gen 5+.
+* Add: Show in-battle Ability slide-outs like Gen 5+.
 * Add: Vending machines have a 1/32 chance of giving an extra item.
 * Add: Cross whirlpools, don't remove them (like HG/SS).
 * Add: Rename RageCandyBar to Cake of Rage.
 * Add: Rename Guard Spec. to Guard Stats.
 * Add: Rename Kay to Carrie (from Pokémon Stadium 2).
 * Add: Rename Slowbro to the Squatter Pokémon. <https://lparchive.org/Pokemon-Blue/code.html>
+* Add: Modernize Battle Tower opponents.
+* Add: Battle Factory.
+* Add: Strengthen special opponents such as Giovanni and Oak.
 
 * Fix: Lt. Surge's electric fence color does not override speech bubbles.
 * Fix: Zap Cannon has 120 power.
 * Fix: Pay Day pays 5 times the user's level, not 2.
 * Fix: Explosion and Self-Destruct do not halve Defense.
+* Fix: Night Slash has a high critical-hit ratio.
 * Fix: Quick Ball catch rate multiplier is 5 on the first turn.
 * Fix: Minimize raises evasion by two stages.
 * Fix: Gen 7 critical hit chances (1/24, 1/8, 1/2, 1/1)
@@ -198,6 +269,7 @@ These changes have been made since the current 2.2.0 release. If you build the p
 * Fix: Dig and Fly prevent capture.
 * Fix: Yellow Carpet is buyable.
 * Fix: Tangrowth can learn Curse.
+* Fix: Voltorb and Electrode can learn Reflect also via TM.
 * Fix: Lyra's Bag is the female version.
 * Fix: Incorrect Cowgirl and Misty sprites.
 * Fix: Pokémon caught during the Bug-Catching Contest are recorded as caught in Goldenrod Harbor.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,17 +101,15 @@ These changes have been made since the current 2.2.0 release. If you build the p
 * Add: Route 23 between Pokémon League Gate and Victory Road.
 * Add: Oak's lab looks different from Elm's lab.
 * Add: Grass-green for Faraway Island.
-* Add: TM prices from OR/AS.
-* Add: Update random Wonder Trade OT names.
 * Add: Respawn roaming beasts when released.
 * Add: Mr. Pokémon gives you a non-OT Ditto, not an Egg, for the Masuda breeding method.
 * Add: Use original Jynx sprite.
 * Add: Make overworld sprites darker at night.
 * Add: Goldenrod Dept. Store and Celadon Mansion roofs have a dark sky at night.
-* Add: Olivine Gym has its two trainers from HGSS.
+* Add: Olivine Gym has its two trainers from HG/SS.
 * Add: Unlock frame type 9.
 * Add: Choose a typeface/font.
-* Add: XY Bicycle music for Cycling Road.
+* Add: X/Y Bicycle music for Cycling Road.
 * Add: Prof.Oak gives you the Oval Charm for seeing all 254 Pokémon, and the Shiny Charm for catching all 254.
 * Add: Prof.Elm is in the intro.
 * Add: Cosplayer, Bug Maniac, Ruin Maniac, Lady, Baker, Tamer, Artist, Aroma Lady, Sightseer♂, and Sightseer♀ trainer classes.
@@ -119,7 +117,7 @@ These changes have been made since the current 2.2.0 release. If you build the p
 * Add: Show PC box quantity.
 * Add: Pokémon stats show caught Poké Ball.
 * Add: Nest, Net, Dive, Luxury, and Heal Balls.
-* Add: Cerulean Bike Shop from HGSS.
+* Add: Cerulean Bike Shop from HG/SS.
 * Add: Elite 4 rooms have floor arenas.
 * Add: Confirm gender selection.
 * Add: Colored party Pokémon icons.
@@ -134,7 +132,7 @@ These changes have been made since the current 2.2.0 release. If you build the p
 * Add: Final Lyra battle.
 * Add: Use a Ball on an already-caught Pokémon to change its Ball.
 * Add: Kurt makes Balls right away.
-* Add: Bug-Catching Contest prizes from HGSS.
+* Add: Bug-Catching Contest prizes from HG/SS.
 * Add: Hidden Grottoes.
 * Add: Unown ! and ?.
 * Add: In-battle symbol to show that Nuzlocke mode prevents capture.
@@ -171,7 +169,7 @@ These changes have been made since the current 2.2.0 release. If you build the p
 * Add: Show genders in party menu.
 * Add: Show weather icons during battle like Gen 5+.
 * Add: Vending machines have a 1/32 chance of giving an extra item.
-* Add: Cross whirlpools, don't remove them (like HGSS).
+* Add: Cross whirlpools, don't remove them (like HG/SS).
 * Add: Rename RageCandyBar to Cake of Rage.
 * Add: Rename Guard Spec. to Guard Stats.
 * Add: Rename Kay to Carrie (from Pokémon Stadium 2).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,6 @@ These changes have been made since the 2.2.0 release. If you build the project a
 * Add: Overworld prompt for Flash.
 * Add: Earl gives Type Chart as he showed in Pokémon Stadium 2.
 * Add: "Odd Souvenir" (Strange Souvenir of Alola) as an Evolution item.
-* Add: Utility Umbrella as an all-weather (instead of sunlight and rain) protection.
 * Add: Ability Capsule helps breeding for a higher chance of Hidden Ability.
 * Add: Judge Machine in Goldenrod PCC, with IV/EV charts like Gen 7+.
 * Add: Hyper Training for full-EV (instead of Lv. 100) Pokémon, with icons to show up in the stat screen and the Judge Machine.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,12 +38,7 @@ These changes have been made since the 2.2.0 release. If you build the project a
    * Confusion has a 33% chance (not 50%) to hit self.
    * Gengar has Cursed Body as its normal Ability. (Can also have Levitate in non-Faithful.)
    * Raikou, Entei, and Suicune have Inner Focus as their Hidden Ability (Faithful).
-   * Balls' catch rate multipliers:
-      * Timer Ball: 1 + (turns passed × 3) / 10.
-      * Nest Ball: (41 − enemy mon level) / 5.
-      * Lure Ball: ×5.
-      * Net Ball: ×3.5.
-      * Dusk Ball: ×3.
+   * The catch rate multipliers of Poké Balls.
    * Critical capture.
    * Non-roaming wild Pokémon no longer flee.
    * Friendship increases more on walks, haircuts, level-ups, and special matches such as Gym Leaders.


### PR DESCRIPTION
This adds major (maybe not all) changes `CHANGELOG.md` was missing onto the list, along with some minor fixes.

It currently strikes through a few changes that were eventually overwritten, instead of deleting them; I don't mind it if it prefers the latter.

The file would need more re-sorting, probably better by category than by date just as it sorts things now.

ed: This still leaves out the implemented but Ineffective or unobtainable items such as Mint Leaf and Catch Charm.
