### PR TITLE
add check for facing sprite when fishing

### DIFF
--- a/engine/events/overworld.asm
+++ b/engine/events/overworld.asm
@@ -1552,6 +1552,8 @@ FishFunction:
 	ld a, [wPlayerState]
 	cp PLAYER_SURF_PIKA
 	jr z, .fail
+	call GetFacingObject
+	jr c, .fail
 	call GetFacingTileCoord
 	call GetTileCollision
 	dec a ; cp WATER_TILE

--- a/engine/events/overworld.asm
+++ b/engine/events/overworld.asm
@@ -480,13 +480,13 @@ SurfFunction:
 	jr z, .alreadyfail
 	cp PLAYER_SURF_PIKA
 	jr z, .alreadyfail
+	call GetFacingObject
+	jr nc, .cannotsurf
 	call GetFacingTileCoord
 	call GetTileCollision
 	dec a ; cp WATER_TILE
 	jr nz, .cannotsurf
 	call CheckDirection
-	jr c, .cannotsurf
-	farcall CheckFacingObject
 	jr c, .cannotsurf
 	ld a, $1
 	ret

--- a/engine/events/overworld.asm
+++ b/engine/events/overworld.asm
@@ -480,13 +480,13 @@ SurfFunction:
 	jr z, .alreadyfail
 	cp PLAYER_SURF_PIKA
 	jr z, .alreadyfail
-	call GetFacingObject
-	jr nc, .cannotsurf
 	call GetFacingTileCoord
 	call GetTileCollision
 	dec a ; cp WATER_TILE
 	jr nz, .cannotsurf
 	call CheckDirection
+	jr c, .cannotsurf
+	farcall CheckFacingObject
 	jr c, .cannotsurf
 	ld a, $1
 	ret
@@ -1552,12 +1552,12 @@ FishFunction:
 	ld a, [wPlayerState]
 	cp PLAYER_SURF_PIKA
 	jr z, .fail
-	call GetFacingObject
-	jr nc, .fail
 	call GetFacingTileCoord
 	call GetTileCollision
 	dec a ; cp WATER_TILE
-	jr z, .facingwater
+	jr nz, .fail
+	farcall CheckFacingObject
+	jr nc, .facingwater
 .fail
 	ld a, $3
 	ret

--- a/engine/events/overworld.asm
+++ b/engine/events/overworld.asm
@@ -1553,7 +1553,7 @@ FishFunction:
 	cp PLAYER_SURF_PIKA
 	jr z, .fail
 	call GetFacingObject
-	jr c, .fail
+	jr nc, .fail
 	call GetFacingTileCoord
 	call GetTileCollision
 	dec a ; cp WATER_TILE


### PR DESCRIPTION
~Addresses [pret/pokecrystal#994](https://github.com/pret/pokecrystal/issues/994)~

Addresses ["You can fish on top of NPCs"](https://pret.github.io/pokecrystal/bugs_and_glitches.html#you-can-fish-on-top-of-npcs) from pokecrystal's bug docs

![polishedcrystal-debug-3.0.0-beta.000.png](https://user-images.githubusercontent.com/9028176/187539203-d8a12cfc-3edb-43a1-b2c8-95e064b04afc.png)