### PR TITLE
Add redundancy check for Destiny Bond

### DIFF
--- a/engine/battle/ai/redundant.asm
+++ b/engine/battle/ai/redundant.asm
@@ -43,6 +43,7 @@ AI_Redundant:
 	dbw EFFECT_BATON_PASS,    .BatonPass
 	dbw EFFECT_ROOST,         .Roost
 	dbw EFFECT_TRICK_ROOM,    .TrickRoom
+	dbw EFFECT_DESTINY_BOND,  .DestinyBond
 	db -1
 
 .Confuse:
@@ -216,3 +217,9 @@ AI_Redundant:
 	ld a, 1
 	and a
 	ret
+
+.DestinyBond:
+	ld a, [wEnemySubStatus2]
+	bit SUBSTATUS_DESTINY_BOND, a
+	ret
+	

--- a/engine/battle/ai/redundant.asm
+++ b/engine/battle/ai/redundant.asm
@@ -222,4 +222,3 @@ AI_Redundant:
 	ld a, [wEnemySubStatus2]
 	bit SUBSTATUS_DESTINY_BOND, a
 	ret
-	


### PR DESCRIPTION
In certain situations, trainers keep spamming Destiny Bond - even when they already used it the previous turn and therefore is a guaranteed fail. I got this situation when fighting with a Poliwrath against trainer Vivian in Rock Tunnel. 

I added the move Destiny Bond to the redundancy checks, to keep trainers from using it if the target already has the Destiny Bond sub status. 