### PR TITLE
Improve Lawrence's leaving animation

### DIFF
--- a/maps/VermilionCity.asm
+++ b/maps/VermilionCity.asm
@@ -128,15 +128,16 @@ LawrenceIntroScript:
 .continue
 	playmusic MUSIC_ZINNIA_ENCOUNTER_ORAS
 	showtext LawrenceIntroText
-	applyonemovement VERMILIONCITY_LAWRENCE, turn_head_down
-	pause 15
-	playsound SFX_EXIT_BUILDING
+	applymovement VERMILIONCITY_LAWRENCE, LawrenceWalkAwayMovementData
 	disappear VERMILIONCITY_LAWRENCE
 	setscene $1
 	setflag ENGINE_FLYPOINT_VERMILION
 	special RestartMapMusic
 	end
 
+LawrenceWalkAwayMovementData:
+	step_down
+	step_down
 LawrenceApproachMovementData:
 	step_down
 	step_down


### PR DESCRIPTION
After the first encounter with Lawrence in Kanto, he disappears on the spot. This looks a bit weird since there's a huge pier below. This PR makes him walk down that pier out of sight.