### PR TITLE
Full Party Naming Screen Issues

### DIFF
--- a/engine/gfx/cgb_layouts.asm
+++ b/engine/gfx/cgb_layouts.asm
@@ -595,6 +595,12 @@ _CGB_NamingScreen:
 	rst AddNTimes
 	ld d, h
 	ld e, l
+	ld a, [wMonType]
+	cp TEMPMON
+	jr nz, .party_mon
+	call LoadTempMonPalette
+	jr .not_pokemon
+.party_mon
 	call LoadPartyMonPalette
 .not_pokemon
 

--- a/engine/gfx/color.asm
+++ b/engine/gfx/color.asm
@@ -763,6 +763,28 @@ LoadPartyMonPalette:
 	pop hl
 	jmp VaryColorsByDVs
 
+LoadTempMonPalette:
+	push de
+	; bc = personality
+	ld bc, wTempMonPersonality
+	; a = species
+	ld a, [wCurPartySpecies]
+	; hl = palette
+	call GetMonNormalOrShinyPalettePointer
+	; load palette in de (set by caller)
+	ld bc, 4
+	call FarCopyColorWRAM
+	; hl = DVs
+	ld hl, wTempMonDVs
+	ld a, [wCurPartySpecies]
+	ld c, a
+	ld a, [wCurForm]
+	ld b, a
+	; Vary colors by DVs
+	call CopyDVsToColorVaryDVs
+	pop hl
+	jmp VaryColorsByDVs
+
 LoadTrainerPalette:
 	; a = class
 	ld a, [wTrainerClass]

--- a/engine/gfx/mon_icons.asm
+++ b/engine/gfx/mon_icons.asm
@@ -218,9 +218,16 @@ LoadNamingScreenMonMini:
 	push de
 	push bc
 
+	ld a, [wMonType]
+	cp TEMPMON
+	jr nz, .party_mon
+	ld hl, wTempMonForm
+	ld a, [hl]
+	jr .got_mon
+.party_mon
 	ld a, MON_FORM ; aka MON_IS_EGG
 	call GetPartyParamLocationAndValue
-
+.got_mon
 	depixel 4, 4, 4, 0
 	jr _LoadMonMini
 

--- a/engine/pokemon/move_mon.asm
+++ b/engine/pokemon/move_mon.asm
@@ -1086,6 +1086,8 @@ GivePoke::
 	ld d, PARTYMON
 	jr nc, .added
 	call .SetUpBoxMon ; d = BOXMON if nc
+	ld a, TEMPMON
+	ld [wMonType], a
 	jmp c, .FailedToGiveMon
 
 .added


### PR DESCRIPTION
I've only managed to partially fix this so far...

The issue mainly was:

If a party is "full", `LoadNamingScreenMonMini:` would call `GetPartyParamLocationAndValue:` and use `wPartyMon1Form` instead of `wTempMonForm`. Thus, if an Egg Or a pokemon with a Form was in the first slot, and the player catches a pokemon.. The naming screen will either show an Egg icon/text or a glitched icon.

This is only a partial fix so far... Although the correct icon/text now loads.. the palette is still wrong. I haven't been able to figure that out yet...