### PR TITLE
Wait for sound effect on receiving key item

### DIFF
--- a/engine/overworld/scripting.asm
+++ b/engine/overworld/scripting.asm
@@ -2654,6 +2654,7 @@ Script_verbosegivekeyitem:
 GiveKeyItemScript:
 	farwritetext _ReceivedItemText
 	playsound SFX_KEY_ITEM
+	waitsfx
 	waitbutton
 	keyitemnotify
 	end


### PR DESCRIPTION
When receiving a key item, the player could (accidentally) instantly close the 'received item' text. With this PR, the SFX has to be played before the text can be closed. This is now consistent with receiving a TM/HM.