### PR TITLE
Fix 'used move text' when charging a two-turn move

### DIFF
--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -5414,7 +5414,6 @@ BattleCommand_charge:
 
 .not_charging
 	push hl
-	call BattleCommand_cleartext
 	pop hl
 	ld a, BATTLE_VARS_STATUS
 	call GetBattleVar


### PR DESCRIPTION
When using a two-turn move like Fly or Dig, the 'used move text' (`[Pokémon] used [move]!`) disappears immediately after it's fully displayed - when the charging animation starts. When text speed is set to instant, it flashes on screen for a split second. 

With this change, the 'used move text' will continue to be on screen during the animation.