### PR TITLE
Fix Sylveon cry in intro

### DIFF
--- a/data/text/common.asm
+++ b/data/text/common.asm
@@ -3275,7 +3275,7 @@ _ElmText2::
 	text "This world is in-"
 	line "habited by crea-"
 	cont "tures that we call"
-	cont "#mon."
+	cont "#mon.@"
 	text_end
 
 SECTION "_ElmText4", ROMX

--- a/data/text/common.asm
+++ b/data/text/common.asm
@@ -3276,7 +3276,7 @@ _ElmText2::
 	line "habited by crea-"
 	cont "tures that we call"
 	cont "#mon."
-	done
+	text_end
 
 SECTION "_ElmText4", ROMX
 _ElmText4::


### PR DESCRIPTION
Hi, while testing 9bit I noticed that the text at this position auto-scrolled by and no Pokémon cry was audible.
Judging by pokecrystal, this should be a ```text_end``` ?
https://github.com/pret/pokecrystal/blob/master/data/text/common_2.asm#L1544