### PR TITLE
Add Odd Souvenir dialogue to Mr. Pokémon

### DIFF
--- a/maps/MrPokemonsHouse.asm
+++ b/maps/MrPokemonsHouse.asm
@@ -245,17 +245,18 @@ MrPokemonText_OddSouvenir:
 	line "on my trip to the"
 	cont "Orange Islands."
 
-	para "Did you know some"
-	line "#mon species"
-	cont "have other forms?"
+	para "I saw some oddly-"
+	line "formed #mon"
+	cont "there too!"
 
 	para "Hmm… I wonder…"
 
-	para "What happens if"
-	line "a #mon with an"
+	para "Is there a conn-"
+	line "ection between"
 
-	para "Alolan form holds"
-	line "that souvenir?"
+	para "that souvenir and"
+	line "those unusual"
+	cont "forms of #mon?"
 	done
 
 MrPokemonText_ImDependingOnYou:

--- a/maps/MrPokemonsHouse.asm
+++ b/maps/MrPokemonsHouse.asm
@@ -63,6 +63,8 @@ MrPokemonsHouse_MrPokemonScript:
 	opentext
 	checkkeyitem RED_SCALE
 	iftruefwd .RedScale
+	checkitem ODD_SOUVENIR
+	iftrue_jumpopenedtext MrPokemonText_OddSouvenir
 	checkevent EVENT_GAVE_MYSTERY_EGG_TO_ELM
 	iftrue_jumpopenedtext MrPokemonText_AlwaysNewDiscoveries
 	jumpopenedtext MrPokemonText_ImDependingOnYou
@@ -234,6 +236,26 @@ MrPokemonsHouse_MrPokemonHealText:
 	para "Here. Your #mon"
 	line "should have some"
 	cont "rest."
+	done
+
+MrPokemonText_OddSouvenir:
+	text "Oh! That souvenir!"
+
+	para "I got one of those"
+	line "on my trip to the"
+	cont "Orange Islands."
+
+	para "Did you know some"
+	line "#mon species"
+	cont "have other forms?"
+
+	para "Hmm… I wonder…"
+
+	para "What happens if"
+	line "a #mon with an"
+
+	para "Alolan form holds"
+	line "that souvenir?"
 	done
 
 MrPokemonText_ImDependingOnYou:


### PR DESCRIPTION
When receiving the Odd Souvenir from Prof. Elm, he says it was given to him by Mr. Pokémon.

Since I didn't know what the Odd Souvenir was for, I went straight to him, but there was no dialogue about the souvenir. I thought it'd be nice for him to tell something about it, so I added dialogue explaining how the Odd Souvenir works (well, kind of). 