### PR TITLE
Disable changing the ball of a traded pokémon

### DIFF
--- a/data/text/common.asm
+++ b/data/text/common.asm
@@ -4621,3 +4621,10 @@ AlreadyInThatBallTextData::
 	text "Your #mon is in"
 	line "that Ball already."
 	prompt
+
+SECTION "CantChangeTradedMonBallTextData", ROMX
+CantChangeTradedMonBallTextData::
+	text "You can't change"
+	line "the Ball a traded"
+	cont "#mon is in."
+	prompt

--- a/engine/events/name_rater.asm
+++ b/engine/events/name_rater.asm
@@ -86,7 +86,7 @@ NameRater:
 .done
 	jmp PrintText
 
-CheckIfMonIsYourOT:
+CheckIfMonIsYourOT::
 ; Checks to see if the partymon loaded in [wCurPartyMon] has the different OT as you.  Returns carry if not.
 	ld hl, wPartyMonOTs
 	ld bc, NAME_LENGTH

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -2305,9 +2305,7 @@ Ball_ReplacePartyMonCaughtBall:
 	bit TRADED_AS_OT_OPT, a
 	jr nz, .no_trade_restriction
 	farcall CheckIfMonIsYourOT
-	jr nc, .no_trade_restriction
-	ld hl, CantChangeTradedMonBallText
-	jmp PrintText
+	jr c, CantChangeTradedMonBallMessage
 
 .no_trade_restriction
 	ld a, [wCurItem]

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -2301,6 +2301,15 @@ Ball_ReplacePartyMonCaughtBall:
 	call UseItem_SelectMon
 	jr c, ItemNotUsed_ExitMenu
 
+	ld a, [wInitialOptions]
+	bit TRADED_AS_OT_OPT, a
+	jr nz, .no_trade_restriction
+	farcall CheckIfMonIsYourOT
+	jr nc, .no_trade_restriction
+	ld hl, CantChangeTradedMonBallText
+	jmp PrintText
+
+.no_trade_restriction
 	ld a, [wCurItem]
 	ld b, a
 	ld a, [wCurPartyMon]
@@ -2333,6 +2342,10 @@ BallReplacedText:
 
 AlreadyInThatBallMessage:
 	ld hl, AlreadyInThatBallText
+	jr CantUseItemMessage
+
+CantChangeTradedMonBallMessage:
+	ld hl, CantChangeTradedMonBallText
 	jr CantUseItemMessage
 
 CantUseOnEggMessage:
@@ -2368,6 +2381,10 @@ CantUseOnEggText:
 
 AlreadyInThatBallText:
 	text_far AlreadyInThatBallTextData
+	text_end
+
+CantChangeTradedMonBallText:
+	text_far CantChangeTradedMonBallTextData
 	text_end
 
 IsntTheTimeText:


### PR DESCRIPTION
...Unless the traded-pokémon-treat-you-as-OT option is set.