### PR TITLE
Fix having to press A twice to end Bill's call

### DIFF
--- a/data/phone/text/bill.asm
+++ b/data/phone/text/bill.asm
@@ -148,4 +148,4 @@ BillPhoneSecondBadgeText:
 
 	para "That's all."
 	line "Buh-bye!"
-	prompt
+	done


### PR DESCRIPTION
A tiny PR that fixes having to press A twice at the end of Bill's phone call after gaining the second badge in Kanto. Now it behaves like other phone calls.