### PR TITLE
Improve text alignment of nurse's dialogue

### DIFF
--- a/maps/Route48.asm
+++ b/maps/Route48.asm
@@ -199,16 +199,14 @@ Route48NurseText1:
 	line "from the window!"
 
 	para "You drove away"
-	line "Team Rocket"
-	cont "and saved the"
-	cont "Pikachu!"
+	line "Team Rocket and"
+	cont "saved the Pikachu!"
 
-	para "Thank you so"
-	line "much!"
+	para "Thank you so much!"
 
 	para "Your #mon de-"
-	line "serve a rest"
-	cont "after all that."
+	line "serve a rest after"
+	cont "all that."
 	done
 
 Route48NurseText2:


### PR DESCRIPTION
Extremely minor polishing of the nurse's dialogue on Route 48. When playing, I noticed the text box had some rather big gaps in there. The dialogue does fit in fewer lines, making it look just a bit more spiffy.