### PR TITLE
Fix two battle texts disappearing too fast

### DIFF
--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -1017,6 +1017,7 @@ BattleCommand_hastarget:
 	call HasOpponentFainted
 	jr nz, .not_fainted
 
+	call BattleCommand_movedelay
 	ld hl, ButItFailedText
 	call StdBattleTextbox
 	call CantMove

--- a/engine/battle/move_effects/future_sight.asm
+++ b/engine/battle/move_effects/future_sight.asm
@@ -24,6 +24,7 @@ BattleCommand_futuresight:
 	or $3
 	ld [hl], a
 
+	call BattleCommand_movedelay
 	ld hl, ForesawAttackText
 	call StdBattleTextbox
 	jmp EndMoveEffect


### PR DESCRIPTION
1. If a Pokémon used Future Sight, the text `[Pokémon] used Future Sight!` disappears immediately after it's fully shown, being replaced with `[Pokémon] foresaw an attack!`.
2. If a Pokémon uses a move but there was not target anymore (for example, after that target selfdestructed), the text `[Pokémon] used [move]!` disappears immediately after being shown, being replaces with `But it failed!`.

In both cases, the solution was to add a delay. 