### PR TITLE
Fix Fish WildMon Forms

### DIFF
--- a/engine/events/overworld.asm
+++ b/engine/events/overworld.asm
@@ -1625,7 +1625,7 @@ FishFunction:
 	ld a, c
 	ld [wTempWildMonSpecies], a
 	ld a, b
-	ld [wCurForm], a
+	ld [wWildMonForm], a
 	ld a, BATTLETYPE_FISH
 	ld [wBattleType], a
 	ld a, $2


### PR DESCRIPTION
Resolve issue where ExtSpecies/Forms were not working correctly while fishing. Need to use `wWildMonForm` instead of `wCurForm` in `FishFunction:` to bypass `wCurForm` from being overwritten later by `GenerateWildForm:`

Resolves Discord Bug Reports: 
https://discord.com/channels/332698009060114434/933019563535253534/1054681881540567091
https://discord.com/channels/332698009060114434/933019563535253534/1054685241157095454