### PR TITLE
Celebi event, make Lyra's text related to Celebi more clear

### DIFF
--- a/maps/Route22Past.asm
+++ b/maps/Route22Past.asm
@@ -35,10 +35,14 @@ Route22PastCelebiEventScript:
 	showtext Route22PastLyraIlexForestDisappearedText
 	applymovement ROUTE22PAST_LYRA, Route22Past_LyraStepDownMovementData
 	turnobject PLAYER, LEFT
+	showtext Route22PastLyraPokeGearText
+	applymovement ROUTE22PAST_LYRA, Route22Past_LyraStepDownTurnHeadRigthMovementData
+	turnobject PLAYER, DOWN
 	showtext Route22PastLyraExplainsTimeTravelText
 	showemote EMOTE_SHOCK, ROUTE22PAST_LYRA, 15
-	turnobject ROUTE22PAST_LYRA, UP
+	applymovement ROUTE22PAST_LYRA, Route22Past_LyraMoveUpToHearMovementData
 	showtext Route22PastLyraHearsSomeoneText
+	applymovement PLAYER, Route22Past_PlayerStepUpToLyraMovementData
 	follow ROUTE22PAST_LYRA, PLAYER
 	applymovement ROUTE22PAST_LYRA, Route22Past_LyraApproachesSilverMovementData
 	turnobject ROUTE22PAST_LYRA, UP
@@ -130,15 +134,27 @@ Route22Past_LyraLooksAroundAgainMovementData:
 
 Route22Past_LyraStepDownMovementData:
 	slow_step_down
+	step_end
+
+Route22Past_LyraStepDownTurnHeadRigthMovementData:
+	slow_step_down
 	turn_head_right
+	step_end
+
+Route22Past_LyraMoveUpToHearMovementData:
+	slow_step_up
+	slow_step_up
+	step_end
+
+Route22Past_PlayerStepUpToLyraMovementData
+	slow_step_up
 	step_end
 
 Route22Past_LyraApproachesSilverMovementData:
 	slow_step_up
 	slow_step_up
-	slow_step_up
 	slow_step_left
-	step_end
+	step_end 
 
 Route22Past_GiovanniLeavesMovementData:
 	slow_step_left
@@ -210,16 +226,23 @@ Route22PastLyraIlexForestDisappearedText:
 	cont "else…?"
 	done
 
-Route22PastLyraExplainsTimeTravelText:
+Route22PastLyraPokeGearText:
 	text "Lyra: <PLAYER>, my"
 	line "#gear radio"
 
 	para "said the date is"
 	line "from three years"
 	cont "ago!"
+	done
 
-	para "Celebi must have"
-	line "used its power to"
+Route22PastLyraExplainsTimeTravelText:
+	text "Is that… am I"
+	line "looking at…"
+	cont "Celebi?"
+
+	para "That explains it!"
+	line "Celebi must have"
+	cont "used its power to"
 
 	para "take us back in"
 	line "time!"

--- a/maps/Route22Past.asm
+++ b/maps/Route22Past.asm
@@ -146,7 +146,7 @@ Route22Past_LyraMoveUpToHearMovementData:
 	slow_step_up
 	step_end
 
-Route22Past_PlayerStepUpToLyraMovementData
+Route22Past_PlayerStepUpToLyraMovementData:
 	slow_step_up
 	step_end
 


### PR DESCRIPTION
## Summary

Lyra's dialogue regarding Celebi is a bit confusing. The original HGSS event has clearer text. This pull request adds some of that text.

## What exactly this pull request adds

The pull request adds **additional dialogue** for Lyra, extracted from the HGSS event:
```
Is that... am I looking at... Celebi?
That explains it!
```
This text happens right before the text `"Celebi must have used its power to [...]"`, in Route 22.

The pull request also **slightly modifies Lyra's movement** in the event to make it clearer that she's seeing Celebi for the first time. This movement resembles more the movement she has in the HGSS event.

## Detailed explanation of why I think this should be added

The first time I played through the Celebi event, the way Lyra talked about Celebi and the legend of the shrine confused me. I had not played the original HGSS event before, but after watching a video showing it, I consider it to be less confusing than the one we have in Polished Crystal.

The problem is that Lyra doesn't seem to see Celebi at first, when in the forest (the dialogue `"Have you heard of the legend of the shrine? They say that people disappear when they tamper with it."` doesn't acknowledge Celebi in that scene at any point); however, later she talks about Celebi as if it was clear to her that Celebi was there all along (`"Celebi must have used its power to take us back in time!"` is the first piece of dialogue where Lyra talks about Celebi). The HGSS event has some additional dialogue in the middle for when Lyra first sees Celebi, in Route 22 (`"Is that... am I looking at... Celebi? That explains it! [...]"`).

I am aware this is a pretty minor thing, but it genuinelly made me believe I had skipped over some of the text by mistake. This is specially regrettable, since there is no way  for us players to redo the event (that I know of) and check if we missed something.