### PR TITLE
Fix some issues in & around Cerulean City

### DIFF
--- a/maps/CeruleanCity.asm
+++ b/maps/CeruleanCity.asm
@@ -246,7 +246,7 @@ CeruleanTrainerTipsText:
 	text "Trainer Tips"
 
 	para "Even without an"
-	line "ItemFinder, you"
+	line "Itemfinder, you"
 
 	para "can find useful"
 	line "items in trees,"

--- a/maps/CeruleanCity.asm
+++ b/maps/CeruleanCity.asm
@@ -53,11 +53,19 @@ CeruleanCityCooltrainerMScript:
 	jumptextfaceplayer CeruleanCityCooltrainerMText1
 
 CeruleanCityCooltrainerFScript:
-	showtextfaceplayer CeruleanCityCooltrainerFText1
+	faceplayer
+	opentext
+	writetext CeruleanCityCooltrainerFText1
+	waitbutton
 	turnobject CERULEANCITY_COOLTRAINER_F, LEFT
-	showtext CeruleanCityCooltrainerFText2
-	showcrytext CeruleanCitySlowbroText, SLOWBRO
-	jumptext CeruleanCityCooltrainerFText3
+	writetext CeruleanCityCooltrainerFText2
+	waitbutton
+	writetext CeruleanCitySlowbroText
+	cry SLOWBRO
+	waitbutton
+	writetext CeruleanCityCooltrainerFText3
+	waitendtext
+	end
 
 CeruleanCityFisherScript:
 	checkevent EVENT_RESTORED_POWER_TO_KANTO

--- a/maps/CeruleanCity.asm
+++ b/maps/CeruleanCity.asm
@@ -18,6 +18,10 @@ CeruleanCity_MapScriptHeader:
 	warp_event 29,  7, CERULEAN_WATER_SHOW_SPEECH_HOUSE, 1
 
 	def_coord_events
+	coord_event 20,  3, 0, Route24BridgeUnderfootTrigger
+	coord_event 21,  3, 0, Route24BridgeUnderfootTrigger
+	coord_event 20,  4, 1, Route24BridgeOverheadTrigger
+	coord_event 21,  4, 1, Route24BridgeOverheadTrigger
 
 	def_bg_events
 	bg_event 17, 20, BGEVENT_JUMPTEXT, CeruleanCitySignText

--- a/maps/Route24.asm
+++ b/maps/Route24.asm
@@ -11,12 +11,20 @@ Route24_MapScriptHeader:
 	coord_event 20, 14, 1, Route24BridgeOverheadTrigger
 	coord_event 21, 14, 1, Route24BridgeOverheadTrigger
 	coord_event 22, 15, 1, Route24BridgeOverheadTrigger
-	coord_event 20, 39, 1, Route24BridgeOverheadTrigger
-	coord_event 21, 39, 1, Route24BridgeOverheadTrigger
 	coord_event 20, 15, 0, Route24BridgeUnderfootTrigger
 	coord_event 21, 15, 0, Route24BridgeUnderfootTrigger
-	coord_event 20, 38, 0, Route24BridgeUnderfootTrigger
-	coord_event 21, 38, 0, Route24BridgeUnderfootTrigger
+	coord_event 20, 39, 0, Route24BridgeUnderfootTrigger
+	coord_event 21, 39, 0, Route24BridgeUnderfootTrigger
+	coord_event 25, 13, 1, Route24BridgeOverheadTrigger
+	coord_event 25, 15, 1, Route24BridgeOverheadTrigger
+	coord_event 25, 16, 1, Route24BridgeOverheadTrigger
+	coord_event 25, 17, 1, Route24BridgeOverheadTrigger
+	coord_event 25, 18, 1, Route24BridgeOverheadTrigger
+	coord_event 25, 19, 1, Route24BridgeOverheadTrigger
+	coord_event 25, 20, 1, Route24BridgeOverheadTrigger
+	coord_event 25, 21, 1, Route24BridgeOverheadTrigger
+	coord_event 25, 22, 1, Route24BridgeOverheadTrigger
+	coord_event 25, 23, 1, Route24BridgeOverheadTrigger
 
 	def_bg_events
 	bg_event 16,  5, BGEVENT_ITEM + POTION, EVENT_ROUTE_24_HIDDEN_POTION


### PR DESCRIPTION
- Fix for incorrect `Itemfinder` casing on a sign
- Fix flashing message boxes during interaction with cool trainer and her Slowbro
- Fix some issues with bridge overhead/underfoot triggering where the player's sprite would be cut-off on certain tiles when entering from Cerulean City and where event triggering could be circumvented by flying