### PR TITLE
Fix two bugs in battle animations

### DIFF
--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -456,7 +456,8 @@ EndTurn:
 OpponentCantMove:
 	call CallOpponentTurn
 CantMove:
-	call CheckRampageStatusAndGetRolloutCount ; ; hl becomes pointer to user substatus3
+	call .cancel_fly_dig
+	call CheckRampageStatusAndGetRolloutCount ; hl becomes pointer to user substatus3
 	jr z, .rampage_done
 	ld a, [de]
 	dec a
@@ -465,14 +466,18 @@ CantMove:
 	pop hl
 .rampage_done
 	ld a, [hl]
-	push hl
-	and (1 << SUBSTATUS_FLYING | 1 << SUBSTATUS_UNDERGROUND)
-	call nz, AppearUserRaiseSub
-	pop hl
 	ld a, ~(1 << SUBSTATUS_RAMPAGE | 1 << SUBSTATUS_CHARGED | 1 << SUBSTATUS_FLYING | 1 << SUBSTATUS_UNDERGROUND | 1 << SUBSTATUS_ROLLOUT)
 	and [hl]
 	ld [hl], a
 	ret
+
+.cancel_fly_dig
+	ld a, BATTLE_VARS_MOVE_ANIM
+	call GetBattleVarAddr
+	cp FLY
+	jp AppearUserRaiseSub
+	cp DIG
+	jp AppearUserRaiseSub
 
 IncreaseMetronomeCount:
 	; Don't arbitrarily boost usage counter twice on a turn

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -475,9 +475,10 @@ CantMove:
 	ld a, BATTLE_VARS_MOVE_ANIM
 	call GetBattleVarAddr
 	cp FLY
-	jp AppearUserRaiseSub
+	jmp z, AppearUserRaiseSub
 	cp DIG
-	jp AppearUserRaiseSub
+	jmp z, AppearUserRaiseSub
+	ret
 
 IncreaseMetronomeCount:
 	; Don't arbitrarily boost usage counter twice on a turn

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -475,10 +475,11 @@ CantMove:
 	ld a, BATTLE_VARS_MOVE_ANIM
 	call GetBattleVarAddr
 	cp FLY
-	jmp z, AppearUserRaiseSub
+	jr z, .fly_dig
 	cp DIG
-	jmp z, AppearUserRaiseSub
-	ret
+	ret nz
+.fly_dig
+	jmp AppearUserRaiseSub
 
 IncreaseMetronomeCount:
 	; Don't arbitrarily boost usage counter twice on a turn

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -616,6 +616,7 @@ HitConfusion:
 	call HitSelfInConfusion
 	call ConfusedDamageCalc
 	call BattleCommand_lowersub
+	call GenericHitAnim
 
 	ldh a, [hBattleTurn]
 	and a


### PR DESCRIPTION
1. The animation that is shown when a Pokémon hits itself in confusion did not show. It seems this was accidentally removed in [this commit](https://github.com/Rangi42/polishedcrystal/commit/0c4a1e04e6900f9fdeac9f695fcb229d5e1ec45c#diff-88dbff1eb3920f69b17a3d5f613643e1a41096514706bc09f449e4aa637f20e4).
2. If the second turn of Dig/Fly fails (for example, when the Pokémon hits itself in confusion) the Pokémon's sprite stayed invisible. This was reported in #665. 

Resolves #665.