### PR TITLE
`Special_CurBoxFullCheck` incorrectly returns nonzero for Non-Full box numbers > 1

### DIFF
--- a/engine/pc/bills_pc.asm
+++ b/engine/pc/bills_pc.asm
@@ -1419,6 +1419,9 @@ Special_CurBoxFullCheck:
 ; Returns [hScriptVar] = zero if wTempMonBox == wCurBox
 ; Returns [hScriptVar] = nonzero if wTempMonBox != wCurBox
 	call CurBoxFullCheck
+	jr nz, .not_equal
+	xor a
+.not_equal
 	ldh [hScriptVar], a
 	ret
 


### PR DESCRIPTION
`CurBoxFullCheck:` correctly returns the `Z` flag when the decremented `wTempMonBox` == `wCurBox`, however it also returns the current box value in register `a`. Thus, `Special_CurBoxFullCheck:` incorrectly reports Non-Full box numbers > 1 as ( `!=` or `nonzero`). This can be fixed by simply checking the zero flag and clearing register `a` before loading into `hScriptVar`.

I confirmed the bug as reported occurs when the player receives something like an egg with a full party, and current box is greater than box 1. The reported "Wise Glasses is full." and "Pecha Berry is full." is due to how `CurBoxFullCheck:` never runs `GetCurBoxName` as it **correctly** returns prior. The issue is cause by the mapscript incorrectly executing `farwritetext _CurBoxFullText` after an incorrect return value from `special Special_CurBoxFullCheck`.

See the following discord bug reports:  
https://discord.com/channels/332698009060114434/933019563535253534/1054183613089972276  
https://discord.com/channels/332698009060114434/933019563535253534/1054207464721092608