### PR TITLE
Add text to sailboat in Goldenrod Harbor

### DIFF
--- a/maps/GoldenrodHarbor.asm
+++ b/maps/GoldenrodHarbor.asm
@@ -27,8 +27,8 @@ GoldenrodHarbor_MapScriptHeader:
 	object_event  6, 14, SPRITE_SWIMMER_GIRL, SPRITEMOVEDATA_STANDING_LEFT, 0, 0, -1, -1, 0, OBJECTTYPE_GENERICTRAINER, 5, GenericTrainerSwimmerfKatie, -1
 	object_event 23, 28, SPRITE_SWIMMER_GUY, SPRITEMOVEDATA_SPINCLOCKWISE, 0, 0, -1, -1, 0, OBJECTTYPE_GENERICTRAINER, 3, GenericTrainerSwimmermJames, -1
 	object_event 22, 19, SPRITE_LASS, SPRITEMOVEDATA_STANDING_DOWN, 0, 0, -1, -1, 0, OBJECTTYPE_COMMAND, jumptextfaceplayer, GoldenrodHarborLass2Text, -1
-	object_event  6, 26, SPRITE_SAILBOAT, SPRITEMOVEDATA_SAILBOAT_TOP, 0, 0, -1, -1, 0, OBJECTTYPE_COMMAND, end, NULL, -1
-	object_event  6, 26, SPRITE_SAILBOAT, SPRITEMOVEDATA_SAILBOAT_BOTTOM, 0, 0, -1, -1, 0, OBJECTTYPE_COMMAND, end, NULL, -1
+	object_event  6, 26, SPRITE_SAILBOAT, SPRITEMOVEDATA_SAILBOAT_TOP, 0, 0, -1, -1, 0, OBJECTTYPE_COMMAND, jumptext, GoldenrodHarborSailboatText, -1
+	object_event  6, 26, SPRITE_SAILBOAT, SPRITEMOVEDATA_SAILBOAT_BOTTOM, 0, 0, -1, -1, 0, OBJECTTYPE_COMMAND, jumptext, GoldenrodHarborSailboatText, -1
 
 GoldenrodHarborFisherScript:
 	faceplayer
@@ -437,4 +437,9 @@ GoldenrodHarborSignText:
 GoldenrodHarborCrateSignText:
 	text "A crate full of"
 	line "rare items!"
+	done
+
+GoldenrodHarborSailboatText:
+	text "It's a sailboat"
+	line "named Amaura."
 	done


### PR DESCRIPTION
Another case of minor polishing. Interacting with the sailboat doesn't do anything, except play the default interaction sound effect. It seems nicer to have some text pop up at that stage, which is added in this PR.