### PR TITLE
Add support for compiling with busybox mktemp

### DIFF
--- a/tools/collision_asm2bin.sh
+++ b/tools/collision_asm2bin.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 # Usage: collision_asm2bin.sh collision.asm collision.bin
 
-TEMP_ASM=$(mktemp collision.asm.XXX)
-TEMP_O=$(mktemp collision.o.XXX)
+TEMP_ASM=$(mktemp collision.asm.XXXXXX)
+TEMP_O=$(mktemp collision.o.XXXXXX)
 
 echo 'INCLUDE "constants/collision_constants.asm"' > "$TEMP_ASM"
 echo 'INCLUDE "macros/collision.asm"' >> "$TEMP_ASM"


### PR DESCRIPTION
Busybox mktemp requires a template with a fixed number of X. This commit
allows Polished Crystal to be compiled within busybox environments, such
as w64devkit on Windows.

Also tested working with Debian.

Signed-off-by: Mahyar Koshkouei <mk@deltabeard.com>