### PR TITLE
Fix flashing 'used move text' when using Fly/Dig

### DIFF
--- a/data/moves/effects.asm
+++ b/data/moves/effects.asm
@@ -2149,8 +2149,8 @@ Teleport:
 Fly:
 Dig:
 	checkobedience
-	usedmovetext
 	doturn
+	usedmovetext
 	hastarget
 	charge
 	checkhit


### PR DESCRIPTION
When using the move Fly or Dig, the text: `[Pokémon] used [Fly/Dig]!` flashes on screen for a split second before the animation begins. When using these moves, this text should not be shown at all (and it isn't in vanilla Crystal). For these moves, the text is shown after the animation. For example, `[Pokémon] flew up high!`.

I resolved this issue by changing the move's effect order. 