### PR TITLE
Convert to `channel_count` and `channel` music headers

### DIFF
--- a/audio/cries.asm
+++ b/audio/cries.asm
@@ -1,146 +1,176 @@
 Cry_Marill:
-	musicheader 3, 5, Cry_Marill_Ch5
-	musicheader 1, 6, Cry_Marill_Ch6
-	musicheader 1, 8, Cry_Marill_Ch8
+	channel_count 3
+	channel 5, Cry_Marill_Ch5
+	channel 6, Cry_Marill_Ch6
+	channel 8, Cry_Marill_Ch8
 
 Cry_Togepi:
-	musicheader 2, 5, Cry_Togepi_Ch5
-	musicheader 1, 6, Cry_Togepi_Ch6
+	channel_count 2
+	channel 5, Cry_Togepi_Ch5
+	channel 6, Cry_Togepi_Ch6
 
 Cry_Togetic:
-	musicheader 2, 5, Cry_Togetic_Ch5
-	musicheader 1, 6, Cry_Togetic_Ch6
+	channel_count 2
+	channel 5, Cry_Togetic_Ch5
+	channel 6, Cry_Togetic_Ch6
 
 Cry_Spinarak:
-	musicheader 3, 5, Cry_Spinarak_Ch5
-	musicheader 1, 6, Cry_Spinarak_Ch6
-	musicheader 1, 8, Cry_Spinarak_Ch8
+	channel_count 3
+	channel 5, Cry_Spinarak_Ch5
+	channel 6, Cry_Spinarak_Ch6
+	channel 8, Cry_Spinarak_Ch8
 
 Cry_Raikou:
-	musicheader 3, 5, Cry_Raikou_Ch5
-	musicheader 1, 6, Cry_Raikou_Ch6
-	musicheader 1, 8, Cry_Raikou_Ch8
+	channel_count 3
+	channel 5, Cry_Raikou_Ch5
+	channel 6, Cry_Raikou_Ch6
+	channel 8, Cry_Raikou_Ch8
 
 Cry_Hoothoot:
-	musicheader 3, 5, Cry_Hoothoot_Ch5
-	musicheader 1, 6, Cry_Hoothoot_Ch6
-	musicheader 1, 8, Cry_Hoothoot_Ch8
+	channel_count 3
+	channel 5, Cry_Hoothoot_Ch5
+	channel 6, Cry_Hoothoot_Ch6
+	channel 8, Cry_Hoothoot_Ch8
 
 Cry_Sentret:
-	musicheader 2, 5, Cry_Sentret_Ch5
-	musicheader 1, 6, Cry_Sentret_Ch6
+	channel_count 2
+	channel 5, Cry_Sentret_Ch5
+	channel 6, Cry_Sentret_Ch6
 
 Cry_Slowking:
-	musicheader 3, 5, Cry_Slowking_Ch5
-	musicheader 1, 6, Cry_Slowking_Ch6
-	musicheader 1, 8, Cry_Slowking_Ch8
+	channel_count 3
+	channel 5, Cry_Slowking_Ch5
+	channel 6, Cry_Slowking_Ch6
+	channel 8, Cry_Slowking_Ch8
 
 Cry_Mareep:
-	musicheader 2, 5, Cry_Mareep_Ch5
-	musicheader 1, 6, Cry_Mareep_Ch6
+	channel_count 2
+	channel 5, Cry_Mareep_Ch5
+	channel 6, Cry_Mareep_Ch6
 
 Cry_Cyndaquil:
-	musicheader 3, 5, Cry_Cyndaquil_Ch5
-	musicheader 1, 6, Cry_Cyndaquil_Ch6
-	musicheader 1, 8, Cry_Cyndaquil_Ch8
+	channel_count 3
+	channel 5, Cry_Cyndaquil_Ch5
+	channel 6, Cry_Cyndaquil_Ch6
+	channel 8, Cry_Cyndaquil_Ch8
 
 Cry_Chikorita:
-	musicheader 3, 5, Cry_Chikorita_Ch5
-	musicheader 1, 6, Cry_Chikorita_Ch6
-	musicheader 1, 8, Cry_Chikorita_Ch8
+	channel_count 3
+	channel 5, Cry_Chikorita_Ch5
+	channel 6, Cry_Chikorita_Ch6
+	channel 8, Cry_Chikorita_Ch8
 
 Cry_Gligar:
-	musicheader 2, 5, Cry_Gligar_Ch5
-	musicheader 1, 8, Cry_Gligar_Ch8
+	channel_count 2
+	channel 5, Cry_Gligar_Ch5
+	channel 8, Cry_Gligar_Ch8
 
 Cry_Girafarig:
-	musicheader 3, 5, Cry_Girafarig_Ch5
-	musicheader 1, 6, Cry_Girafarig_Ch6
-	musicheader 1, 8, Cry_Girafarig_Ch8
+	channel_count 3
+	channel 5, Cry_Girafarig_Ch5
+	channel 6, Cry_Girafarig_Ch6
+	channel 8, Cry_Girafarig_Ch8
 
 Cry_Slugma:
-	musicheader 2, 5, Cry_Slugma_Ch5
-	musicheader 1, 8, Cry_Slugma_Ch8
+	channel_count 2
+	channel 5, Cry_Slugma_Ch5
+	channel 8, Cry_Slugma_Ch8
 
 Cry_Ledyba:
-	musicheader 3, 5, Cry_Ledyba_Ch5
-	musicheader 1, 6, Cry_Ledyba_Ch6
-	musicheader 1, 8, Cry_Ledyba_Ch8
+	channel_count 3
+	channel 5, Cry_Ledyba_Ch5
+	channel 6, Cry_Ledyba_Ch6
+	channel 8, Cry_Ledyba_Ch8
 
 Cry_Wooper:
-	musicheader 3, 5, Cry_Wooper_Ch5
-	musicheader 1, 6, Cry_Wooper_Ch6
-	musicheader 1, 8, Cry_Wooper_Ch8
+	channel_count 3
+	channel 5, Cry_Wooper_Ch5
+	channel 6, Cry_Wooper_Ch6
+	channel 8, Cry_Wooper_Ch8
 
 Cry_Donphan:
-	musicheader 3, 5, Cry_Donphan_Ch5
-	musicheader 1, 6, Cry_Donphan_Ch6
-	musicheader 1, 8, Cry_Donphan_Ch8
+	channel_count 3
+	channel 5, Cry_Donphan_Ch5
+	channel 6, Cry_Donphan_Ch6
+	channel 8, Cry_Donphan_Ch8
 
 Cry_Typhlosion:
-	musicheader 3, 5, Cry_Typhlosion_Ch5
-	musicheader 1, 6, Cry_Typhlosion_Ch6
-	musicheader 1, 8, Cry_Typhlosion_Ch8
+	channel_count 3
+	channel 5, Cry_Typhlosion_Ch5
+	channel 6, Cry_Typhlosion_Ch6
+	channel 8, Cry_Typhlosion_Ch8
 
 Cry_Natu:
-	musicheader 3, 5, Cry_Natu_Ch5
-	musicheader 1, 6, Cry_Natu_Ch6
-	musicheader 1, 8, Cry_Natu_Ch8
+	channel_count 3
+	channel 5, Cry_Natu_Ch5
+	channel 6, Cry_Natu_Ch6
+	channel 8, Cry_Natu_Ch8
 
 Cry_Teddiursa:
-	musicheader 3, 5, Cry_Teddiursa_Ch5
-	musicheader 1, 6, Cry_Teddiursa_Ch6
-	musicheader 1, 8, Cry_Teddiursa_Ch8
+	channel_count 3
+	channel 5, Cry_Teddiursa_Ch5
+	channel 6, Cry_Teddiursa_Ch6
+	channel 8, Cry_Teddiursa_Ch8
 
 Cry_Remoraid:
-	musicheader 3, 5, Cry_Remoraid_Ch5
-	musicheader 1, 6, Cry_Remoraid_Ch6
-	musicheader 1, 8, Cry_Remoraid_Ch8
+	channel_count 3
+	channel 5, Cry_Remoraid_Ch5
+	channel 6, Cry_Remoraid_Ch6
+	channel 8, Cry_Remoraid_Ch8
 
 Cry_Ampharos:
-	musicheader 3, 5, Cry_Ampharos_Ch5
-	musicheader 1, 6, Cry_Ampharos_Ch6
-	musicheader 1, 8, Cry_Ampharos_Ch8
+	channel_count 3
+	channel 5, Cry_Ampharos_Ch5
+	channel 6, Cry_Ampharos_Ch6
+	channel 8, Cry_Ampharos_Ch8
 
 Cry_Totodile:
-	musicheader 3, 5, Cry_Totodile_Ch5
-	musicheader 1, 6, Cry_Totodile_Ch6
-	musicheader 1, 8, Cry_Totodile_Ch8
+	channel_count 3
+	channel 5, Cry_Totodile_Ch5
+	channel 6, Cry_Totodile_Ch6
+	channel 8, Cry_Totodile_Ch8
 
 Cry_Bellossom:
-	musicheader 3, 5, Cry_Bellossom_Ch5
-	musicheader 1, 6, Cry_Bellossom_Ch6
-	musicheader 1, 8, Cry_Bellossom_Ch8
+	channel_count 3
+	channel 5, Cry_Bellossom_Ch5
+	channel 6, Cry_Bellossom_Ch6
+	channel 8, Cry_Bellossom_Ch8
 
 Cry_Pichu:
-	musicheader 3, 5, Cry_Pichu_Ch5
-	musicheader 1, 6, Cry_Pichu_Ch6
-	musicheader 1, 8, Cry_Pichu_Ch8
+	channel_count 3
+	channel 5, Cry_Pichu_Ch5
+	channel 6, Cry_Pichu_Ch6
+	channel 8, Cry_Pichu_Ch8
 
 Cry_Tyrogue:
-	musicheader 3, 5, Cry_Tyrogue_Ch5
-	musicheader 1, 6, Cry_Tyrogue_Ch6
-	musicheader 1, 8, Cry_Tyrogue_Ch8
+	channel_count 3
+	channel 5, Cry_Tyrogue_Ch5
+	channel 6, Cry_Tyrogue_Ch6
+	channel 8, Cry_Tyrogue_Ch8
 
 Cry_Dunsparce:
-	musicheader 3, 5, Cry_Dunsparce_Ch5
-	musicheader 1, 6, Cry_Dunsparce_Ch6
-	musicheader 1, 8, Cry_Dunsparce_Ch8
+	channel_count 3
+	channel 5, Cry_Dunsparce_Ch5
+	channel 6, Cry_Dunsparce_Ch6
+	channel 8, Cry_Dunsparce_Ch8
 
 Cry_Magcargo:
-	musicheader 3, 5, Cry_Magcargo_Ch5
-	musicheader 1, 6, Cry_Magcargo_Ch6
-	musicheader 1, 8, Cry_Magcargo_Ch8
+	channel_count 3
+	channel 5, Cry_Magcargo_Ch5
+	channel 6, Cry_Magcargo_Ch6
+	channel 8, Cry_Magcargo_Ch8
 
 Cry_Entei:
-	musicheader 3, 5, Cry_Entei_Ch5
-	musicheader 1, 6, Cry_Entei_Ch6
-	musicheader 1, 8, Cry_Entei_Ch8
+	channel_count 3
+	channel 5, Cry_Entei_Ch5
+	channel 6, Cry_Entei_Ch6
+	channel 8, Cry_Entei_Ch8
 
 Cry_Mantine:
-	musicheader 3, 5, Cry_Mantine_Ch5
-	musicheader 1, 6, Cry_Mantine_Ch6
-	musicheader 1, 8, Cry_Mantine_Ch8
+	channel_count 3
+	channel 5, Cry_Mantine_Ch5
+	channel 6, Cry_Mantine_Ch6
+	channel 8, Cry_Mantine_Ch8
 
 Cry_Entei_Ch5:
 	soundinput $ff
@@ -825,194 +855,232 @@ Cry_Tyrogue_branch_f3460:
 	endchannel
 
 Cry_Nidoran_M:
-	musicheader 3, 5, Cry_Nidoran_M_Ch5
-	musicheader 1, 6, Cry_Nidoran_M_Ch6
-	musicheader 1, 8, Cry_Nidoran_M_Ch8
+	channel_count 3
+	channel 5, Cry_Nidoran_M_Ch5
+	channel 6, Cry_Nidoran_M_Ch6
+	channel 8, Cry_Nidoran_M_Ch8
 
 Cry_Nidoran_F:
-	musicheader 3, 5, Cry_Nidoran_F_Ch5
-	musicheader 1, 6, Cry_Nidoran_F_Ch6
-	musicheader 1, 8, Cry_Nidoran_F_Ch8
+	channel_count 3
+	channel 5, Cry_Nidoran_F_Ch5
+	channel 6, Cry_Nidoran_F_Ch6
+	channel 8, Cry_Nidoran_F_Ch8
 
 Cry_Slowpoke:
-	musicheader 3, 5, Cry_Slowpoke_Ch5
-	musicheader 1, 6, Cry_Slowpoke_Ch6
-	musicheader 1, 8, Cry_Slowpoke_Ch8
+	channel_count 3
+	channel 5, Cry_Slowpoke_Ch5
+	channel 6, Cry_Slowpoke_Ch6
+	channel 8, Cry_Slowpoke_Ch8
 
 Cry_Kangaskhan:
-	musicheader 3, 5, Cry_Kangaskhan_Ch5
-	musicheader 1, 6, Cry_Kangaskhan_Ch6
-	musicheader 1, 8, Cry_Kangaskhan_Ch8
+	channel_count 3
+	channel 5, Cry_Kangaskhan_Ch5
+	channel 6, Cry_Kangaskhan_Ch6
+	channel 8, Cry_Kangaskhan_Ch8
 
 Cry_Charmander:
-	musicheader 3, 5, Cry_Charmander_Ch5
-	musicheader 1, 6, Cry_Charmander_Ch6
-	musicheader 1, 8, Cry_Charmander_Ch8
+	channel_count 3
+	channel 5, Cry_Charmander_Ch5
+	channel 6, Cry_Charmander_Ch6
+	channel 8, Cry_Charmander_Ch8
 
 Cry_Grimer:
-	musicheader 3, 5, Cry_Grimer_Ch5
-	musicheader 1, 6, Cry_Grimer_Ch6
-	musicheader 1, 8, Cry_Grimer_Ch8
+	channel_count 3
+	channel 5, Cry_Grimer_Ch5
+	channel 6, Cry_Grimer_Ch6
+	channel 8, Cry_Grimer_Ch8
 
 Cry_Voltorb:
-	musicheader 3, 5, Cry_Voltorb_Ch5
-	musicheader 1, 6, Cry_Voltorb_Ch6
-	musicheader 1, 8, Cry_Voltorb_Ch8
+	channel_count 3
+	channel 5, Cry_Voltorb_Ch5
+	channel 6, Cry_Voltorb_Ch6
+	channel 8, Cry_Voltorb_Ch8
 
 Cry_Muk:
-	musicheader 3, 5, Cry_Muk_Ch5
-	musicheader 1, 6, Cry_Muk_Ch6
-	musicheader 1, 8, Cry_Muk_Ch8
+	channel_count 3
+	channel 5, Cry_Muk_Ch5
+	channel 6, Cry_Muk_Ch6
+	channel 8, Cry_Muk_Ch8
 
 Cry_Oddish:
-	musicheader 3, 5, Cry_Oddish_Ch5
-	musicheader 1, 6, Cry_Oddish_Ch6
-	musicheader 1, 8, Cry_Oddish_Ch8
+	channel_count 3
+	channel 5, Cry_Oddish_Ch5
+	channel 6, Cry_Oddish_Ch6
+	channel 8, Cry_Oddish_Ch8
 
 Cry_Raichu:
-	musicheader 3, 5, Cry_Raichu_Ch5
-	musicheader 1, 6, Cry_Raichu_Ch6
-	musicheader 1, 8, Cry_Raichu_Ch8
+	channel_count 3
+	channel 5, Cry_Raichu_Ch5
+	channel 6, Cry_Raichu_Ch6
+	channel 8, Cry_Raichu_Ch8
 
 Cry_Nidoqueen:
-	musicheader 3, 5, Cry_Nidoqueen_Ch5
-	musicheader 1, 6, Cry_Nidoqueen_Ch6
-	musicheader 1, 8, Cry_Nidoqueen_Ch8
+	channel_count 3
+	channel 5, Cry_Nidoqueen_Ch5
+	channel 6, Cry_Nidoqueen_Ch6
+	channel 8, Cry_Nidoqueen_Ch8
 
 Cry_Diglett:
-	musicheader 3, 5, Cry_Diglett_Ch5
-	musicheader 1, 6, Cry_Diglett_Ch6
-	musicheader 1, 8, Cry_Diglett_Ch8
+	channel_count 3
+	channel 5, Cry_Diglett_Ch5
+	channel 6, Cry_Diglett_Ch6
+	channel 8, Cry_Diglett_Ch8
 
 Cry_Seel:
-	musicheader 3, 5, Cry_Seel_Ch5
-	musicheader 1, 6, Cry_Seel_Ch6
-	musicheader 1, 8, Cry_Seel_Ch8
+	channel_count 3
+	channel 5, Cry_Seel_Ch5
+	channel 6, Cry_Seel_Ch6
+	channel 8, Cry_Seel_Ch8
 
 Cry_Drowzee:
-	musicheader 3, 5, Cry_Drowzee_Ch5
-	musicheader 1, 6, Cry_Drowzee_Ch6
-	musicheader 1, 8, Cry_Drowzee_Ch8
+	channel_count 3
+	channel 5, Cry_Drowzee_Ch5
+	channel 6, Cry_Drowzee_Ch6
+	channel 8, Cry_Drowzee_Ch8
 
 Cry_Pidgey:
-	musicheader 3, 5, Cry_Pidgey_Ch5
-	musicheader 1, 6, Cry_Pidgey_Ch6
-	musicheader 1, 8, Cry_Pidgey_Ch8
+	channel_count 3
+	channel 5, Cry_Pidgey_Ch5
+	channel 6, Cry_Pidgey_Ch6
+	channel 8, Cry_Pidgey_Ch8
 
 Cry_Bulbasaur:
-	musicheader 3, 5, Cry_Bulbasaur_Ch5
-	musicheader 1, 6, Cry_Bulbasaur_Ch6
-	musicheader 1, 8, Cry_Bulbasaur_Ch8
+	channel_count 3
+	channel 5, Cry_Bulbasaur_Ch5
+	channel 6, Cry_Bulbasaur_Ch6
+	channel 8, Cry_Bulbasaur_Ch8
 
 Cry_Farfetch_d:
-	musicheader 3, 5, Cry_Farfetch_d_Ch5
-	musicheader 1, 6, Cry_Farfetch_d_Ch6
-	musicheader 1, 8, Cry_Farfetch_d_Ch8
+	channel_count 3
+	channel 5, Cry_Farfetch_d_Ch5
+	channel 6, Cry_Farfetch_d_Ch6
+	channel 8, Cry_Farfetch_d_Ch8
 
 Cry_Rhydon:
-	musicheader 3, 5, Cry_Rhydon_Ch5
-	musicheader 1, 6, Cry_Rhydon_Ch6
-	musicheader 1, 8, Cry_Rhydon_Ch8
+	channel_count 3
+	channel 5, Cry_Rhydon_Ch5
+	channel 6, Cry_Rhydon_Ch6
+	channel 8, Cry_Rhydon_Ch8
 
 Cry_Golem:
-	musicheader 3, 5, Cry_Golem_Ch5
-	musicheader 1, 6, Cry_Golem_Ch6
-	musicheader 1, 8, Cry_Golem_Ch8
+	channel_count 3
+	channel 5, Cry_Golem_Ch5
+	channel 6, Cry_Golem_Ch6
+	channel 8, Cry_Golem_Ch8
 
 Cry_Blastoise:
-	musicheader 3, 5, Cry_Blastoise_Ch5
-	musicheader 1, 6, Cry_Blastoise_Ch6
-	musicheader 1, 8, Cry_Blastoise_Ch8
+	channel_count 3
+	channel 5, Cry_Blastoise_Ch5
+	channel 6, Cry_Blastoise_Ch6
+	channel 8, Cry_Blastoise_Ch8
 
 Cry_Pidgeotto:
-	musicheader 3, 5, Cry_Pidgeotto_Ch5
-	musicheader 1, 6, Cry_Pidgeotto_Ch6
-	musicheader 1, 8, Cry_Pidgeotto_Ch8
+	channel_count 3
+	channel 5, Cry_Pidgeotto_Ch5
+	channel 6, Cry_Pidgeotto_Ch6
+	channel 8, Cry_Pidgeotto_Ch8
 
 Cry_Weedle:
-	musicheader 3, 5, Cry_Weedle_Ch5
-	musicheader 1, 6, Cry_Weedle_Ch6
-	musicheader 1, 8, Cry_Weedle_Ch8
+	channel_count 3
+	channel 5, Cry_Weedle_Ch5
+	channel 6, Cry_Weedle_Ch6
+	channel 8, Cry_Weedle_Ch8
 
 Cry_Caterpie:
-	musicheader 3, 5, Cry_Caterpie_Ch5
-	musicheader 1, 6, Cry_Caterpie_Ch6
-	musicheader 1, 8, Cry_Caterpie_Ch8
+	channel_count 3
+	channel 5, Cry_Caterpie_Ch5
+	channel 6, Cry_Caterpie_Ch6
+	channel 8, Cry_Caterpie_Ch8
 
 Cry_Ekans:
-	musicheader 3, 5, Cry_Ekans_Ch5
-	musicheader 1, 6, Cry_Ekans_Ch6
-	musicheader 1, 8, Cry_Ekans_Ch8
+	channel_count 3
+	channel 5, Cry_Ekans_Ch5
+	channel 6, Cry_Ekans_Ch6
+	channel 8, Cry_Ekans_Ch8
 
 Cry_Shellder:
-	musicheader 3, 5, Cry_Shellder_Ch5
-	musicheader 1, 6, Cry_Shellder_Ch6
-	musicheader 1, 8, Cry_Shellder_Ch8
+	channel_count 3
+	channel 5, Cry_Shellder_Ch5
+	channel 6, Cry_Shellder_Ch6
+	channel 8, Cry_Shellder_Ch8
 
 Cry_Clefairy:
-	musicheader 3, 5, Cry_Clefairy_Ch5
-	musicheader 1, 6, Cry_Clefairy_Ch6
-	musicheader 1, 8, Cry_Clefairy_Ch8
+	channel_count 3
+	channel 5, Cry_Clefairy_Ch5
+	channel 6, Cry_Clefairy_Ch6
+	channel 8, Cry_Clefairy_Ch8
 
 Cry_Venonat:
-	musicheader 3, 5, Cry_Venonat_Ch5
-	musicheader 1, 6, Cry_Venonat_Ch6
-	musicheader 1, 8, Cry_Venonat_Ch8
+	channel_count 3
+	channel 5, Cry_Venonat_Ch5
+	channel 6, Cry_Venonat_Ch6
+	channel 8, Cry_Venonat_Ch8
 
 Cry_Lapras:
-	musicheader 3, 5, Cry_Lapras_Ch5
-	musicheader 1, 6, Cry_Lapras_Ch6
-	musicheader 1, 8, Cry_Lapras_Ch8
+	channel_count 3
+	channel 5, Cry_Lapras_Ch5
+	channel 6, Cry_Lapras_Ch6
+	channel 8, Cry_Lapras_Ch8
 
 Cry_Metapod:
-	musicheader 3, 5, Cry_Metapod_Ch5
-	musicheader 1, 6, Cry_Metapod_Ch6
-	musicheader 1, 8, Cry_Metapod_Ch8
+	channel_count 3
+	channel 5, Cry_Metapod_Ch5
+	channel 6, Cry_Metapod_Ch6
+	channel 8, Cry_Metapod_Ch8
 
 Cry_Squirtle:
-	musicheader 3, 5, Cry_Squirtle_Ch5
-	musicheader 1, 6, Cry_Squirtle_Ch6
-	musicheader 1, 8, Cry_Squirtle_Ch8
+	channel_count 3
+	channel 5, Cry_Squirtle_Ch5
+	channel 6, Cry_Squirtle_Ch6
+	channel 8, Cry_Squirtle_Ch8
 
 Cry_Paras:
-	musicheader 3, 5, Cry_Paras_Ch5
-	musicheader 1, 6, Cry_Paras_Ch6
-	musicheader 1, 8, Cry_Paras_Ch8
+	channel_count 3
+	channel 5, Cry_Paras_Ch5
+	channel 6, Cry_Paras_Ch6
+	channel 8, Cry_Paras_Ch8
 
 Cry_Growlithe:
-	musicheader 3, 5, Cry_Growlithe_Ch5
-	musicheader 1, 6, Cry_Growlithe_Ch6
-	musicheader 1, 8, Cry_Growlithe_Ch8
+	channel_count 3
+	channel 5, Cry_Growlithe_Ch5
+	channel 6, Cry_Growlithe_Ch6
+	channel 8, Cry_Growlithe_Ch8
 
 Cry_Krabby:
-	musicheader 3, 5, Cry_Krabby_Ch5
-	musicheader 1, 6, Cry_Krabby_Ch6
-	musicheader 1, 8, Cry_Krabby_Ch8
+	channel_count 3
+	channel 5, Cry_Krabby_Ch5
+	channel 6, Cry_Krabby_Ch6
+	channel 8, Cry_Krabby_Ch8
 
 Cry_Psyduck:
-	musicheader 3, 5, Cry_Psyduck_Ch5
-	musicheader 1, 6, Cry_Psyduck_Ch6
-	musicheader 1, 8, Cry_Psyduck_Ch8
+	channel_count 3
+	channel 5, Cry_Psyduck_Ch5
+	channel 6, Cry_Psyduck_Ch6
+	channel 8, Cry_Psyduck_Ch8
 
 Cry_Rattata:
-	musicheader 3, 5, Cry_Rattata_Ch5
-	musicheader 1, 6, Cry_Rattata_Ch6
-	musicheader 1, 8, Cry_Rattata_Ch8
+	channel_count 3
+	channel 5, Cry_Rattata_Ch5
+	channel 6, Cry_Rattata_Ch6
+	channel 8, Cry_Rattata_Ch8
 
 Cry_Vileplume:
-	musicheader 3, 5, Cry_Vileplume_Ch5
-	musicheader 1, 6, Cry_Vileplume_Ch6
-	musicheader 1, 8, Cry_Vileplume_Ch8
+	channel_count 3
+	channel 5, Cry_Vileplume_Ch5
+	channel 6, Cry_Vileplume_Ch6
+	channel 8, Cry_Vileplume_Ch8
 
 Cry_Vulpix:
-	musicheader 3, 5, Cry_Vulpix_Ch5
-	musicheader 1, 6, Cry_Vulpix_Ch6
-	musicheader 1, 8, Cry_Vulpix_Ch8
+	channel_count 3
+	channel 5, Cry_Vulpix_Ch5
+	channel 6, Cry_Vulpix_Ch6
+	channel 8, Cry_Vulpix_Ch8
 
 Cry_Weepinbell:
-	musicheader 3, 5, Cry_Weepinbell_Ch5
-	musicheader 1, 6, Cry_Weepinbell_Ch6
-	musicheader 1, 8, Cry_Weepinbell_Ch8
+	channel_count 3
+	channel 5, Cry_Weepinbell_Ch5
+	channel 6, Cry_Weepinbell_Ch6
+	channel 8, Cry_Weepinbell_Ch8
 
 Cry_Raichu_Ch5:
 	sound_duty 0, 0, 3, 3

--- a/audio/music/aftertherivalfight.asm
+++ b/audio/music/aftertherivalfight.asm
@@ -1,8 +1,9 @@
 Music_AfterTheRivalFight:
-	musicheader 4, 1, Music_AfterTheRivalFight_Ch1
-	musicheader 1, 2, Music_AfterTheRivalFight_Ch2
-	musicheader 1, 3, Music_AfterTheRivalFight_Ch3
-	musicheader 1, 4, Music_AfterTheRivalFight_Ch4
+	channel_count 4
+	channel 1, Music_AfterTheRivalFight_Ch1
+	channel 2, Music_AfterTheRivalFight_Ch2
+	channel 3, Music_AfterTheRivalFight_Ch3
+	channel 4, Music_AfterTheRivalFight_Ch4
 
 Music_AfterTheRivalFight_Ch1:
 	tempo 112

--- a/audio/music/azaleatown.asm
+++ b/audio/music/azaleatown.asm
@@ -1,8 +1,9 @@
 Music_AzaleaTown:
-	musicheader 4, 1, Music_AzaleaTown_Ch1
-	musicheader 1, 2, Music_AzaleaTown_Ch2
-	musicheader 1, 3, Music_AzaleaTown_Ch3
-	musicheader 1, 4, Music_AzaleaTown_Ch4
+	channel_count 4
+	channel 1, Music_AzaleaTown_Ch1
+	channel 2, Music_AzaleaTown_Ch2
+	channel 3, Music_AzaleaTown_Ch3
+	channel 4, Music_AzaleaTown_Ch4
 
 Music_AzaleaTown_Ch1:
 	tempo 160

--- a/audio/music/b2w2/hiddengrotto.asm
+++ b/audio/music/b2w2/hiddengrotto.asm
@@ -4,10 +4,11 @@
 ; http://picosong.com/wkT7C/
 
 Music_HiddenGrottoB2W2:
-	musicheader 4, 1, Music_HiddenGrottoB2W2_Ch1
-	musicheader 1, 2, Music_HiddenGrottoB2W2_Ch2
-	musicheader 1, 3, Music_HiddenGrottoB2W2_Ch3
-	musicheader 1, 4, Music_HiddenGrottoB2W2_Ch4
+	channel_count 4
+	channel 1, Music_HiddenGrottoB2W2_Ch1
+	channel 2, Music_HiddenGrottoB2W2_Ch2
+	channel 3, Music_HiddenGrottoB2W2_Ch3
+	channel 4, Music_HiddenGrottoB2W2_Ch4
 
 Music_HiddenGrottoB2W2_Ch1:
 	dutycycle 2

--- a/audio/music/b2w2/marinetube.asm
+++ b/audio/music/b2w2/marinetube.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/
 
 Music_MarineTubeB2W2:
-	musicheader 4, 1, Music_MarineTubeB2W2_Ch1
-	musicheader 1, 2, Music_MarineTubeB2W2_Ch2
-	musicheader 1, 3, Music_MarineTubeB2W2_Ch3
-	musicheader 1, 4, Music_MarineTubeB2W2_Ch4
+	channel_count 4
+	channel 1, Music_MarineTubeB2W2_Ch1
+	channel 2, Music_MarineTubeB2W2_Ch2
+	channel 3, Music_MarineTubeB2W2_Ch3
+	channel 4, Music_MarineTubeB2W2_Ch4
 
 Music_MarineTubeB2W2_Ch1:
 	tempo 132

--- a/audio/music/b2w2/reversalmountainwhite.asm
+++ b/audio/music/b2w2/reversalmountainwhite.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/2/
 
 Music_ReversalMountainWhite2:
-	musicheader 4, 1, Music_ReversalMountainWhite2_Ch1
-	musicheader 1, 2, Music_ReversalMountainWhite2_Ch2
-	musicheader 1, 3, Music_ReversalMountainWhite2_Ch3
-	musicheader 1, 4, Music_ReversalMountainWhite2_Ch4
+	channel_count 4
+	channel 1, Music_ReversalMountainWhite2_Ch1
+	channel 2, Music_ReversalMountainWhite2_Ch2
+	channel 3, Music_ReversalMountainWhite2_Ch3
+	channel 4, Music_ReversalMountainWhite2_Ch4
 
 Music_ReversalMountainWhite2_Ch1:
 	tempo 176

--- a/audio/music/b2w2/roadtoreversalmountain.asm
+++ b/audio/music/b2w2/roadtoreversalmountain.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/
 
 Music_RoadToReversalMountainB2W2:
-	musicheader 4, 1, Music_RoadToReversalMountainB2W2_Ch1
-	musicheader 1, 2, Music_RoadToReversalMountainB2W2_Ch2
-	musicheader 1, 3, Music_RoadToReversalMountainB2W2_Ch3
-	musicheader 1, 4, Music_RoadToReversalMountainB2W2_Ch4
+	channel_count 4
+	channel 1, Music_RoadToReversalMountainB2W2_Ch1
+	channel 2, Music_RoadToReversalMountainB2W2_Ch2
+	channel 3, Music_RoadToReversalMountainB2W2_Ch3
+	channel 4, Music_RoadToReversalMountainB2W2_Ch4
 
 Music_RoadToReversalMountainB2W2_Ch1:
 	tempo 140

--- a/audio/music/b2w2/whitetreehollow.asm
+++ b/audio/music/b2w2/whitetreehollow.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/4/
 
 Music_WhiteTreehollowWhite2:
-	musicheader 4, 1, Music_WhiteTreehollowWhite2_Ch1
-	musicheader 1, 2, Music_WhiteTreehollowWhite2_Ch2
-	musicheader 1, 3, Music_WhiteTreehollowWhite2_Ch3
-	musicheader 1, 4, Music_WhiteTreehollowWhite2_Ch4
+	channel_count 4
+	channel 1, Music_WhiteTreehollowWhite2_Ch1
+	channel 2, Music_WhiteTreehollowWhite2_Ch2
+	channel 3, Music_WhiteTreehollowWhite2_Ch3
+	channel 4, Music_WhiteTreehollowWhite2_Ch4
 
 Music_WhiteTreehollowWhite2_Ch1:
 	tempo 176

--- a/audio/music/battletowerlobby.asm
+++ b/audio/music/battletowerlobby.asm
@@ -1,8 +1,9 @@
 Music_BattleTowerLobby:
-	musicheader 4, 1, Music_BattleTowerLobby_Ch1
-	musicheader 1, 2, Music_BattleTowerLobby_Ch2
-	musicheader 1, 3, Music_BattleTowerLobby_Ch3
-	musicheader 1, 4, Music_BattleTowerLobby_Ch4
+	channel_count 4
+	channel 1, Music_BattleTowerLobby_Ch1
+	channel 2, Music_BattleTowerLobby_Ch2
+	channel 3, Music_BattleTowerLobby_Ch3
+	channel 4, Music_BattleTowerLobby_Ch4
 
 Music_BattleTowerLobby_Ch1:
 	tempo 152

--- a/audio/music/battletowertheme.asm
+++ b/audio/music/battletowertheme.asm
@@ -1,8 +1,9 @@
 Music_BattleTowerTheme:
-	musicheader 4, 1, Music_BattleTowerTheme_Ch1
-	musicheader 1, 2, Music_BattleTowerTheme_Ch2
-	musicheader 1, 3, Music_BattleTowerTheme_Ch3
-	musicheader 1, 4, Music_BattleTowerTheme_Ch4
+	channel_count 4
+	channel 1, Music_BattleTowerTheme_Ch1
+	channel 2, Music_BattleTowerTheme_Ch2
+	channel 3, Music_BattleTowerTheme_Ch3
+	channel 4, Music_BattleTowerTheme_Ch4
 
 Music_BattleTowerTheme_Ch1:
 	tempo 141

--- a/audio/music/bicycle.asm
+++ b/audio/music/bicycle.asm
@@ -1,8 +1,9 @@
 Music_Bicycle:
-	musicheader 4, 1, Music_Bicycle_Ch1
-	musicheader 1, 2, Music_Bicycle_Ch2
-	musicheader 1, 3, Music_Bicycle_Ch3
-	musicheader 1, 4, Music_Bicycle_Ch4
+	channel_count 4
+	channel 1, Music_Bicycle_Ch1
+	channel 2, Music_Bicycle_Ch2
+	channel 3, Music_Bicycle_Ch3
+	channel 4, Music_Bicycle_Ch4
 
 Music_Bicycle_Ch1:
 	tempo 140

--- a/audio/music/buenaspassword.asm
+++ b/audio/music/buenaspassword.asm
@@ -1,8 +1,9 @@
 Music_BuenasPassword:
-	musicheader 4, 1, Music_BuenasPassword_Ch1
-	musicheader 1, 2, Music_BuenasPassword_Ch2
-	musicheader 1, 3, Music_BuenasPassword_Ch3
-	musicheader 1, 4, Music_BuenasPassword_Ch4
+	channel_count 4
+	channel 1, Music_BuenasPassword_Ch1
+	channel 2, Music_BuenasPassword_Ch2
+	channel 3, Music_BuenasPassword_Ch3
+	channel 4, Music_BuenasPassword_Ch4
 
 Music_BuenasPassword_Ch1:
 	tempo 136

--- a/audio/music/bugcatchingcontest.asm
+++ b/audio/music/bugcatchingcontest.asm
@@ -1,8 +1,9 @@
 Music_BugCatchingContest:
-	musicheader 4, 1, Music_BugCatchingContest_Ch1
-	musicheader 1, 2, Music_BugCatchingContest_Ch2
-	musicheader 1, 3, Music_BugCatchingContest_Ch3
-	musicheader 1, 4, Music_BugCatchingContest_Ch4
+	channel_count 4
+	channel 1, Music_BugCatchingContest_Ch1
+	channel 2, Music_BugCatchingContest_Ch2
+	channel 3, Music_BugCatchingContest_Ch3
+	channel 4, Music_BugCatchingContest_Ch4
 
 Music_BugCatchingContest_Ch1:
 	tempo 144

--- a/audio/music/burnedtower.asm
+++ b/audio/music/burnedtower.asm
@@ -1,8 +1,9 @@
 Music_BurnedTower:
-	musicheader 4, 1, Music_BurnedTower_Ch1
-	musicheader 1, 2, Music_BurnedTower_Ch2
-	musicheader 1, 3, Music_BurnedTower_Ch3
-	musicheader 1, 4, Music_BurnedTower_Ch4
+	channel_count 4
+	channel 1, Music_BurnedTower_Ch1
+	channel 2, Music_BurnedTower_Ch2
+	channel 3, Music_BurnedTower_Ch3
+	channel 4, Music_BurnedTower_Ch4
 
 Music_BurnedTower_Ch1:
 	tempo 168

--- a/audio/music/bw/blackcity.asm
+++ b/audio/music/bw/blackcity.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/9/
 
 Music_BlackCityBW:
-	musicheader 4, 1, Music_BlackCityBW_Ch1
-	musicheader 1, 2, Music_BlackCityBW_Ch2
-	musicheader 1, 3, Music_BlackCityBW_Ch3
-	musicheader 1, 4, Music_BlackCityBW_Ch4
+	channel_count 4
+	channel 1, Music_BlackCityBW_Ch1
+	channel 2, Music_BlackCityBW_Ch2
+	channel 3, Music_BlackCityBW_Ch3
+	channel 4, Music_BlackCityBW_Ch4
 
 Music_BlackCityBW_Ch1:
 	vibrato $12, $15

--- a/audio/music/bw/celestialtower.asm
+++ b/audio/music/bw/celestialtower.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/9/
 
 Music_CelestialTowerBW_NoIntro:
-	musicheader 4, 1, Music_CelestialTowerBW_NoIntro_Ch1
-	musicheader 1, 2, Music_CelestialTowerBW_NoIntro_Ch2
-	musicheader 1, 3, Music_CelestialTowerBW_NoIntro_Ch3
-	musicheader 1, 4, Music_CelestialTowerBW_NoIntro_Ch4
+	channel_count 4
+	channel 1, Music_CelestialTowerBW_NoIntro_Ch1
+	channel 2, Music_CelestialTowerBW_NoIntro_Ch2
+	channel 3, Music_CelestialTowerBW_NoIntro_Ch3
+	channel 4, Music_CelestialTowerBW_NoIntro_Ch4
 
 Music_CelestialTowerBW_NoIntro_Ch1:
 	tempo 232

--- a/audio/music/bw/elitefourbattle.asm
+++ b/audio/music/bw/elitefourbattle.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/9/
 
 Music_EliteFourBattleBW:
-	musicheader 4, 1, Music_EliteFourBattleBW_Ch1
-	musicheader 1, 2, Music_EliteFourBattleBW_Ch2
-	musicheader 1, 3, Music_EliteFourBattleBW_Ch3
-	musicheader 1, 4, Music_EliteFourBattleBW_Ch4
+	channel_count 4
+	channel 1, Music_EliteFourBattleBW_Ch1
+	channel 2, Music_EliteFourBattleBW_Ch2
+	channel 3, Music_EliteFourBattleBW_Ch3
+	channel 4, Music_EliteFourBattleBW_Ch4
 
 Music_EliteFourBattleBW_Ch1:
 	dutycycle $2

--- a/audio/music/bw/finalpokemon.asm
+++ b/audio/music/bw/finalpokemon.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/6/
 
 Music_FinalPokemonBW:
-	musicheader 4, 1, Music_FinalPokemonBW_Ch1
-	musicheader 1, 2, Music_FinalPokemonBW_Ch2
-	musicheader 1, 3, Music_FinalPokemonBW_Ch3
-	musicheader 1, 4, Music_FinalPokemonBW_Ch4
+	channel_count 4
+	channel 1, Music_FinalPokemonBW_Ch1
+	channel 2, Music_FinalPokemonBW_Ch2
+	channel 3, Music_FinalPokemonBW_Ch3
+	channel 4, Music_FinalPokemonBW_Ch4
 
 Music_FinalPokemonBW_Ch1:
 	tempo 240

--- a/audio/music/bw/gymleaderbattle.asm
+++ b/audio/music/bw/gymleaderbattle.asm
@@ -3,10 +3,11 @@
 ; https://hax.iimarckus.org/topic/6443/
 
 Music_GymLeaderBattleBW:
-	musicheader 4, 1, GymLeaderBattleBW_Channel1
-	musicheader 1, 2, GymLeaderBattleBW_Channel2
-	musicheader 1, 3, GymLeaderBattleBW_Channel3
-	musicheader 1, 4, GymLeaderBattleBW_Channel4
+	channel_count 4
+	channel 1, GymLeaderBattleBW_Channel1
+	channel 2, GymLeaderBattleBW_Channel2
+	channel 3, GymLeaderBattleBW_Channel3
+	channel 4, GymLeaderBattleBW_Channel4
 
 GymLeaderBattleBW_Channel1:
 	tempo $35

--- a/audio/music/bw/route12.asm
+++ b/audio/music/bw/route12.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/2/
 
 Music_Route12BW:
-	musicheader 4, 1, Music_Route12BW_Ch1
-	musicheader 1, 2, Music_Route12BW_Ch2
-	musicheader 1, 3, Music_Route12BW_Ch3
-	musicheader 1, 4, Music_Route12BW_Ch4
+	channel_count 4
+	channel 1, Music_Route12BW_Ch1
+	channel 2, Music_Route12BW_Ch2
+	channel 3, Music_Route12BW_Ch3
+	channel 4, Music_Route12BW_Ch4
 
 Music_Route12BW_Ch1:
 	tempo 236

--- a/audio/music/bw/route4.asm
+++ b/audio/music/bw/route4.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/
 
 Music_Route4BW:
-	musicheader 4, 1, Music_Route4BW_Ch1
-	musicheader 1, 2, Music_Route4BW_Ch2
-	musicheader 1, 3, Music_Route4BW_Ch3
-	musicheader 1, 4, Music_Route4BW_Ch4
+	channel_count 4
+	channel 1, Music_Route4BW_Ch1
+	channel 2, Music_Route4BW_Ch2
+	channel 3, Music_Route4BW_Ch3
+	channel 4, Music_Route4BW_Ch4
 
 Music_Route4BW_Ch1:
 	tempo 144

--- a/audio/music/bw/trainerbattle.asm
+++ b/audio/music/bw/trainerbattle.asm
@@ -3,10 +3,11 @@
 ; https://pastebin.com/7Hz9jRHq
 
 Music_TrainerBattleBW:
-	musicheader 4, 1, Music_TrainerBattleBW_Ch1
-	musicheader 1, 2, Music_TrainerBattleBW_Ch2
-	musicheader 1, 3, Music_TrainerBattleBW_Ch3
-	musicheader 1, 4, Music_TrainerBattleBW_Ch4
+	channel_count 4
+	channel 1, Music_TrainerBattleBW_Ch1
+	channel 2, Music_TrainerBattleBW_Ch2
+	channel 3, Music_TrainerBattleBW_Ch3
+	channel 4, Music_TrainerBattleBW_Ch4
 
 Music_TrainerBattleBW_Ch1:
 	volume $77

--- a/audio/music/celadoncity.asm
+++ b/audio/music/celadoncity.asm
@@ -1,7 +1,8 @@
 Music_CeladonCity:
-	musicheader 3, 1, Music_CeladonCity_Ch1
-	musicheader 1, 2, Music_CeladonCity_Ch2
-	musicheader 1, 3, Music_CeladonCity_Ch3
+	channel_count 3
+	channel 1, Music_CeladonCity_Ch1
+	channel 2, Music_CeladonCity_Ch2
+	channel 3, Music_CeladonCity_Ch3
 
 Music_CeladonCity_Ch1:
 	tempo 146

--- a/audio/music/championbattle.asm
+++ b/audio/music/championbattle.asm
@@ -1,7 +1,8 @@
 Music_ChampionBattle:
-	musicheader 3, 1, Music_ChampionBattle_Ch1
-	musicheader 1, 2, Music_ChampionBattle_Ch2
-	musicheader 1, 3, Music_ChampionBattle_Ch3
+	channel_count 3
+	channel 1, Music_ChampionBattle_Ch1
+	channel 2, Music_ChampionBattle_Ch2
+	channel 3, Music_ChampionBattle_Ch3
 
 Music_ChampionBattle_Ch1:
 	tempo 98

--- a/audio/music/cherrygrovecity.asm
+++ b/audio/music/cherrygrovecity.asm
@@ -1,8 +1,9 @@
 Music_CherrygroveCity:
-	musicheader 4, 1, Music_CherrygroveCity_Ch1
-	musicheader 1, 2, Music_CherrygroveCity_Ch2
-	musicheader 1, 3, Music_CherrygroveCity_Ch3
-	musicheader 1, 4, Music_CherrygroveCity_Ch4
+	channel_count 4
+	channel 1, Music_CherrygroveCity_Ch1
+	channel 2, Music_CherrygroveCity_Ch2
+	channel 3, Music_CherrygroveCity_Ch3
+	channel 4, Music_CherrygroveCity_Ch4
 
 Music_CherrygroveCity_Ch1:
 	tempo 152

--- a/audio/music/clair.asm
+++ b/audio/music/clair.asm
@@ -1,8 +1,9 @@
 Music_Clair:
-	musicheader 4, 1, Music_Clair_Ch1
-	musicheader 1, 2, Music_Clair_Ch2
-	musicheader 1, 3, Music_Clair_Ch3
-	musicheader 1, 4, Music_Clair_Ch4
+	channel_count 4
+	channel 1, Music_Clair_Ch1
+	channel 2, Music_Clair_Ch2
+	channel 3, Music_Clair_Ch3
+	channel 4, Music_Clair_Ch4
 
 Music_Clair_Ch1:
 	tempo 136

--- a/audio/music/contestresults.asm
+++ b/audio/music/contestresults.asm
@@ -1,8 +1,9 @@
 Music_ContestResults:
-	musicheader 4, 1, Music_ContestResults_Ch1
-	musicheader 1, 2, Music_ContestResults_Ch2
-	musicheader 1, 3, Music_ContestResults_Ch3
-	musicheader 1, 4, Music_ContestResults_Ch4
+	channel_count 4
+	channel 1, Music_ContestResults_Ch1
+	channel 2, Music_ContestResults_Ch2
+	channel 3, Music_ContestResults_Ch3
+	channel 4, Music_ContestResults_Ch4
 
 Music_ContestResults_Ch1:
 	tempo 144

--- a/audio/music/credits.asm
+++ b/audio/music/credits.asm
@@ -1,8 +1,9 @@
 Music_Credits:
-	musicheader 4, 1, Music_Credits_Ch1
-	musicheader 1, 2, Music_Credits_Ch2
-	musicheader 1, 3, Music_Credits_Ch3
-	musicheader 1, 4, Music_Credits_Ch4
+	channel_count 4
+	channel 1, Music_Credits_Ch1
+	channel 2, Music_Credits_Ch2
+	channel 3, Music_Credits_Ch3
+	channel 4, Music_Credits_Ch4
 
 Music_Credits_Ch1:
 	tempo 139

--- a/audio/music/crystalopening.asm
+++ b/audio/music/crystalopening.asm
@@ -1,8 +1,9 @@
 Music_CrystalOpening:
-	musicheader 4, 1, Music_CrystalOpening_Ch1
-	musicheader 1, 2, Music_CrystalOpening_Ch2
-	musicheader 1, 3, Music_CrystalOpening_Ch3
-	musicheader 1, 4, Music_CrystalOpening_Ch4
+	channel_count 4
+	channel 1, Music_CrystalOpening_Ch1
+	channel 2, Music_CrystalOpening_Ch2
+	channel 3, Music_CrystalOpening_Ch3
+	channel 4, Music_CrystalOpening_Ch4
 
 Music_CrystalOpening_Ch1:
 	tempo 136

--- a/audio/music/dancinghall.asm
+++ b/audio/music/dancinghall.asm
@@ -1,7 +1,8 @@
 Music_DancingHall:
-	musicheader 3, 1, Music_DancingHall_Ch1
-	musicheader 1, 2, Music_DancingHall_Ch2
-	musicheader 1, 3, Music_DancingHall_Ch3
+	channel_count 3
+	channel 1, Music_DancingHall_Ch1
+	channel 2, Music_DancingHall_Ch2
+	channel 3, Music_DancingHall_Ch3
 
 Music_DancingHall_Ch1:
 	tempo 208

--- a/audio/music/darkcave.asm
+++ b/audio/music/darkcave.asm
@@ -1,8 +1,9 @@
 Music_DarkCave:
-	musicheader 4, 1, Music_DarkCave_Ch1
-	musicheader 1, 2, Music_DarkCave_Ch2
-	musicheader 1, 3, Music_DarkCave_Ch3
-	musicheader 1, 4, Music_DarkCave_Ch4
+	channel_count 4
+	channel 1, Music_DarkCave_Ch1
+	channel 2, Music_DarkCave_Ch2
+	channel 3, Music_DarkCave_Ch3
+	channel 4, Music_DarkCave_Ch4
 
 Music_DarkCave_Ch1:
 	tempo 128

--- a/audio/music/dppt/championbattle.asm
+++ b/audio/music/dppt/championbattle.asm
@@ -3,10 +3,11 @@
 ; https://github.com/froggestspirit/pokecrystal/blob/master/audio/music/145_ChampionBattle.asm
 
 Music_ChampionBattleDPPt:
-	musicheader 4, 1, Music_ChampionBattleDPPt_Ch1
-	musicheader 1, 2, Music_ChampionBattleDPPt_Ch2
-	musicheader 1, 3, Music_ChampionBattleDPPt_Ch3
-	musicheader 1, 4, Music_ChampionBattleDPPt_Ch4
+	channel_count 4
+	channel 1, Music_ChampionBattleDPPt_Ch1
+	channel 2, Music_ChampionBattleDPPt_Ch2
+	channel 3, Music_ChampionBattleDPPt_Ch3
+	channel 4, Music_ChampionBattleDPPt_Ch4
 
 Music_ChampionBattleDPPt_Ch1:
 	volume $77

--- a/audio/music/dppt/gymleaderbattle.asm
+++ b/audio/music/dppt/gymleaderbattle.asm
@@ -3,10 +3,11 @@
 ; https://soundcloud.com/froggestspirit/battle-gym-leader
 
 Music_GymLeaderBattleDPPt:
-	musicheader 4, 1, Music_GymLeaderBattleDPPt_Ch1
-	musicheader 1, 2, Music_GymLeaderBattleDPPt_Ch2
-	musicheader 1, 3, Music_GymLeaderBattleDPPt_Ch3
-	musicheader 1, 4, Music_GymLeaderBattleDPPt_Ch4
+	channel_count 4
+	channel 1, Music_GymLeaderBattleDPPt_Ch1
+	channel 2, Music_GymLeaderBattleDPPt_Ch2
+	channel 3, Music_GymLeaderBattleDPPt_Ch3
+	channel 4, Music_GymLeaderBattleDPPt_Ch4
 
 Music_GymLeaderBattleDPPt_Ch1:
 	tempo $6A

--- a/audio/music/dppt/route225.asm
+++ b/audio/music/dppt/route225.asm
@@ -3,10 +3,11 @@
 ; https://github.com/froggestspirit/pokecrystal/blob/master/audio/music/077_Route225.asm
 
 Music_Route225DPPt:
-	musicheader 4, 1, Music_Route225DPPt_Ch1
-	musicheader 1, 2, Music_Route225DPPt_Ch2
-	musicheader 1, 3, Music_Route225DPPt_Ch3
-	musicheader 1, 4, Music_Route225DPPt_Ch4
+	channel_count 4
+	channel 1, Music_Route225DPPt_Ch1
+	channel 2, Music_Route225DPPt_Ch2
+	channel 3, Music_Route225DPPt_Ch3
+	channel 4, Music_Route225DPPt_Ch4
 
 Music_Route225DPPt_Ch1:
 	volume $77

--- a/audio/music/dppt/starkmountain.asm
+++ b/audio/music/dppt/starkmountain.asm
@@ -3,10 +3,11 @@
 ; https://github.com/froggestspirit/pokecrystal/blob/master/Demixes.zip
 
 Music_StarkMountainDPPt:
-	musicheader 4, 1, Music_StarkMountainDPPt_Ch1
-	musicheader 1, 2, Music_StarkMountainDPPt_Ch2
-	musicheader 1, 3, Music_StarkMountainDPPt_Ch3
-	musicheader 1, 4, Music_StarkMountainDPPt_Ch4
+	channel_count 4
+	channel 1, Music_StarkMountainDPPt_Ch1
+	channel 2, Music_StarkMountainDPPt_Ch2
+	channel 3, Music_StarkMountainDPPt_Ch3
+	channel 4, Music_StarkMountainDPPt_Ch4
 
 Music_StarkMountainDPPt_Ch1:
 	volume $77

--- a/audio/music/dppt/sunyshorecity.asm
+++ b/audio/music/dppt/sunyshorecity.asm
@@ -3,10 +3,11 @@
 ; https://github.com/froggestspirit/pokecrystal/blob/master/Demixes.zip
 
 Music_SunyshoreCityDPPt:
-	musicheader 4, 1, Music_SunyshoreCityDPPt_Ch1
-	musicheader 1, 2, Music_SunyshoreCityDPPt_Ch2
-	musicheader 1, 3, Music_SunyshoreCityDPPt_Ch3
-	musicheader 1, 4, Music_SunyshoreCityDPPt_Ch4
+	channel_count 4
+	channel 1, Music_SunyshoreCityDPPt_Ch1
+	channel 2, Music_SunyshoreCityDPPt_Ch2
+	channel 3, Music_SunyshoreCityDPPt_Ch3
+	channel 4, Music_SunyshoreCityDPPt_Ch4
 
 Music_SunyshoreCityDPPt_Ch1:
 	volume $77

--- a/audio/music/dppt/trainerbattle.asm
+++ b/audio/music/dppt/trainerbattle.asm
@@ -3,10 +3,11 @@
 ; https://github.com/froggestspirit/CrystalComplete/blob/master/audio/music/DPPt/sinnohtrainer.asm
 
 Music_TrainerBattleDPPt:
-	musicheader 4, 1, Music_TrainerBattleDPPt_Ch1
-	musicheader 1, 2, Music_TrainerBattleDPPt_Ch2
-	musicheader 1, 3, Music_TrainerBattleDPPt_Ch3
-	musicheader 1, 4, Music_TrainerBattleDPPt_Ch4
+	channel_count 4
+	channel 1, Music_TrainerBattleDPPt_Ch1
+	channel 2, Music_TrainerBattleDPPt_Ch2
+	channel 3, Music_TrainerBattleDPPt_Ch3
+	channel 4, Music_TrainerBattleDPPt_Ch4
 
 Music_TrainerBattleDPPt_Ch1:
 	volume $77

--- a/audio/music/dragonsden.asm
+++ b/audio/music/dragonsden.asm
@@ -1,8 +1,9 @@
 Music_DragonsDen:
-	musicheader 4, 1, Music_DragonsDen_Ch1
-	musicheader 1, 2, Music_DragonsDen_Ch2
-	musicheader 1, 3, Music_DragonsDen_Ch3
-	musicheader 1, 4, Music_DragonsDen_Ch4
+	channel_count 4
+	channel 1, Music_DragonsDen_Ch1
+	channel 2, Music_DragonsDen_Ch2
+	channel 3, Music_DragonsDen_Ch3
+	channel 4, Music_DragonsDen_Ch4
 
 Music_DragonsDen_Ch1:
 	tempo 144

--- a/audio/music/ecruteakcity.asm
+++ b/audio/music/ecruteakcity.asm
@@ -1,7 +1,8 @@
 Music_EcruteakCity:
-	musicheader 3, 1, Music_EcruteakCity_Ch1
-	musicheader 1, 2, Music_EcruteakCity_Ch2
-	musicheader 1, 3, Music_EcruteakCity_Ch3
+	channel_count 3
+	channel 1, Music_EcruteakCity_Ch1
+	channel 2, Music_EcruteakCity_Ch2
+	channel 3, Music_EcruteakCity_Ch3
 
 Music_EcruteakCity_Ch1:
 	tempo 197

--- a/audio/music/elmslab.asm
+++ b/audio/music/elmslab.asm
@@ -1,8 +1,9 @@
 Music_ElmsLab:
-	musicheader 4, 1, Music_ElmsLab_Ch1
-	musicheader 1, 2, Music_ElmsLab_Ch2
-	musicheader 1, 3, Music_ElmsLab_Ch3
-	musicheader 1, 4, Music_ElmsLab_Ch4
+	channel_count 4
+	channel 1, Music_ElmsLab_Ch1
+	channel 2, Music_ElmsLab_Ch2
+	channel 3, Music_ElmsLab_Ch3
+	channel 4, Music_ElmsLab_Ch4
 
 Music_ElmsLab_Ch1:
 	tempo 144

--- a/audio/music/evolution.asm
+++ b/audio/music/evolution.asm
@@ -1,8 +1,9 @@
 Music_Evolution:
-	musicheader 4, 1, Music_Evolution_Ch1
-	musicheader 1, 2, Music_Evolution_Ch2
-	musicheader 1, 3, Music_Evolution_Ch3
-	musicheader 1, 4, Music_Evolution_Ch4
+	channel_count 4
+	channel 1, Music_Evolution_Ch1
+	channel 2, Music_Evolution_Ch2
+	channel 3, Music_Evolution_Ch3
+	channel 4, Music_Evolution_Ch4
 
 Music_Evolution_Ch1:
 	tempo 132

--- a/audio/music/gamecorner.asm
+++ b/audio/music/gamecorner.asm
@@ -1,8 +1,9 @@
 Music_GameCorner:
-	musicheader 4, 1, Music_GameCorner_Ch1
-	musicheader 1, 2, Music_GameCorner_Ch2
-	musicheader 1, 3, Music_GameCorner_Ch3
-	musicheader 1, 4, Music_GameCorner_Ch4
+	channel_count 4
+	channel 1, Music_GameCorner_Ch1
+	channel 2, Music_GameCorner_Ch2
+	channel 3, Music_GameCorner_Ch3
+	channel 4, Music_GameCorner_Ch4
 
 Music_GameCorner_Ch1:
 	tempo 147

--- a/audio/music/go/gymbattle.asm
+++ b/audio/music/go/gymbattle.asm
@@ -3,9 +3,10 @@
 ; https://soundcloud.com/user-927422935-571023782/pokemon-go-gym-battle-8-bit/s-nRFXX
 
 Music_GymLeaderBattleGo:
-	musicheader 3, 1, Music_GymLeaderBattleGo_Ch1
-	musicheader 1, 2, Music_GymLeaderBattleGo_Ch2
-	musicheader 1, 3, Music_GymLeaderBattleGo_Ch3
+	channel_count 3
+	channel 1, Music_GymLeaderBattleGo_Ch1
+	channel 2, Music_GymLeaderBattleGo_Ch2
+	channel 3, Music_GymLeaderBattleGo_Ch3
 
 Music_GymLeaderBattleGo_Ch1:
 	tempo $B4

--- a/audio/music/go/wildbattle.asm
+++ b/audio/music/go/wildbattle.asm
@@ -3,10 +3,11 @@
 ; https://soundcloud.com/user-927422935-571023782/pokemon-go-wild-battle-8-bit-1/s-4NapJ
 
 Music_WildBattleGo:
-	musicheader 4, 1, Music_WildBattleGo_Ch1
-	musicheader 1, 2, Music_WildBattleGo_Ch2
-	musicheader 1, 3, Music_WildBattleGo_Ch3
-	musicheader 1, 4, Music_WildBattleGo_Ch4
+	channel_count 4
+	channel 1, Music_WildBattleGo_Ch1
+	channel 2, Music_WildBattleGo_Ch2
+	channel 3, Music_WildBattleGo_Ch3
+	channel 4, Music_WildBattleGo_Ch4
 
 Music_WildBattleGo_Ch1:
 	tempo $70

--- a/audio/music/goldenrodcity.asm
+++ b/audio/music/goldenrodcity.asm
@@ -1,8 +1,9 @@
 Music_GoldenrodCity:
-	musicheader 4, 1, Music_GoldenrodCity_Ch1
-	musicheader 1, 2, Music_GoldenrodCity_Ch2
-	musicheader 1, 3, Music_GoldenrodCity_Ch3
-	musicheader 1, 4, Music_GoldenrodCity_Ch4
+	channel_count 4
+	channel 1, Music_GoldenrodCity_Ch1
+	channel 2, Music_GoldenrodCity_Ch2
+	channel 3, Music_GoldenrodCity_Ch3
+	channel 4, Music_GoldenrodCity_Ch4
 
 Music_GoldenrodCity_Ch1:
 	stereopanning $f

--- a/audio/music/gym.asm
+++ b/audio/music/gym.asm
@@ -1,8 +1,9 @@
 Music_Gym:
-	musicheader 4, 1, Music_Gym_Ch1
-	musicheader 1, 2, Music_Gym_Ch2
-	musicheader 1, 3, Music_Gym_Ch3
-	musicheader 1, 4, Music_Gym_Ch4
+	channel_count 4
+	channel 1, Music_Gym_Ch1
+	channel 2, Music_Gym_Ch2
+	channel 3, Music_Gym_Ch3
+	channel 4, Music_Gym_Ch4
 
 Music_Gym_Ch1:
 	tempo 156

--- a/audio/music/gymleadervictory.asm
+++ b/audio/music/gymleadervictory.asm
@@ -1,8 +1,9 @@
 Music_GymLeaderVictory:
-	musicheader 4, 1, Music_GymLeaderVictory_Ch1
-	musicheader 1, 2, Music_GymLeaderVictory_Ch2
-	musicheader 1, 3, Music_GymLeaderVictory_Ch3
-	musicheader 1, 4, Music_GymLeaderVictory_Ch4
+	channel_count 4
+	channel 1, Music_GymLeaderVictory_Ch1
+	channel 2, Music_GymLeaderVictory_Ch2
+	channel 3, Music_GymLeaderVictory_Ch3
+	channel 4, Music_GymLeaderVictory_Ch4
 
 Music_GymLeaderVictory_Ch1:
 	tempo 116

--- a/audio/music/halloffame.asm
+++ b/audio/music/halloffame.asm
@@ -1,8 +1,9 @@
 Music_HallOfFame:
-	musicheader 4, 1, Music_HallOfFame_Ch1
-	musicheader 1, 2, Music_HallOfFame_Ch2
-	musicheader 1, 3, Music_HallOfFame_Ch3
-	musicheader 1, 4, Music_HallOfFame_Ch4
+	channel_count 4
+	channel 1, Music_HallOfFame_Ch1
+	channel 2, Music_HallOfFame_Ch2
+	channel 3, Music_HallOfFame_Ch3
+	channel 4, Music_HallOfFame_Ch4
 
 Music_HallOfFame_Ch1:
 	tempo 112

--- a/audio/music/healpokemon.asm
+++ b/audio/music/healpokemon.asm
@@ -1,7 +1,8 @@
 Music_HealPokemon:
-	musicheader 3, 1, Music_HealPokemon_Ch1
-	musicheader 1, 2, Music_HealPokemon_Ch2
-	musicheader 1, 3, Music_HealPokemon_Ch3
+	channel_count 3
+	channel 1, Music_HealPokemon_Ch1
+	channel 2, Music_HealPokemon_Ch2
+	channel 3, Music_HealPokemon_Ch3
 
 Music_HealPokemon_Ch1:
 	tempo 144

--- a/audio/music/hgss/cianwoodcity.asm
+++ b/audio/music/hgss/cianwoodcity.asm
@@ -3,9 +3,10 @@
 ; https://pastebin.com/GguFiV8e
 
 Music_CianwoodCityHGSS:
-	musicheader 3, 1, Music_CianwoodCityHGSS_Ch1
-	musicheader 1, 2, Music_CianwoodCityHGSS_Ch2
-	musicheader 1, 3, Music_CianwoodCityHGSS_Ch3
+	channel_count 3
+	channel 1, Music_CianwoodCityHGSS_Ch1
+	channel 2, Music_CianwoodCityHGSS_Ch2
+	channel 3, Music_CianwoodCityHGSS_Ch3
 
 Music_CianwoodCityHGSS_Ch1:
 	tempo 197

--- a/audio/music/hgss/lyradeparture.asm
+++ b/audio/music/hgss/lyradeparture.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/3/
 
 Music_LyraDepartureHGSS:
-	musicheader 4, 1, Music_LyraDepartureHGSS_Ch1
-	musicheader 1, 2, Music_LyraDepartureHGSS_Ch2
-	musicheader 1, 3, Music_LyraDepartureHGSS_Ch3
-	musicheader 1, 4, Music_LyraDepartureHGSS_Ch4
+	channel_count 4
+	channel 1, Music_LyraDepartureHGSS_Ch1
+	channel 2, Music_LyraDepartureHGSS_Ch2
+	channel 3, Music_LyraDepartureHGSS_Ch3
+	channel 4, Music_LyraDepartureHGSS_Ch4
 
 Music_LyraDepartureHGSS_Ch1:
 	tempo 184

--- a/audio/music/hgss/lyraencounter.asm
+++ b/audio/music/hgss/lyraencounter.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/3/
 
 Music_LyraEncounterHGSS:
-	musicheader 4, 1, Music_LyraEncounterHGSS_Ch1
-	musicheader 1, 2, Music_LyraEncounterHGSS_Ch2
-	musicheader 1, 3, Music_LyraEncounterHGSS_Ch3
-	musicheader 1, 4, Music_LyraEncounterHGSS_Ch4
+	channel_count 4
+	channel 1, Music_LyraEncounterHGSS_Ch1
+	channel 2, Music_LyraEncounterHGSS_Ch2
+	channel 3, Music_LyraEncounterHGSS_Ch3
+	channel 4, Music_LyraEncounterHGSS_Ch4
 
 Music_LyraEncounterHGSS_Ch1:
 	tempo 184

--- a/audio/music/hgss/route47.asm
+++ b/audio/music/hgss/route47.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/4/
 
 Music_Route47HGSS:
-	musicheader 4, 1, Music_Route47HGSS_Ch1
-	musicheader 1, 2, Music_Route47HGSS_Ch2
-	musicheader 1, 3, Music_Route47HGSS_Ch3
-	musicheader 1, 4, Music_Route47HGSS_Ch4
+	channel_count 4
+	channel 1, Music_Route47HGSS_Ch1
+	channel 2, Music_Route47HGSS_Ch2
+	channel 3, Music_Route47HGSS_Ch3
+	channel 4, Music_Route47HGSS_Ch4
 
 Music_Route47HGSS_Ch1:
 	tempo 192

--- a/audio/music/hgss/safarizonegate.asm
+++ b/audio/music/hgss/safarizonegate.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/4/
 
 Music_SafariZoneGateHGSS:
-	musicheader 4, 1, Music_SafariZoneGateHGSS_Ch1
-	musicheader 1, 2, Music_SafariZoneGateHGSS_Ch2
-	musicheader 1, 3, Music_SafariZoneGateHGSS_Ch3
-	musicheader 1, 4, Music_SafariZoneGateHGSS_Ch4
+	channel_count 4
+	channel 1, Music_SafariZoneGateHGSS_Ch1
+	channel 2, Music_SafariZoneGateHGSS_Ch2
+	channel 3, Music_SafariZoneGateHGSS_Ch3
+	channel 4, Music_SafariZoneGateHGSS_Ch4
 
 Music_SafariZoneGateHGSS_Ch1:
 	tempo 164

--- a/audio/music/hgss/summoningdance.asm
+++ b/audio/music/hgss/summoningdance.asm
@@ -4,9 +4,10 @@
 ; https://hax.iimarckus.org/topic/6777/3/
 
 Music_SummoningDanceHGSS:
-	musicheader 3, 1, Music_SummoningDanceHGSS_Ch1
-	musicheader 1, 2, Music_SummoningDanceHGSS_Ch2
-	musicheader 1, 3, Music_SummoningDanceHGSS_Ch3
+	channel_count 3
+	channel 1, Music_SummoningDanceHGSS_Ch1
+	channel 2, Music_SummoningDanceHGSS_Ch2
+	channel 3, Music_SummoningDanceHGSS_Ch3
 
 Music_SummoningDanceHGSS_Ch1:
 	tempo 220

--- a/audio/music/indigoplateau.asm
+++ b/audio/music/indigoplateau.asm
@@ -1,8 +1,9 @@
 Music_IndigoPlateau:
-	musicheader 4, 1, Music_IndigoPlateau_Ch1
-	musicheader 1, 2, Music_IndigoPlateau_Ch2
-	musicheader 1, 3, Music_IndigoPlateau_Ch3
-	musicheader 1, 4, Music_IndigoPlateau_Ch4
+	channel_count 4
+	channel 1, Music_IndigoPlateau_Ch1
+	channel 2, Music_IndigoPlateau_Ch2
+	channel 3, Music_IndigoPlateau_Ch3
+	channel 4, Music_IndigoPlateau_Ch4
 
 Music_IndigoPlateau_Ch1:
 	tempo 128

--- a/audio/music/johtogymbattle.asm
+++ b/audio/music/johtogymbattle.asm
@@ -1,7 +1,8 @@
 Music_JohtoGymBattle:
-	musicheader 3, 1, Music_JohtoGymBattle_Ch1
-	musicheader 1, 2, Music_JohtoGymBattle_Ch2
-	musicheader 1, 3, Music_JohtoGymBattle_Ch3
+	channel_count 3
+	channel 1, Music_JohtoGymBattle_Ch1
+	channel 2, Music_JohtoGymBattle_Ch2
+	channel 3, Music_JohtoGymBattle_Ch3
 
 Music_JohtoGymBattle_Ch1:
 	tempo 101

--- a/audio/music/johtotrainerbattle.asm
+++ b/audio/music/johtotrainerbattle.asm
@@ -1,7 +1,8 @@
 Music_JohtoTrainerBattle:
-	musicheader 3, 1, Music_JohtoTrainerBattle_Ch1
-	musicheader 1, 2, Music_JohtoTrainerBattle_Ch2
-	musicheader 1, 3, Music_JohtoTrainerBattle_Ch3
+	channel_count 3
+	channel 1, Music_JohtoTrainerBattle_Ch1
+	channel 2, Music_JohtoTrainerBattle_Ch2
+	channel 3, Music_JohtoTrainerBattle_Ch3
 
 Music_JohtoTrainerBattle_Ch1:
 	tempo 102

--- a/audio/music/johtowildbattle.asm
+++ b/audio/music/johtowildbattle.asm
@@ -1,7 +1,8 @@
 Music_JohtoWildBattle:
-	musicheader 3, 1, Music_JohtoWildBattle_Ch1
-	musicheader 1, 2, Music_JohtoWildBattle_Ch2
-	musicheader 1, 3, Music_JohtoWildBattle_Ch3
+	channel_count 3
+	channel 1, Music_JohtoWildBattle_Ch1
+	channel 2, Music_JohtoWildBattle_Ch2
+	channel 3, Music_JohtoWildBattle_Ch3
 
 Music_JohtoWildBattle_Ch1:
 	tempo 104

--- a/audio/music/johtowildbattlenight.asm
+++ b/audio/music/johtowildbattlenight.asm
@@ -1,7 +1,8 @@
 Music_JohtoWildBattleNight:
-	musicheader 3, 1, Music_JohtoWildBattleNight_Ch1
-	musicheader 1, 2, Music_JohtoWildBattleNight_Ch2
-	musicheader 1, 3, Music_JohtoWildBattleNight_Ch3
+	channel_count 3
+	channel 1, Music_JohtoWildBattleNight_Ch1
+	channel 2, Music_JohtoWildBattleNight_Ch2
+	channel 3, Music_JohtoWildBattleNight_Ch3
 
 Music_JohtoWildBattleNight_Ch1:
 	tempo 107

--- a/audio/music/kantogymbattle.asm
+++ b/audio/music/kantogymbattle.asm
@@ -1,7 +1,8 @@
 Music_KantoGymBattle:
-	musicheader 3, 1, Music_KantoGymBattle_Ch1
-	musicheader 1, 2, Music_KantoGymBattle_Ch2
-	musicheader 1, 3, Music_KantoGymBattle_Ch3
+	channel_count 3
+	channel 1, Music_KantoGymBattle_Ch1
+	channel 2, Music_KantoGymBattle_Ch2
+	channel 3, Music_KantoGymBattle_Ch3
 
 Music_KantoGymBattle_Ch1:
 	tempo 101

--- a/audio/music/kantotrainerbattle.asm
+++ b/audio/music/kantotrainerbattle.asm
@@ -1,7 +1,8 @@
 Music_KantoTrainerBattle:
-	musicheader 3, 1, Music_KantoTrainerBattle_Ch1
-	musicheader 1, 2, Music_KantoTrainerBattle_Ch2
-	musicheader 1, 3, Music_KantoTrainerBattle_Ch3
+	channel_count 3
+	channel 1, Music_KantoTrainerBattle_Ch1
+	channel 2, Music_KantoTrainerBattle_Ch2
+	channel 3, Music_KantoTrainerBattle_Ch3
 
 Music_KantoTrainerBattle_Ch1:
 	tempo 114

--- a/audio/music/kantowildbattle.asm
+++ b/audio/music/kantowildbattle.asm
@@ -1,9 +1,10 @@
 ; Optimized by TriteHexagon
 
 Music_KantoWildBattle:
-	musicheader 3, 1, Music_KantoWildBattle_Ch1
-	musicheader 1, 2, Music_KantoWildBattle_Ch2
-	musicheader 1, 3, Music_KantoWildBattle_Ch3
+	channel_count 3
+	channel 1, Music_KantoWildBattle_Ch1
+	channel 2, Music_KantoWildBattle_Ch2
+	channel 3, Music_KantoWildBattle_Ch3
 
 Music_KantoWildBattle_Ch1:
 	tempo 112

--- a/audio/music/kantowildbattlenight.asm
+++ b/audio/music/kantowildbattlenight.asm
@@ -4,9 +4,10 @@
 ; https://hax.iimarckus.org/topic/7697/
 
 Music_KantoWildBattleNight:
-	musicheader 3, 1, Music_KantoWildBattleNight_Ch1
-	musicheader 1, 2, Music_KantoWildBattleNight_Ch2
-	musicheader 1, 3, Music_KantoWildBattleNight_Ch3
+	channel_count 3
+	channel 1, Music_KantoWildBattleNight_Ch1
+	channel 2, Music_KantoWildBattleNight_Ch2
+	channel 3, Music_KantoWildBattleNight_Ch3
 
 Music_KantoWildBattleNight_Ch1:
 	tempo 117

--- a/audio/music/lakeofrage.asm
+++ b/audio/music/lakeofrage.asm
@@ -1,8 +1,9 @@
 Music_LakeOfRage:
-	musicheader 4, 1, Music_LakeOfRage_Ch1
-	musicheader 1, 2, Music_LakeOfRage_Ch2
-	musicheader 1, 3, Music_LakeOfRage_Ch3
-	musicheader 1, 4, Music_LakeOfRage_Ch4
+	channel_count 4
+	channel 1, Music_LakeOfRage_Ch1
+	channel 2, Music_LakeOfRage_Ch2
+	channel 3, Music_LakeOfRage_Ch3
+	channel 4, Music_LakeOfRage_Ch4
 
 Music_LakeOfRage_Ch1:
 	tempo 144

--- a/audio/music/lakeofragerocketradio.asm
+++ b/audio/music/lakeofragerocketradio.asm
@@ -1,7 +1,8 @@
 Music_LakeOfRageRocketRadio:
-	musicheader 3, 1, Music_LakeOfRageRocketRadio_Ch1
-	musicheader 1, 2, Music_LakeOfRageRocketRadio_Ch2
-	musicheader 1, 3, Music_LakeOfRageRocketRadio_Ch3
+	channel_count 3
+	channel 1, Music_LakeOfRageRocketRadio_Ch1
+	channel 2, Music_LakeOfRageRocketRadio_Ch2
+	channel 3, Music_LakeOfRageRocketRadio_Ch3
 
 Music_LakeOfRageRocketRadio_Ch1:
 	tempo 160

--- a/audio/music/lavendertown.asm
+++ b/audio/music/lavendertown.asm
@@ -1,7 +1,8 @@
 Music_LavenderTown:
-	musicheader 3, 1, Music_LavenderTown_Ch1
-	musicheader 1, 2, Music_LavenderTown_Ch2
-	musicheader 1, 3, Music_LavenderTown_Ch3
+	channel_count 3
+	channel 1, Music_LavenderTown_Ch1
+	channel 2, Music_LavenderTown_Ch2
+	channel 3, Music_LavenderTown_Ch3
 
 Music_LavenderTown_Ch1:
 	tempo 160

--- a/audio/music/lighthouse.asm
+++ b/audio/music/lighthouse.asm
@@ -1,8 +1,9 @@
 Music_Lighthouse:
-	musicheader 4, 1, Music_Lighthouse_Ch1
-	musicheader 1, 2, Music_Lighthouse_Ch2
-	musicheader 1, 3, Music_Lighthouse_Ch3
-	musicheader 1, 4, Music_Lighthouse_Ch4
+	channel_count 4
+	channel 1, Music_Lighthouse_Ch1
+	channel 2, Music_Lighthouse_Ch2
+	channel 3, Music_Lighthouse_Ch3
+	channel 4, Music_Lighthouse_Ch4
 
 Music_Lighthouse_Ch1:
 	tempo 144

--- a/audio/music/lookbeauty.asm
+++ b/audio/music/lookbeauty.asm
@@ -1,8 +1,9 @@
 Music_LookBeauty:
-	musicheader 4, 1, Music_LookBeauty_Ch1
-	musicheader 1, 2, Music_LookBeauty_Ch2
-	musicheader 1, 3, Music_LookBeauty_Ch3
-	musicheader 1, 4, Music_LookBeauty_Ch4
+	channel_count 4
+	channel 1, Music_LookBeauty_Ch1
+	channel 2, Music_LookBeauty_Ch2
+	channel 3, Music_LookBeauty_Ch3
+	channel 4, Music_LookBeauty_Ch4
 
 Music_LookBeauty_Ch1:
 	stereopanning $f

--- a/audio/music/lookhiker.asm
+++ b/audio/music/lookhiker.asm
@@ -1,8 +1,9 @@
 Music_LookHiker:
-	musicheader 4, 1, Music_LookHiker_Ch1
-	musicheader 1, 2, Music_LookHiker_Ch2
-	musicheader 1, 3, Music_LookHiker_Ch3
-	musicheader 1, 4, Music_LookHiker_Ch4
+	channel_count 4
+	channel 1, Music_LookHiker_Ch1
+	channel 2, Music_LookHiker_Ch2
+	channel 3, Music_LookHiker_Ch3
+	channel 4, Music_LookHiker_Ch4
 
 Music_LookHiker_Ch1:
 	tempo 132

--- a/audio/music/lookkimonogirl.asm
+++ b/audio/music/lookkimonogirl.asm
@@ -1,7 +1,8 @@
 Music_LookKimonoGirl:
-	musicheader 3, 1, Music_LookKimonoGirl_Ch1
-	musicheader 1, 2, Music_LookKimonoGirl_Ch2
-	musicheader 1, 3, Music_LookKimonoGirl_Ch3
+	channel_count 3
+	channel 1, Music_LookKimonoGirl_Ch1
+	channel 2, Music_LookKimonoGirl_Ch2
+	channel 3, Music_LookKimonoGirl_Ch3
 
 Music_LookKimonoGirl_Ch1:
 	tempo 160

--- a/audio/music/looklass.asm
+++ b/audio/music/looklass.asm
@@ -1,8 +1,9 @@
 Music_LookLass:
-	musicheader 4, 1, Music_LookLass_Ch1
-	musicheader 1, 2, Music_LookLass_Ch2
-	musicheader 1, 3, Music_LookLass_Ch3
-	musicheader 1, 4, Music_LookLass_Ch4
+	channel_count 4
+	channel 1, Music_LookLass_Ch1
+	channel 2, Music_LookLass_Ch2
+	channel 3, Music_LookLass_Ch3
+	channel 4, Music_LookLass_Ch4
 
 Music_LookLass_Ch1:
 	tempo 132

--- a/audio/music/lookmysticalman.asm
+++ b/audio/music/lookmysticalman.asm
@@ -1,8 +1,9 @@
 Music_LookMysticalMan:
-	musicheader 4, 1, Music_LookMysticalMan_Ch1
-	musicheader 1, 2, Music_LookMysticalMan_Ch2
-	musicheader 1, 3, Music_LookMysticalMan_Ch3
-	musicheader 1, 4, Music_LookMysticalMan_Ch4
+	channel_count 4
+	channel 1, Music_LookMysticalMan_Ch1
+	channel 2, Music_LookMysticalMan_Ch2
+	channel 3, Music_LookMysticalMan_Ch3
+	channel 4, Music_LookMysticalMan_Ch4
 
 Music_LookMysticalMan_Ch1:
 	tempo 136

--- a/audio/music/lookofficer.asm
+++ b/audio/music/lookofficer.asm
@@ -1,7 +1,8 @@
 Music_LookOfficer:
-	musicheader 3, 1, Music_LookOfficer_Ch1
-	musicheader 1, 2, Music_LookOfficer_Ch2
-	musicheader 1, 3, Music_LookOfficer_Ch3
+	channel_count 3
+	channel 1, Music_LookOfficer_Ch1
+	channel 2, Music_LookOfficer_Ch2
+	channel 3, Music_LookOfficer_Ch3
 
 Music_LookOfficer_Ch1:
 	tempo 116

--- a/audio/music/lookpokemaniac.asm
+++ b/audio/music/lookpokemaniac.asm
@@ -1,7 +1,8 @@
 Music_LookPokemaniac:
-	musicheader 3, 1, Music_LookPokemaniac_Ch1
-	musicheader 1, 2, Music_LookPokemaniac_Ch2
-	musicheader 1, 3, Music_LookPokemaniac_Ch3
+	channel_count 3
+	channel 1, Music_LookPokemaniac_Ch1
+	channel 2, Music_LookPokemaniac_Ch2
+	channel 3, Music_LookPokemaniac_Ch3
 
 Music_LookPokemaniac_Ch1:
 	stereopanning $f

--- a/audio/music/lookrival.asm
+++ b/audio/music/lookrival.asm
@@ -1,8 +1,9 @@
 Music_LookRival:
-	musicheader 4, 1, Music_LookRival_Ch1
-	musicheader 1, 2, Music_LookRival_Ch2
-	musicheader 1, 3, Music_LookRival_Ch3
-	musicheader 1, 4, Music_LookRival_Ch4
+	channel_count 4
+	channel 1, Music_LookRival_Ch1
+	channel 2, Music_LookRival_Ch2
+	channel 3, Music_LookRival_Ch3
+	channel 4, Music_LookRival_Ch4
 
 Music_LookRival_Ch1:
 	tempo 112

--- a/audio/music/lookrocket.asm
+++ b/audio/music/lookrocket.asm
@@ -1,8 +1,9 @@
 Music_LookRocket:
-	musicheader 4, 1, Music_LookRocket_Ch1
-	musicheader 1, 2, Music_LookRocket_Ch2
-	musicheader 1, 3, Music_LookRocket_Ch3
-	musicheader 1, 4, Music_LookRocket_Ch4
+	channel_count 4
+	channel 1, Music_LookRocket_Ch1
+	channel 2, Music_LookRocket_Ch2
+	channel 3, Music_LookRocket_Ch3
+	channel 4, Music_LookRocket_Ch4
 
 Music_LookRocket_Ch1:
 	tempo 123

--- a/audio/music/looksage.asm
+++ b/audio/music/looksage.asm
@@ -1,6 +1,7 @@
 Music_LookSage:
-	musicheader 2, 1, Music_LookSage_Ch1
-	musicheader 1, 3, Music_LookSage_Ch3
+	channel_count 2
+	channel 1, Music_LookSage_Ch1
+	channel 3, Music_LookSage_Ch3
 
 Music_LookSage_Ch1:
 	tempo 144

--- a/audio/music/lookyoungster.asm
+++ b/audio/music/lookyoungster.asm
@@ -1,7 +1,8 @@
 Music_LookYoungster:
-	musicheader 3, 1, Music_LookYoungster_Ch1
-	musicheader 1, 2, Music_LookYoungster_Ch2
-	musicheader 1, 3, Music_LookYoungster_Ch3
+	channel_count 3
+	channel 1, Music_LookYoungster_Ch1
+	channel 2, Music_LookYoungster_Ch2
+	channel 3, Music_LookYoungster_Ch3
 
 Music_LookYoungster_Ch1:
 	tempo 118

--- a/audio/music/m02/lugiassong.asm
+++ b/audio/music/m02/lugiassong.asm
@@ -3,15 +3,17 @@
 ; https://pastebin.com/UikDn8qP
 
 Music_LugiasSong2000:
-	musicheader 4, 1, Music_LugiasSong2000_Ch1
-	musicheader 1, 2, Music_LugiasSong2000_Ch2
-	musicheader 1, 3, Music_LugiasSong2000_Ch3
-	musicheader 1, 4, Music_LugiasSong2000_Ch4
+	channel_count 4
+	channel 1, Music_LugiasSong2000_Ch1
+	channel 2, Music_LugiasSong2000_Ch2
+	channel 3, Music_LugiasSong2000_Ch3
+	channel 4, Music_LugiasSong2000_Ch4
 
 Music_LugiasSong2000_NoIntro:
-	musicheader 3, 1, Music_LugiasSong2000_Ch1_loop_main
-	musicheader 1, 2, Music_LugiasSong2000_Ch2_loop_main
-	musicheader 1, 3, Music_LugiasSong2000_Ch3_loop
+	channel_count 3
+	channel 1, Music_LugiasSong2000_Ch1_loop_main
+	channel 2, Music_LugiasSong2000_Ch2_loop_main
+	channel 3, Music_LugiasSong2000_Ch3_loop
 
 Music_LugiasSong2000_Ch1:
 	dutycycle $3

--- a/audio/music/magnettrain.asm
+++ b/audio/music/magnettrain.asm
@@ -1,8 +1,9 @@
 Music_MagnetTrain:
-	musicheader 4, 1, Music_MagnetTrain_Ch1
-	musicheader 1, 2, Music_MagnetTrain_Ch2
-	musicheader 1, 3, Music_MagnetTrain_Ch3
-	musicheader 1, 4, Music_MagnetTrain_Ch4
+	channel_count 4
+	channel 1, Music_MagnetTrain_Ch1
+	channel 2, Music_MagnetTrain_Ch2
+	channel 3, Music_MagnetTrain_Ch3
+	channel 4, Music_MagnetTrain_Ch4
 
 Music_MagnetTrain_Ch1:
 	tempo 110

--- a/audio/music/mainmenu.asm
+++ b/audio/music/mainmenu.asm
@@ -1,8 +1,9 @@
 Music_MainMenu:
-	musicheader 4, 1, Music_MainMenu_Ch1
-	musicheader 1, 2, Music_MainMenu_Ch2
-	musicheader 1, 3, Music_MainMenu_Ch3
-	musicheader 1, 4, Music_MainMenu_Ch4
+	channel_count 4
+	channel 1, Music_MainMenu_Ch1
+	channel 2, Music_MainMenu_Ch2
+	channel 3, Music_MainMenu_Ch3
+	channel 4, Music_MainMenu_Ch4
 
 Music_MainMenu_Ch1:
 	tempo 160

--- a/audio/music/mom.asm
+++ b/audio/music/mom.asm
@@ -1,7 +1,8 @@
 Music_Mom:
-	musicheader 3, 2, Music_Mom_Ch2
-	musicheader 1, 3, Music_Mom_Ch3
-	musicheader 1, 4, Music_Mom_Ch4
+	channel_count 3
+	channel 2, Music_Mom_Ch2
+	channel 3, Music_Mom_Ch3
+	channel 4, Music_Mom_Ch4
 
 Music_Mom_Ch2:
 	tempo 144

--- a/audio/music/mtmoon.asm
+++ b/audio/music/mtmoon.asm
@@ -1,8 +1,9 @@
 Music_MtMoon:
-	musicheader 4, 1, Music_MtMoon_Ch1
-	musicheader 1, 2, Music_MtMoon_Ch2
-	musicheader 1, 3, Music_MtMoon_Ch3
-	musicheader 1, 4, Music_MtMoon_Ch4
+	channel_count 4
+	channel 1, Music_MtMoon_Ch1
+	channel 2, Music_MtMoon_Ch2
+	channel 3, Music_MtMoon_Ch3
+	channel 4, Music_MtMoon_Ch4
 
 Music_MtMoon_Ch1:
 	tempo 208

--- a/audio/music/mtmoonsquare.asm
+++ b/audio/music/mtmoonsquare.asm
@@ -1,6 +1,7 @@
 Music_MtMoonSquare:
-	musicheader 2, 1, Music_MtMoonSquare_Ch1
-	musicheader 1, 2, Music_MtMoonSquare_Ch2
+	channel_count 2
+	channel 1, Music_MtMoonSquare_Ch1
+	channel 2, Music_MtMoonSquare_Ch2
 
 Music_MtMoonSquare_Ch1:
 	tempo 112

--- a/audio/music/nationalpark.asm
+++ b/audio/music/nationalpark.asm
@@ -1,8 +1,9 @@
 Music_NationalPark:
-	musicheader 4, 1, Music_NationalPark_Ch1
-	musicheader 1, 2, Music_NationalPark_Ch2
-	musicheader 1, 3, Music_NationalPark_Ch3
-	musicheader 1, 4, Music_NationalPark_Ch4
+	channel_count 4
+	channel 1, Music_NationalPark_Ch1
+	channel 2, Music_NationalPark_Ch2
+	channel 3, Music_NationalPark_Ch3
+	channel 4, Music_NationalPark_Ch4
 
 Music_NationalPark_Ch1:
 	tempo 192

--- a/audio/music/newbarktown.asm
+++ b/audio/music/newbarktown.asm
@@ -1,7 +1,8 @@
 Music_NewBarkTown:
-	musicheader 3, 1, Music_NewBarkTown_Ch1
-	musicheader 1, 2, Music_NewBarkTown_Ch2
-	musicheader 1, 3, Music_NewBarkTown_Ch3
+	channel_count 3
+	channel 1, Music_NewBarkTown_Ch1
+	channel 2, Music_NewBarkTown_Ch2
+	channel 3, Music_NewBarkTown_Ch3
 
 Music_NewBarkTown_Ch1:
 	tempo 187

--- a/audio/music/nothing.asm
+++ b/audio/music/nothing.asm
@@ -1,8 +1,9 @@
 Music_Nothing:
-	musicheader 4, 1, Music_Nothing_Ch1
-	musicheader 1, 2, Music_Nothing_Ch2
-	musicheader 1, 3, Music_Nothing_Ch3
-	musicheader 1, 4, Music_Nothing_Ch4
+	channel_count 4
+	channel 1, Music_Nothing_Ch1
+	channel 2, Music_Nothing_Ch2
+	channel 3, Music_Nothing_Ch3
+	channel 4, Music_Nothing_Ch4
 
 Music_Nothing_Ch1:
 Music_Nothing_Ch2:

--- a/audio/music/oras/wallybattle.asm
+++ b/audio/music/oras/wallybattle.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/4/
 
 Music_WallyBattleORAS:
-	musicheader 4, 1, Music_WallyBattleORAS_Ch1
-	musicheader 1, 2, Music_WallyBattleORAS_Ch2
-	musicheader 1, 3, Music_WallyBattleORAS_Ch3
-	musicheader 1, 4, Music_WallyBattleORAS_Ch4
+	channel_count 4
+	channel 1, Music_WallyBattleORAS_Ch1
+	channel 2, Music_WallyBattleORAS_Ch2
+	channel 3, Music_WallyBattleORAS_Ch3
+	channel 4, Music_WallyBattleORAS_Ch4
 
 Music_WallyBattleORAS_Ch1:
 	tempo 192

--- a/audio/music/oras/wallyencounter.asm
+++ b/audio/music/oras/wallyencounter.asm
@@ -4,8 +4,9 @@
 ; https://hax.iimarckus.org/topic/6777/5/
 
 Music_WallyEncounterORAS:
-	musicheader 2, 1, Music_WallyEncounterORAS_Ch1
-	musicheader 1, 2, Music_WallyEncounterORAS_Ch2
+	channel_count 2
+	channel 1, Music_WallyEncounterORAS_Ch1
+	channel 2, Music_WallyEncounterORAS_Ch2
 
 Music_WallyEncounterORAS_Ch1:
 	tempo 208

--- a/audio/music/oras/zinniabattle.asm
+++ b/audio/music/oras/zinniabattle.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/4/
 
 Music_ZinniaBattleORAS:
-	musicheader 4, 1, Music_ZinniaBattleORAS_Ch1
-	musicheader 1, 2, Music_ZinniaBattleORAS_Ch2
-	musicheader 1, 3, Music_ZinniaBattleORAS_Ch3
-	musicheader 1, 4, Music_ZinniaBattleORAS_Ch4
+	channel_count 4
+	channel 1, Music_ZinniaBattleORAS_Ch1
+	channel 2, Music_ZinniaBattleORAS_Ch2
+	channel 3, Music_ZinniaBattleORAS_Ch3
+	channel 4, Music_ZinniaBattleORAS_Ch4
 
 Music_ZinniaBattleORAS_Ch1:
 	tempo 212

--- a/audio/music/oras/zinniaencounter.asm
+++ b/audio/music/oras/zinniaencounter.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/4/
 
 Music_ZinniaEncounterORAS:
-	musicheader 4, 1, Music_ZinniaEncounterORAS_Ch1
-	musicheader 1, 2, Music_ZinniaEncounterORAS_Ch2
-	musicheader 1, 3, Music_ZinniaEncounterORAS_Ch3
-	musicheader 1, 4, Music_ZinniaEncounterORAS_Ch4
+	channel_count 4
+	channel 1, Music_ZinniaEncounterORAS_Ch1
+	channel 2, Music_ZinniaEncounterORAS_Ch2
+	channel 3, Music_ZinniaEncounterORAS_Ch3
+	channel 4, Music_ZinniaEncounterORAS_Ch4
 
 Music_ZinniaEncounterORAS_Ch1:
 	tempo 176

--- a/audio/music/pallettown.asm
+++ b/audio/music/pallettown.asm
@@ -1,7 +1,8 @@
 Music_PalletTown:
-	musicheader 3, 1, Music_PalletTown_Ch1
-	musicheader 1, 2, Music_PalletTown_Ch2
-	musicheader 1, 3, Music_PalletTown_Ch3
+	channel_count 3
+	channel 1, Music_PalletTown_Ch1
+	channel 2, Music_PalletTown_Ch2
+	channel 3, Music_PalletTown_Ch3
 
 Music_PalletTown_Ch1:
 	tempo 188

--- a/audio/music/pokecomcenter.asm
+++ b/audio/music/pokecomcenter.asm
@@ -1,8 +1,9 @@
 Music_PokeComCenter:
-	musicheader 4, 1, Music_PokeComCenter_Ch1
-	musicheader 1, 2, Music_PokeComCenter_Ch2
-	musicheader 1, 3, Music_PokeComCenter_Ch3
-	musicheader 1, 4, Music_PokeComCenter_Ch4
+	channel_count 4
+	channel 1, Music_PokeComCenter_Ch1
+	channel 2, Music_PokeComCenter_Ch2
+	channel 3, Music_PokeComCenter_Ch3
+	channel 4, Music_PokeComCenter_Ch4
 
 Music_PokeComCenter_Ch1:
 	tempo 160

--- a/audio/music/pokeflutechannel.asm
+++ b/audio/music/pokeflutechannel.asm
@@ -1,7 +1,8 @@
 Music_PokeFluteChannel:
-	musicheader 3, 1, Music_PokeFluteChannel_Ch1
-	musicheader 1, 2, Music_PokeFluteChannel_Ch2
-	musicheader 1, 3, Music_PokeFluteChannel_Ch3
+	channel_count 3
+	channel 1, Music_PokeFluteChannel_Ch1
+	channel 2, Music_PokeFluteChannel_Ch2
+	channel 3, Music_PokeFluteChannel_Ch3
 
 Music_PokeFluteChannel_Ch1:
 	tempo 240

--- a/audio/music/pokemoncenter.asm
+++ b/audio/music/pokemoncenter.asm
@@ -1,8 +1,9 @@
 Music_PokemonCenter:
-	musicheader 4, 1, Music_PokemonCenter_Ch1
-	musicheader 1, 2, Music_PokemonCenter_Ch2
-	musicheader 1, 3, Music_PokemonCenter_Ch3
-	musicheader 1, 4, Music_PokemonCenter_Ch4
+	channel_count 4
+	channel 1, Music_PokemonCenter_Ch1
+	channel 2, Music_PokemonCenter_Ch2
+	channel 3, Music_PokemonCenter_Ch3
+	channel 4, Music_PokemonCenter_Ch4
 
 Music_PokemonCenter_Ch1:
 	tempo 152

--- a/audio/music/pokemonchannel.asm
+++ b/audio/music/pokemonchannel.asm
@@ -1,8 +1,9 @@
 Music_PokemonChannel:
-	musicheader 4, 1, Music_PokemonChannel_Ch1
-	musicheader 1, 2, Music_PokemonChannel_Ch2
-	musicheader 1, 3, Music_PokemonChannel_Ch3
-	musicheader 1, 4, Music_PokemonChannel_Ch4
+	channel_count 4
+	channel 1, Music_PokemonChannel_Ch1
+	channel 2, Music_PokemonChannel_Ch2
+	channel 3, Music_PokemonChannel_Ch3
+	channel 4, Music_PokemonChannel_Ch4
 
 Music_PokemonChannel_Ch1:
 	tempo 128

--- a/audio/music/pokemonlullaby.asm
+++ b/audio/music/pokemonlullaby.asm
@@ -1,7 +1,8 @@
 Music_PokemonLullaby:
-	musicheader 3, 1, Music_PokemonLullaby_Ch1
-	musicheader 1, 2, Music_PokemonLullaby_Ch2
-	musicheader 1, 3, Music_PokemonLullaby_Ch3
+	channel_count 3
+	channel 1, Music_PokemonLullaby_Ch1
+	channel 2, Music_PokemonLullaby_Ch2
+	channel 3, Music_PokemonLullaby_Ch3
 
 Music_PokemonLullaby_Ch1:
 	tempo 224

--- a/audio/music/pokemonmarch.asm
+++ b/audio/music/pokemonmarch.asm
@@ -1,8 +1,9 @@
 Music_PokemonMarch:
-	musicheader 4, 1, Music_PokemonMarch_Ch1
-	musicheader 1, 2, Music_PokemonMarch_Ch2
-	musicheader 1, 3, Music_PokemonMarch_Ch3
-	musicheader 1, 4, Music_PokemonMarch_Ch4
+	channel_count 4
+	channel 1, Music_PokemonMarch_Ch1
+	channel 2, Music_PokemonMarch_Ch2
+	channel 3, Music_PokemonMarch_Ch3
+	channel 4, Music_PokemonMarch_Ch4
 
 Music_PokemonMarch_Ch1:
 	tempo 144

--- a/audio/music/postcredits.asm
+++ b/audio/music/postcredits.asm
@@ -1,6 +1,7 @@
 Music_PostCredits:
-	musicheader 2, 1, Music_PostCredits_Ch1
-	musicheader 1, 2, Music_PostCredits_Ch2
+	channel_count 2
+	channel 1, Music_PostCredits_Ch1
+	channel 2, Music_PostCredits_Ch2
 
 Music_PostCredits_Ch1:
 	tempo 271

--- a/audio/music/prism/gymleaderbattle.asm
+++ b/audio/music/prism/gymleaderbattle.asm
@@ -3,9 +3,10 @@
 ; Revised by FroggestSpirit
 
 Music_GymLeaderBattlePrism:
-	musicheader 3, 1, Music_GymLeaderBattlePrism_Ch1
-	musicheader 1, 2, Music_GymLeaderBattlePrism_Ch2
-	musicheader 1, 3, Music_GymLeaderBattlePrism_Ch3
+	channel_count 3
+	channel 1, Music_GymLeaderBattlePrism_Ch1
+	channel 2, Music_GymLeaderBattlePrism_Ch2
+	channel 3, Music_GymLeaderBattlePrism_Ch3
 
 Music_GymLeaderBattlePrism_Ch1:
 	tempo 101

--- a/audio/music/prism/palettebattle.asm
+++ b/audio/music/prism/palettebattle.asm
@@ -3,9 +3,10 @@
 ; Revised by NotFroggestSpirit
 
 Music_PaletteBattlePrism:
-	musicheader 3, 1, Music_PaletteBattlePrism_Ch1
-	musicheader 1, 2, Music_PaletteBattlePrism_Ch2
-	musicheader 1, 3, Music_PaletteBattlePrism_Ch3
+	channel_count 3
+	channel 1, Music_PaletteBattlePrism_Ch1
+	channel 2, Music_PaletteBattlePrism_Ch2
+	channel 3, Music_PaletteBattlePrism_Ch3
 
 Music_PaletteBattlePrism_Ch1:
 	tempo 96

--- a/audio/music/prism/trainerbattle.asm
+++ b/audio/music/prism/trainerbattle.asm
@@ -3,9 +3,10 @@
 ; Revised by NotFroggestSpirit
 
 Music_TrainerBattlePrism:
-	musicheader 3, 1, Music_TrainerBattlePrism_Ch2
-	musicheader 1, 2, Music_TrainerBattlePrism_Ch1
-	musicheader 1, 3, Music_TrainerBattlePrism_Ch3
+	channel_count 3
+	channel 1, Music_TrainerBattlePrism_Ch2
+	channel 2, Music_TrainerBattlePrism_Ch1
+	channel 3, Music_TrainerBattlePrism_Ch3
 
 Music_TrainerBattlePrism_Ch1:
 	tempo 102

--- a/audio/music/prism/wildbattle.asm
+++ b/audio/music/prism/wildbattle.asm
@@ -3,9 +3,10 @@
 ; Revised by FroggestSpirit
 
 Music_WildBattlePrism:
-	musicheader 3, 1, Music_WildBattlePrism_Ch1
-	musicheader 1, 2, Music_WildBattlePrism_Ch2
-	musicheader 1, 3, Music_WildBattlePrism_Ch3
+	channel_count 3
+	channel 1, Music_WildBattlePrism_Ch1
+	channel 2, Music_WildBattlePrism_Ch2
+	channel 3, Music_WildBattlePrism_Ch3
 
 Music_WildBattlePrism_Ch1:
 	tempo 104

--- a/audio/music/profoak.asm
+++ b/audio/music/profoak.asm
@@ -1,7 +1,8 @@
 Music_ProfOak:
-	musicheader 3, 1, Music_ProfOak_Ch1
-	musicheader 1, 2, Music_ProfOak_Ch2
-	musicheader 1, 3, Music_ProfOak_Ch3
+	channel_count 3
+	channel 1, Music_ProfOak_Ch1
+	channel 2, Music_ProfOak_Ch2
+	channel 3, Music_ProfOak_Ch3
 
 Music_ProfOak_Ch1:
 	tempo 118

--- a/audio/music/profoakspokemontalk.asm
+++ b/audio/music/profoakspokemontalk.asm
@@ -1,7 +1,8 @@
 Music_ProfOaksPokemonTalk:
-	musicheader 3, 1, Music_ProfOaksPokemonTalk_Ch1
-	musicheader 1, 2, Music_ProfOaksPokemonTalk_Ch2
-	musicheader 1, 3, Music_ProfOaksPokemonTalk_Ch3
+	channel_count 3
+	channel 1, Music_ProfOaksPokemonTalk_Ch1
+	channel 2, Music_ProfOaksPokemonTalk_Ch2
+	channel 3, Music_ProfOaksPokemonTalk_Ch3
 
 Music_ProfOaksPokemonTalk_Ch1:
 	tempo 164

--- a/audio/music/rivalbattle.asm
+++ b/audio/music/rivalbattle.asm
@@ -1,7 +1,8 @@
 Music_RivalBattle:
-	musicheader 3, 1, Music_RivalBattle_Ch1
-	musicheader 1, 2, Music_RivalBattle_Ch2
-	musicheader 1, 3, Music_RivalBattle_Ch3
+	channel_count 3
+	channel 1, Music_RivalBattle_Ch1
+	channel 2, Music_RivalBattle_Ch2
+	channel 3, Music_RivalBattle_Ch3
 
 Music_RivalBattle_Ch1:
 	tempo 102

--- a/audio/music/rocketbattle.asm
+++ b/audio/music/rocketbattle.asm
@@ -1,7 +1,8 @@
 Music_RocketBattle:
-	musicheader 3, 1, Music_RocketBattle_Ch1
-	musicheader 1, 2, Music_RocketBattle_Ch2
-	musicheader 1, 3, Music_RocketBattle_Ch3
+	channel_count 3
+	channel 1, Music_RocketBattle_Ch1
+	channel 2, Music_RocketBattle_Ch2
+	channel 3, Music_RocketBattle_Ch3
 
 Music_RocketBattle_Ch1:
 	tempo 101

--- a/audio/music/rockethideout.asm
+++ b/audio/music/rockethideout.asm
@@ -1,8 +1,9 @@
 Music_RocketHideout:
-	musicheader 4, 1, Music_RocketHideout_Ch1
-	musicheader 1, 2, Music_RocketHideout_Ch2
-	musicheader 1, 3, Music_RocketHideout_Ch3
-	musicheader 1, 4, Music_RocketHideout_Ch4
+	channel_count 4
+	channel 1, Music_RocketHideout_Ch1
+	channel 2, Music_RocketHideout_Ch2
+	channel 3, Music_RocketHideout_Ch3
+	channel 4, Music_RocketHideout_Ch4
 
 Music_RocketHideout_Ch1:
 	tempo 144

--- a/audio/music/rockettheme.asm
+++ b/audio/music/rockettheme.asm
@@ -1,8 +1,9 @@
 Music_RocketTheme:
-	musicheader 4, 1, Music_RocketTheme_Ch1
-	musicheader 1, 2, Music_RocketTheme_Ch2
-	musicheader 1, 3, Music_RocketTheme_Ch3
-	musicheader 1, 4, Music_RocketTheme_Ch4
+	channel_count 4
+	channel 1, Music_RocketTheme_Ch1
+	channel 2, Music_RocketTheme_Ch2
+	channel 3, Music_RocketTheme_Ch3
+	channel 4, Music_RocketTheme_Ch4
 
 Music_RocketTheme_Ch1:
 	tempo 128

--- a/audio/music/route1.asm
+++ b/audio/music/route1.asm
@@ -1,7 +1,8 @@
 Music_Route1:
-	musicheader 3, 1, Music_Route1_Ch1
-	musicheader 1, 2, Music_Route1_Ch2
-	musicheader 1, 3, Music_Route1_Ch3
+	channel_count 3
+	channel 1, Music_Route1_Ch1
+	channel 2, Music_Route1_Ch2
+	channel 3, Music_Route1_Ch3
 
 Music_Route1_Ch1:
 	stereopanning $f

--- a/audio/music/route12.asm
+++ b/audio/music/route12.asm
@@ -1,8 +1,9 @@
 Music_Route12:
-	musicheader 4, 1, Music_Route12_Ch1
-	musicheader 1, 2, Music_Route12_Ch2
-	musicheader 1, 3, Music_Route12_Ch3
-	musicheader 1, 4, Music_Route12_Ch4
+	channel_count 4
+	channel 1, Music_Route12_Ch1
+	channel 2, Music_Route12_Ch2
+	channel 3, Music_Route12_Ch3
+	channel 4, Music_Route12_Ch4
 
 Music_Route12_Ch1:
 	tempo 148

--- a/audio/music/route26.asm
+++ b/audio/music/route26.asm
@@ -1,8 +1,9 @@
 Music_Route26:
-	musicheader 4, 1, Music_Route26_Ch1
-	musicheader 1, 2, Music_Route26_Ch2
-	musicheader 1, 3, Music_Route26_Ch3
-	musicheader 1, 4, Music_Route26_Ch4
+	channel_count 4
+	channel 1, Music_Route26_Ch1
+	channel 2, Music_Route26_Ch2
+	channel 3, Music_Route26_Ch3
+	channel 4, Music_Route26_Ch4
 
 Music_Route26_Ch1:
 	stereopanning $f

--- a/audio/music/route29.asm
+++ b/audio/music/route29.asm
@@ -1,8 +1,9 @@
 Music_Route29:
-	musicheader 4, 1, Music_Route29_Ch1
-	musicheader 1, 2, Music_Route29_Ch2
-	musicheader 1, 3, Music_Route29_Ch3
-	musicheader 1, 4, Music_Route29_Ch4
+	channel_count 4
+	channel 1, Music_Route29_Ch1
+	channel 2, Music_Route29_Ch2
+	channel 3, Music_Route29_Ch3
+	channel 4, Music_Route29_Ch4
 
 Music_Route29_Ch1:
 	tempo 146

--- a/audio/music/route3.asm
+++ b/audio/music/route3.asm
@@ -1,8 +1,9 @@
 Music_Route3:
-	musicheader 4, 1, Music_Route3_Ch1
-	musicheader 1, 2, Music_Route3_Ch2
-	musicheader 1, 3, Music_Route3_Ch3
-	musicheader 1, 4, Music_Route3_Ch4
+	channel_count 4
+	channel 1, Music_Route3_Ch1
+	channel 2, Music_Route3_Ch2
+	channel 3, Music_Route3_Ch3
+	channel 4, Music_Route3_Ch4
 
 Music_Route3_Ch1:
 	stereopanning $f

--- a/audio/music/route30.asm
+++ b/audio/music/route30.asm
@@ -1,8 +1,9 @@
 Music_Route30:
-	musicheader 4, 1, Music_Route30_Ch1
-	musicheader 1, 2, Music_Route30_Ch2
-	musicheader 1, 3, Music_Route30_Ch3
-	musicheader 1, 4, Music_Route30_Ch4
+	channel_count 4
+	channel 1, Music_Route30_Ch1
+	channel 2, Music_Route30_Ch2
+	channel 3, Music_Route30_Ch3
+	channel 4, Music_Route30_Ch4
 
 Music_Route30_Ch1:
 	tempo 144

--- a/audio/music/route36.asm
+++ b/audio/music/route36.asm
@@ -1,8 +1,9 @@
 Music_Route36:
-	musicheader 4, 1, Music_Route36_Ch1
-	musicheader 1, 2, Music_Route36_Ch2
-	musicheader 1, 3, Music_Route36_Ch3
-	musicheader 1, 4, Music_Route36_Ch4
+	channel_count 4
+	channel 1, Music_Route36_Ch1
+	channel 2, Music_Route36_Ch2
+	channel 3, Music_Route36_Ch3
+	channel 4, Music_Route36_Ch4
 
 Music_Route36_Ch1:
 	tempo 144

--- a/audio/music/route37.asm
+++ b/audio/music/route37.asm
@@ -1,8 +1,9 @@
 Music_Route37:
-	musicheader 4, 1, Music_Route37_Ch1
-	musicheader 1, 2, Music_Route37_Ch2
-	musicheader 1, 3, Music_Route37_Ch3
-	musicheader 1, 4, Music_Route37_Ch4
+	channel_count 4
+	channel 1, Music_Route37_Ch1
+	channel 2, Music_Route37_Ch2
+	channel 3, Music_Route37_Ch3
+	channel 4, Music_Route37_Ch4
 
 Music_Route37_Ch1:
 	tempo 144

--- a/audio/music/rse/abandonedship.asm
+++ b/audio/music/rse/abandonedship.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/
 
 Music_AbandonedShipRSE:
-	musicheader 4, 1, Music_AbandonedShipRSE_Ch1
-	musicheader 1, 2, Music_AbandonedShipRSE_Ch2
-	musicheader 1, 3, Music_AbandonedShipRSE_Ch3
-	musicheader 1, 4, Music_AbandonedShipRSE_Ch4
+	channel_count 4
+	channel 1, Music_AbandonedShipRSE_Ch1
+	channel 2, Music_AbandonedShipRSE_Ch2
+	channel 3, Music_AbandonedShipRSE_Ch3
+	channel 4, Music_AbandonedShipRSE_Ch4
 
 Music_AbandonedShipRSE_Ch1:
 	tempo 188

--- a/audio/music/rse/battlefactory.asm
+++ b/audio/music/rse/battlefactory.asm
@@ -4,10 +4,11 @@
 ; https://soundcloud.com/mmmmmmmmmmmmmmmmm-1/battle-factory-gbc-8-bit
 
 Music_BattleFactoryRSE:
-	musicheader 4, 1, Music_BattleFactoryRSE_Ch1
-	musicheader 1, 2, Music_BattleFactoryRSE_Ch2
-	musicheader 1, 3, Music_BattleFactoryRSE_Ch3
-	musicheader 1, 4, Music_BattleFactoryRSE_Ch4
+	channel_count 4
+	channel 1, Music_BattleFactoryRSE_Ch1
+	channel 2, Music_BattleFactoryRSE_Ch2
+	channel 3, Music_BattleFactoryRSE_Ch3
+	channel 4, Music_BattleFactoryRSE_Ch4
 
 Music_BattleFactoryRSE_Ch1:
 	tempo 132

--- a/audio/music/rse/bicycle.asm
+++ b/audio/music/rse/bicycle.asm
@@ -4,10 +4,11 @@
 ; https://soundcloud.com/mmmmmmmmmmmmmmmmm-1/hoenn-bicycle-gbc-8-bit
 
 Music_BicycleRSE:
-	musicheader 4, 1, Music_BicycleRSE_Ch1
-	musicheader 1, 2, Music_BicycleRSE_Ch2
-	musicheader 1, 3, Music_BicycleRSE_Ch3
-	musicheader 1, 4, Music_BicycleRSE_Ch4
+	channel_count 4
+	channel 1, Music_BicycleRSE_Ch1
+	channel 2, Music_BicycleRSE_Ch2
+	channel 3, Music_BicycleRSE_Ch3
+	channel 4, Music_BicycleRSE_Ch4
 
 Music_BicycleRSE_Ch1:
 	tempo 70

--- a/audio/music/rse/championbattle.asm
+++ b/audio/music/rse/championbattle.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/4/
 
 Music_ChampionBattleRSE:
-	musicheader 4, 1, Music_ChampionBattleRSE_Ch1
-	musicheader 1, 2, Music_ChampionBattleRSE_Ch2
-	musicheader 1, 3, Music_ChampionBattleRSE_Ch3
-	musicheader 1, 4, Music_ChampionBattleRSE_Ch4
+	channel_count 4
+	channel 1, Music_ChampionBattleRSE_Ch1
+	channel 2, Music_ChampionBattleRSE_Ch2
+	channel 3, Music_ChampionBattleRSE_Ch3
+	channel 4, Music_ChampionBattleRSE_Ch4
 
 Music_ChampionBattleRSE_Ch1:
 	tempo 192

--- a/audio/music/rse/dewfordtown.asm
+++ b/audio/music/rse/dewfordtown.asm
@@ -3,10 +3,11 @@
 ; https://github.com/huderlem/pokestyle-music-devamps/blob/master/music/hoenn_dewford_town.asm
 
 Music_DewfordTownRSE:
-	musicheader 4, 1, Music_DewfordTownRSE_Ch1
-	musicheader 1, 2, Music_DewfordTownRSE_Ch2
-	musicheader 1, 3, Music_DewfordTownRSE_Ch3
-	musicheader 1, 4, Music_DewfordTownRSE_Ch4
+	channel_count 4
+	channel 1, Music_DewfordTownRSE_Ch1
+	channel 2, Music_DewfordTownRSE_Ch2
+	channel 3, Music_DewfordTownRSE_Ch3
+	channel 4, Music_DewfordTownRSE_Ch4
 
 Music_DewfordTownRSE_Ch1:
 	tempo 138

--- a/audio/music/rse/evergrandecity.asm
+++ b/audio/music/rse/evergrandecity.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/
 
 Music_EverGrandeCityRSE:
-	musicheader 4, 1, Music_EverGrandeCityRSE_Ch1
-	musicheader 1, 2, Music_EverGrandeCityRSE_Ch2
-	musicheader 1, 3, Music_EverGrandeCityRSE_Ch3
-	musicheader 1, 4, Music_EverGrandeCityRSE_Ch4
+	channel_count 4
+	channel 1, Music_EverGrandeCityRSE_Ch1
+	channel 2, Music_EverGrandeCityRSE_Ch2
+	channel 3, Music_EverGrandeCityRSE_Ch3
+	channel 4, Music_EverGrandeCityRSE_Ch4
 
 Music_EverGrandeCityRSE_Ch1:
 	tempo 100

--- a/audio/music/rse/meteorfalls.asm
+++ b/audio/music/rse/meteorfalls.asm
@@ -4,9 +4,10 @@
 ; https://hax.iimarckus.org/topic/6777/
 
 Music_MeteorFallsRSE:
-	musicheader 3, 1, Music_MeteorFallsRSE_Ch1
-	musicheader 1, 2, Music_MeteorFallsRSE_Ch2
-	musicheader 1, 3, Music_MeteorFallsRSE_Ch3
+	channel_count 3
+	channel 1, Music_MeteorFallsRSE_Ch1
+	channel 2, Music_MeteorFallsRSE_Ch2
+	channel 3, Music_MeteorFallsRSE_Ch3
 
 Music_MeteorFallsRSE_Ch1:
 	tempo 190

--- a/audio/music/rse/mountchimney.asm
+++ b/audio/music/rse/mountchimney.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/4/
 
 Music_MountChimneyRSE:
-	musicheader 4, 1, Music_MountChimneyRSE_Ch1
-	musicheader 1, 2, Music_MountChimneyRSE_Ch2
-	musicheader 1, 3, Music_MountChimneyRSE_Ch3
-	musicheader 1, 4, Music_MountChimneyRSE_Ch4
+	channel_count 4
+	channel 1, Music_MountChimneyRSE_Ch1
+	channel 2, Music_MountChimneyRSE_Ch2
+	channel 3, Music_MountChimneyRSE_Ch3
+	channel 4, Music_MountChimneyRSE_Ch4
 
 Music_MountChimneyRSE_Ch1:
 	tempo 160

--- a/audio/music/rse/mountpyre.asm
+++ b/audio/music/rse/mountpyre.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/
 
 Music_MountPyreRSE:
-	musicheader 4, 1, Music_MountPyreRSE_Ch1
-	musicheader 1, 2, Music_MountPyreRSE_Ch2
-	musicheader 1, 3, Music_MountPyreRSE_Ch3
-	musicheader 1, 4, Music_MountPyreRSE_Ch4
+	channel_count 4
+	channel 1, Music_MountPyreRSE_Ch1
+	channel 2, Music_MountPyreRSE_Ch2
+	channel 3, Music_MountPyreRSE_Ch3
+	channel 4, Music_MountPyreRSE_Ch4
 
 Music_MountPyreRSE_Ch1:
 	tempo 212

--- a/audio/music/rse/route101.asm
+++ b/audio/music/rse/route101.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/
 
 Music_Route101RSE:
-	musicheader 4, 1, Music_Route101RSE_Ch1
-	musicheader 1, 2, Music_Route101RSE_Ch2
-	musicheader 1, 3, Music_Route101RSE_Ch3
-	musicheader 1, 4, Music_Route101RSE_Ch4
+	channel_count 4
+	channel 1, Music_Route101RSE_Ch1
+	channel 2, Music_Route101RSE_Ch2
+	channel 3, Music_Route101RSE_Ch3
+	channel 4, Music_Route101RSE_Ch4
 
 Music_Route101RSE_Ch1:
 	tempo 166

--- a/audio/music/rse/surfing.asm
+++ b/audio/music/rse/surfing.asm
@@ -4,9 +4,10 @@
 ; https://soundcloud.com/monstarules/pokemon-rse-surf-theme-gbc-conversion
 
 Music_SurfRSE:
-	musicheader 3, 1, Music_SurfRSE_Ch1
-	musicheader 1, 2, Music_SurfRSE_Ch2
-	musicheader 1, 3, Music_SurfRSE_Ch3
+	channel_count 3
+	channel 1, Music_SurfRSE_Ch1
+	channel 2, Music_SurfRSE_Ch2
+	channel 3, Music_SurfRSE_Ch3
 
 Music_SurfRSE_Ch1:
 	tempo $75

--- a/audio/music/ruinsofalphinterior.asm
+++ b/audio/music/ruinsofalphinterior.asm
@@ -1,7 +1,8 @@
 Music_RuinsOfAlphInterior:
-	musicheader 3, 1, Music_RuinsOfAlphInterior_Ch1
-	musicheader 1, 2, Music_RuinsOfAlphInterior_Ch2
-	musicheader 1, 3, Music_RuinsOfAlphInterior_Ch3
+	channel_count 3
+	channel 1, Music_RuinsOfAlphInterior_Ch1
+	channel 2, Music_RuinsOfAlphInterior_Ch2
+	channel 3, Music_RuinsOfAlphInterior_Ch3
 
 Music_RuinsOfAlphInterior_Ch1:
 	tempo 224

--- a/audio/music/ruinsofalphradio.asm
+++ b/audio/music/ruinsofalphradio.asm
@@ -1,7 +1,8 @@
 Music_RuinsOfAlphRadio:
-	musicheader 3, 1, Music_RuinsOfAlphRadio_Ch1
-	musicheader 1, 2, Music_RuinsOfAlphRadio_Ch2
-	musicheader 1, 3, Music_RuinsOfAlphRadio_Ch3
+	channel_count 3
+	channel 1, Music_RuinsOfAlphRadio_Ch1
+	channel 2, Music_RuinsOfAlphRadio_Ch2
+	channel 3, Music_RuinsOfAlphRadio_Ch3
 
 Music_RuinsOfAlphRadio_Ch1:
 	tempo 160

--- a/audio/music/showmearound.asm
+++ b/audio/music/showmearound.asm
@@ -1,8 +1,9 @@
 Music_ShowMeAround:
-	musicheader 4, 1, Music_ShowMeAround_Ch1
-	musicheader 1, 2, Music_ShowMeAround_Ch2
-	musicheader 1, 3, Music_ShowMeAround_Ch3
-	musicheader 1, 4, Music_ShowMeAround_Ch4
+	channel_count 4
+	channel 1, Music_ShowMeAround_Ch1
+	channel 2, Music_ShowMeAround_Ch2
+	channel 3, Music_ShowMeAround_Ch3
+	channel 4, Music_ShowMeAround_Ch4
 
 Music_ShowMeAround_Ch1:
 	tempo 144

--- a/audio/music/sm/elitefourbattle.asm
+++ b/audio/music/sm/elitefourbattle.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/8/
 
 Music_EliteFourBattleSM:
-	musicheader 4, 1, Music_EliteFourBattleSM_Ch1
-	musicheader 1, 2, Music_EliteFourBattleSM_Ch2
-	musicheader 1, 3, Music_EliteFourBattleSM_Ch3
-	musicheader 1, 4, Music_EliteFourBattleSM_Ch4
+	channel_count 4
+	channel 1, Music_EliteFourBattleSM_Ch1
+	channel 2, Music_EliteFourBattleSM_Ch2
+	channel 3, Music_EliteFourBattleSM_Ch3
+	channel 4, Music_EliteFourBattleSM_Ch4
 
 Music_EliteFourBattleSM_Ch1:
 	tempo 184

--- a/audio/music/sm/motherbeastbattle.asm
+++ b/audio/music/sm/motherbeastbattle.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/5/
 
 Music_MotherBeastBattleSM:
-	musicheader 4, 1, Music_MotherBeastBattleSM_Ch1
-	musicheader 1, 2, Music_MotherBeastBattleSM_Ch2
-	musicheader 1, 3, Music_MotherBeastBattleSM_Ch3
-	musicheader 1, 4, Music_MotherBeastBattleSM_Ch4
+	channel_count 4
+	channel 1, Music_MotherBeastBattleSM_Ch1
+	channel 2, Music_MotherBeastBattleSM_Ch2
+	channel 3, Music_MotherBeastBattleSM_Ch3
+	channel 4, Music_MotherBeastBattleSM_Ch4
 
 Music_MotherBeastBattleSM_Ch1:
 	dutycycle 3

--- a/audio/music/sm/trainerbattle.asm
+++ b/audio/music/sm/trainerbattle.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/7/
 
 Music_TrainerBattleSM:
-	musicheader 4, 1, Music_TrainerBattleSM_Ch1
-	musicheader 1, 2, Music_TrainerBattleSM_Ch2
-	musicheader 1, 3, Music_TrainerBattleSM_Ch3
-	musicheader 1, 4, Music_TrainerBattleSM_Ch4
+	channel_count 4
+	channel 1, Music_TrainerBattleSM_Ch1
+	channel 2, Music_TrainerBattleSM_Ch2
+	channel 3, Music_TrainerBattleSM_Ch3
+	channel 4, Music_TrainerBattleSM_Ch4
 
 Music_TrainerBattleSM_Ch1:
 	tempo 204

--- a/audio/music/sm/wildbattle.asm
+++ b/audio/music/sm/wildbattle.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/6/
 
 Music_WildBattleSM:
-	musicheader 4, 1, Music_WildBattleSM_Ch1
-	musicheader 1, 2, Music_WildBattleSM_Ch2
-	musicheader 1, 3, Music_WildBattleSM_Ch3
-	musicheader 1, 4, Music_WildBattleSM_Ch4
+	channel_count 4
+	channel 1, Music_WildBattleSM_Ch1
+	channel 2, Music_WildBattleSM_Ch2
+	channel 3, Music_WildBattleSM_Ch3
+	channel 4, Music_WildBattleSM_Ch4
 
 Music_WildBattleSM_Ch1:
 	tempo 204

--- a/audio/music/sprouttower.asm
+++ b/audio/music/sprouttower.asm
@@ -1,8 +1,9 @@
 Music_SproutTower:
-	musicheader 4, 1, Music_SproutTower_Ch1
-	musicheader 1, 2, Music_SproutTower_Ch2
-	musicheader 1, 3, Music_SproutTower_Ch3
-	musicheader 1, 4, Music_SproutTower_Ch4
+	channel_count 4
+	channel 1, Music_SproutTower_Ch1
+	channel 2, Music_SproutTower_Ch2
+	channel 3, Music_SproutTower_Ch3
+	channel 4, Music_SproutTower_Ch4
 
 Music_SproutTower_Ch1:
 	tempo 176

--- a/audio/music/ssaqua.asm
+++ b/audio/music/ssaqua.asm
@@ -1,8 +1,9 @@
 Music_SSAqua:
-	musicheader 4, 1, Music_SSAqua_Ch1
-	musicheader 1, 2, Music_SSAqua_Ch2
-	musicheader 1, 3, Music_SSAqua_Ch3
-	musicheader 1, 4, Music_SSAqua_Ch4
+	channel_count 4
+	channel 1, Music_SSAqua_Ch1
+	channel 2, Music_SSAqua_Ch2
+	channel 3, Music_SSAqua_Ch3
+	channel 4, Music_SSAqua_Ch4
 
 Music_SSAqua_Ch1:
 	tempo 117

--- a/audio/music/stadium/mewtwobattle.asm
+++ b/audio/music/stadium/mewtwobattle.asm
@@ -3,10 +3,11 @@
 ; https://soundcloud.com/user-927422935-571023782/battle-with-mewtwo-8-bit
 
 Music_MewtwoBattleStadium:
-	musicheader 4, 1, Music_MewtwoBattleStadium_Ch1
-	musicheader 1, 2, Music_MewtwoBattleStadium_Ch2
-	musicheader 1, 3, Music_MewtwoBattleStadium_Ch3
-	musicheader 1, 4, Music_MewtwoBattleStadium_Ch4
+	channel_count 4
+	channel 1, Music_MewtwoBattleStadium_Ch1
+	channel 2, Music_MewtwoBattleStadium_Ch2
+	channel 3, Music_MewtwoBattleStadium_Ch3
+	channel 4, Music_MewtwoBattleStadium_Ch4
 
 Music_MewtwoBattleStadium_Ch1:
 	tempo $78

--- a/audio/music/successfulcapture.asm
+++ b/audio/music/successfulcapture.asm
@@ -1,7 +1,8 @@
 Music_SuccessfulCapture:
-	musicheader 3, 1, Music_SuccessfulCapture_Ch1
-	musicheader 1, 2, Music_SuccessfulCapture_Ch2
-	musicheader 1, 3, Music_SuccessfulCapture_Ch3
+	channel_count 3
+	channel 1, Music_SuccessfulCapture_Ch1
+	channel 2, Music_SuccessfulCapture_Ch2
+	channel 3, Music_SuccessfulCapture_Ch3
 
 Music_SuccessfulCapture_Ch1:
 	tempo 126

--- a/audio/music/suicunebattle.asm
+++ b/audio/music/suicunebattle.asm
@@ -1,7 +1,8 @@
 Music_SuicuneBattle:
-	musicheader 3, 1, Music_SuicuneBattle_Ch1
-	musicheader 1, 2, Music_SuicuneBattle_Ch2
-	musicheader 1, 3, Music_SuicuneBattle_Ch3
+	channel_count 3
+	channel 1, Music_SuicuneBattle_Ch1
+	channel 2, Music_SuicuneBattle_Ch2
+	channel 3, Music_SuicuneBattle_Ch3
 
 Music_SuicuneBattle_Ch1:
 	tempo 101

--- a/audio/music/surf.asm
+++ b/audio/music/surf.asm
@@ -1,7 +1,8 @@
 Music_Surf:
-	musicheader 3, 1, Music_Surf_Ch1
-	musicheader 1, 2, Music_Surf_Ch2
-	musicheader 1, 3, Music_Surf_Ch3
+	channel_count 3
+	channel 1, Music_Surf_Ch1
+	channel 2, Music_Surf_Ch2
+	channel 3, Music_Surf_Ch3
 
 Music_Surf_Ch1:
 	tempo 108

--- a/audio/music/swsh/gymleaderbattle.asm
+++ b/audio/music/swsh/gymleaderbattle.asm
@@ -3,10 +3,11 @@
 ; https://soundcloud.com/user-927422935-571023782/swsh-gym-leader-theme-8-bit-by-shinkonetcavy
 
 Music_GymLeaderBattleSwSh:
-	musicheader 4, 1, Music_GymLeaderBattleSwSh_Ch1
-	musicheader 1, 2, Music_GymLeaderBattleSwSh_Ch2
-	musicheader 1, 3, Music_GymLeaderBattleSwSh_Ch3
-	musicheader 1, 4, Music_GymLeaderBattleSwSh_Ch4
+	channel_count 4
+	channel 1, Music_GymLeaderBattleSwSh_Ch1
+	channel 2, Music_GymLeaderBattleSwSh_Ch2
+	channel 3, Music_GymLeaderBattleSwSh_Ch3
+	channel 4, Music_GymLeaderBattleSwSh_Ch4
 
 Music_GymLeaderBattleSwSh_Ch1:
 	tempo $89

--- a/audio/music/tintower.asm
+++ b/audio/music/tintower.asm
@@ -1,8 +1,9 @@
 Music_TinTower:
-	musicheader 4, 1, Music_TinTower_Ch1
-	musicheader 1, 2, Music_TinTower_Ch2
-	musicheader 1, 3, Music_TinTower_Ch3
-	musicheader 1, 4, Music_TinTower_Ch4
+	channel_count 4
+	channel 1, Music_TinTower_Ch1
+	channel 2, Music_TinTower_Ch2
+	channel 3, Music_TinTower_Ch3
+	channel 4, Music_TinTower_Ch4
 
 Music_TinTower_Ch1:
 	tempo 208

--- a/audio/music/titlescreen.asm
+++ b/audio/music/titlescreen.asm
@@ -1,8 +1,9 @@
 Music_TitleScreen:
-	musicheader 4, 1, Music_TitleScreen_Ch1
-	musicheader 1, 2, Music_TitleScreen_Ch2
-	musicheader 1, 3, Music_TitleScreen_Ch3
-	musicheader 1, 4, Music_TitleScreen_Ch4
+	channel_count 4
+	channel 1, Music_TitleScreen_Ch1
+	channel 2, Music_TitleScreen_Ch2
+	channel 3, Music_TitleScreen_Ch3
+	channel 4, Music_TitleScreen_Ch4
 
 Music_TitleScreen_Ch1:
 	tempo 134

--- a/audio/music/trainervictory.asm
+++ b/audio/music/trainervictory.asm
@@ -1,7 +1,8 @@
 Music_TrainerVictory:
-	musicheader 3, 1, Music_TrainerVictory_Ch1
-	musicheader 1, 2, Music_TrainerVictory_Ch2
-	musicheader 1, 3, Music_TrainerVictory_Ch3
+	channel_count 3
+	channel 1, Music_TrainerVictory_Ch1
+	channel 2, Music_TrainerVictory_Ch2
+	channel 3, Music_TrainerVictory_Ch3
 
 Music_TrainerVictory_Ch1:
 	tempo 120

--- a/audio/music/undertale/megalovania.asm
+++ b/audio/music/undertale/megalovania.asm
@@ -2,10 +2,11 @@
 ; Demixed by Shockslayer
 
 Music_Megalovania:
-	musicheader 4, 1, Music_Megalovania_Ch1
-	musicheader 1, 2, Music_Megalovania_Ch2
-	musicheader 1, 3, Music_Megalovania_Ch3
-	musicheader 1, 4, Music_Megalovania_Ch4
+	channel_count 4
+	channel 1, Music_Megalovania_Ch1
+	channel 2, Music_Megalovania_Ch2
+	channel 3, Music_Megalovania_Ch3
+	channel 4, Music_Megalovania_Ch4
 
 Music_Megalovania_Ch1:
 	tempo $A0

--- a/audio/music/unioncave.asm
+++ b/audio/music/unioncave.asm
@@ -1,8 +1,9 @@
 Music_UnionCave:
-	musicheader 4, 1, Music_UnionCave_Ch1
-	musicheader 1, 2, Music_UnionCave_Ch2
-	musicheader 1, 3, Music_UnionCave_Ch3
-	musicheader 1, 4, Music_UnionCave_Ch4
+	channel_count 4
+	channel 1, Music_UnionCave_Ch1
+	channel 2, Music_UnionCave_Ch2
+	channel 3, Music_UnionCave_Ch3
+	channel 4, Music_UnionCave_Ch4
 
 Music_UnionCave_Ch1:
 	tempo 160

--- a/audio/music/vermilioncity.asm
+++ b/audio/music/vermilioncity.asm
@@ -1,7 +1,8 @@
 Music_VermilionCity:
-	musicheader 3, 1, Music_VermilionCity_Ch1
-	musicheader 1, 2, Music_VermilionCity_Ch2
-	musicheader 1, 3, Music_VermilionCity_Ch3
+	channel_count 3
+	channel 1, Music_VermilionCity_Ch1
+	channel 2, Music_VermilionCity_Ch2
+	channel 3, Music_VermilionCity_Ch3
 
 Music_VermilionCity_Ch1:
 	stereopanning $f

--- a/audio/music/victoryroad.asm
+++ b/audio/music/victoryroad.asm
@@ -1,8 +1,9 @@
 Music_VictoryRoad:
-	musicheader 4, 1, Music_VictoryRoad_Ch1
-	musicheader 1, 2, Music_VictoryRoad_Ch2
-	musicheader 1, 3, Music_VictoryRoad_Ch3
-	musicheader 1, 4, Music_VictoryRoad_Ch4
+	channel_count 4
+	channel 1, Music_VictoryRoad_Ch1
+	channel 2, Music_VictoryRoad_Ch2
+	channel 3, Music_VictoryRoad_Ch3
+	channel 4, Music_VictoryRoad_Ch4
 
 Music_VictoryRoad_Ch1:
 	tempo 144

--- a/audio/music/violetcity.asm
+++ b/audio/music/violetcity.asm
@@ -1,8 +1,9 @@
 Music_VioletCity:
-	musicheader 4, 1, Music_VioletCity_Ch1
-	musicheader 1, 2, Music_VioletCity_Ch2
-	musicheader 1, 3, Music_VioletCity_Ch3
-	musicheader 1, 4, Music_VioletCity_Ch4
+	channel_count 4
+	channel 1, Music_VioletCity_Ch1
+	channel 2, Music_VioletCity_Ch2
+	channel 3, Music_VioletCity_Ch3
+	channel 4, Music_VioletCity_Ch4
 
 Music_VioletCity_Ch1:
 	tempo 164

--- a/audio/music/viridiancity.asm
+++ b/audio/music/viridiancity.asm
@@ -1,8 +1,9 @@
 Music_ViridianCity:
-	musicheader 4, 1, Music_ViridianCity_Ch1
-	musicheader 1, 2, Music_ViridianCity_Ch2
-	musicheader 1, 3, Music_ViridianCity_Ch3
-	musicheader 1, 4, Music_ViridianCity_Ch4
+	channel_count 4
+	channel 1, Music_ViridianCity_Ch1
+	channel 2, Music_ViridianCity_Ch2
+	channel 3, Music_ViridianCity_Ch3
+	channel 4, Music_ViridianCity_Ch4
 
 Music_ViridianCity_Ch1:
 	tempo 157

--- a/audio/music/viridianforest.asm
+++ b/audio/music/viridianforest.asm
@@ -1,8 +1,9 @@
 Music_ViridianForest:
-	musicheader 4, 1, Music_ViridianForest_Ch1
-	musicheader 1, 2, Music_ViridianForest_Ch2
-	musicheader 1, 3, Music_ViridianForest_Ch3
-	musicheader 1, 4, Music_ViridianForest_Ch4
+	channel_count 4
+	channel 1, Music_ViridianForest_Ch1
+	channel 2, Music_ViridianForest_Ch2
+	channel 3, Music_ViridianForest_Ch3
+	channel 4, Music_ViridianForest_Ch4
 
 Music_ViridianForest_Ch1:
 	tempo 151

--- a/audio/music/wildpokemonvictory.asm
+++ b/audio/music/wildpokemonvictory.asm
@@ -1,7 +1,8 @@
 Music_WildPokemonVictory:
-	musicheader 3, 1, Music_WildPokemonVictory_Ch1
-	musicheader 1, 2, Music_WildPokemonVictory_Ch2
-	musicheader 1, 3, Music_WildPokemonVictory_Ch3
+	channel_count 3
+	channel 1, Music_WildPokemonVictory_Ch1
+	channel 2, Music_WildPokemonVictory_Ch2
+	channel 3, Music_WildPokemonVictory_Ch3
 
 Music_WildPokemonVictory_Ch1:
 	tempo 126

--- a/audio/music/xy/frostcavern.asm
+++ b/audio/music/xy/frostcavern.asm
@@ -4,9 +4,10 @@
 ; https://hax.iimarckus.org/topic/6777/8/
 
 Music_FrostCavernXY:
-	musicheader 3, 1, Music_FrostCavernXY_Ch1
-	musicheader 1, 2, Music_FrostCavernXY_Ch2
-	musicheader 1, 3, Music_FrostCavernXY_Ch3
+	channel_count 3
+	channel 1, Music_FrostCavernXY_Ch1
+	channel 2, Music_FrostCavernXY_Ch2
+	channel 3, Music_FrostCavernXY_Ch3
 
 Music_FrostCavernXY_Ch1:
 	tempo 152

--- a/audio/music/xy/gymleaderbattle.asm
+++ b/audio/music/xy/gymleaderbattle.asm
@@ -3,10 +3,11 @@
 ; https://hax.iimarckus.org/topic/6443/
 
 Music_GymLeaderBattleXY:
-	musicheader 4, 1, Music_GymLeaderBattleXY_Ch1
-	musicheader 1, 2, Music_GymLeaderBattleXY_Ch2
-	musicheader 1, 3, Music_GymLeaderBattleXY_Ch3
-	musicheader 1, 4, Music_GymLeaderBattleXY_Ch4
+	channel_count 4
+	channel 1, Music_GymLeaderBattleXY_Ch1
+	channel 2, Music_GymLeaderBattleXY_Ch2
+	channel 3, Music_GymLeaderBattleXY_Ch3
+	channel 4, Music_GymLeaderBattleXY_Ch4
 
 Music_GymLeaderBattleXY_Ch1:
 	tempo $82

--- a/audio/music/xy/laverrecity.asm
+++ b/audio/music/xy/laverrecity.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/
 
 Music_LaverreCityXY:
-	musicheader 4, 1, Music_LaverreCityXY_Ch1
-	musicheader 1, 2, Music_LaverreCityXY_Ch2
-	musicheader 1, 3, Music_LaverreCityXY_Ch3
-	musicheader 1, 4, Music_LaverreCityXY_Ch4
+	channel_count 4
+	channel 1, Music_LaverreCityXY_Ch1
+	channel 2, Music_LaverreCityXY_Ch2
+	channel 3, Music_LaverreCityXY_Ch3
+	channel 4, Music_LaverreCityXY_Ch4
 
 Music_LaverreCityXY_Ch1:
 	tempo 120

--- a/audio/music/xy/legendarybattle.asm
+++ b/audio/music/xy/legendarybattle.asm
@@ -4,9 +4,10 @@
 ; https://hax.iimarckus.org/topic/6777/9/
 
 Music_LegendaryBattleXY:
-	musicheader 3, 1, Music_LegendaryBattleXY_Ch1
-	musicheader 1, 2, Music_LegendaryBattleXY_Ch2
-	musicheader 1, 3, Music_LegendaryBattleXY_Ch3
+	channel_count 3
+	channel 1, Music_LegendaryBattleXY_Ch1
+	channel 2, Music_LegendaryBattleXY_Ch2
+	channel 3, Music_LegendaryBattleXY_Ch3
 
 Music_LegendaryBattleXY_Ch1:
 	vibrato $12, $15

--- a/audio/music/xy/powerplant.asm
+++ b/audio/music/xy/powerplant.asm
@@ -3,10 +3,11 @@
 ; https://github.com/huderlem/pokestyle-music-devamps/blob/master/music/kalos_powerplant.asm
 
 Music_PowerPlantXY:
-	musicheader 4, 1, Music_PowerPlantXY_Ch1
-	musicheader 1, 2, Music_PowerPlantXY_Ch2
-	musicheader 1, 3, Music_PowerPlantXY_Ch3
-	musicheader 1, 4, Music_PowerPlantXY_Ch4
+	channel_count 4
+	channel 1, Music_PowerPlantXY_Ch1
+	channel 2, Music_PowerPlantXY_Ch2
+	channel 3, Music_PowerPlantXY_Ch3
+	channel 4, Music_PowerPlantXY_Ch4
 
 Music_PowerPlantXY_Ch1:
 	tempo 175

--- a/audio/music/xy/rivalbattle.asm
+++ b/audio/music/xy/rivalbattle.asm
@@ -4,10 +4,11 @@
 ; https://hax.iimarckus.org/topic/6777/3/
 
 Music_RivalBattleXY:
-	musicheader 4, 1, Music_RivalBattleXY_Ch1
-	musicheader 1, 2, Music_RivalBattleXY_Ch2
-	musicheader 1, 3, Music_RivalBattleXY_Ch3
-	musicheader 1, 4, Music_RivalBattleXY_Ch4
+	channel_count 4
+	channel 1, Music_RivalBattleXY_Ch1
+	channel 2, Music_RivalBattleXY_Ch2
+	channel 3, Music_RivalBattleXY_Ch3
+	channel 4, Music_RivalBattleXY_Ch4
 
 Music_RivalBattleXY_Ch1:
 	tempo 116

--- a/audio/music/xy/scaryhouse.asm
+++ b/audio/music/xy/scaryhouse.asm
@@ -4,9 +4,10 @@
 ; https://hax.iimarckus.org/topic/6777/9/
 
 Music_ScaryHouseXY:
-	musicheader 3, 1, Music_ScaryHouseXY_Ch1
-	musicheader 1, 2, Music_ScaryHouseXY_Ch2
-	musicheader 1, 3, Music_ScaryHouseXY_Ch3
+	channel_count 3
+	channel 1, Music_ScaryHouseXY_Ch1
+	channel 2, Music_ScaryHouseXY_Ch2
+	channel 3, Music_ScaryHouseXY_Ch3
 
 Music_ScaryHouseXY_Ch1:
 	vibrato $12, $15

--- a/audio/music/xy/titlescreen.asm
+++ b/audio/music/xy/titlescreen.asm
@@ -3,10 +3,11 @@
 ; https://github.com/huderlem/pokestyle-music-devamps/blob/master/music/kalos_titlescreen.asm
 
 Music_TitleScreenXY:
-	musicheader 4, 1, Music_TitleScreenXY_Ch1
-	musicheader 1, 2, Music_TitleScreenXY_Ch2
-	musicheader 1, 3, Music_TitleScreenXY_Ch3
-	musicheader 1, 4, Music_TitleScreenXY_Ch4
+	channel_count 4
+	channel 1, Music_TitleScreenXY_Ch1
+	channel 2, Music_TitleScreenXY_Ch2
+	channel 3, Music_TitleScreenXY_Ch3
+	channel 4, Music_TitleScreenXY_Ch4
 
 Music_TitleScreenXY_Ch1:
 	tempo 125

--- a/audio/sfx.asm
+++ b/audio/sfx.asm
@@ -1,7 +1,8 @@
 SECTION "Sfx_PokeballsPlacedOnTable", ROMX
 
 Sfx_PokeballsPlacedOnTable:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -16,7 +17,8 @@ Sfx_PokeballsPlacedOnTable:
 SECTION "Sfx_BallWiggle", ROMX
 
 Sfx_BallWiggle:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -31,7 +33,8 @@ Sfx_BallWiggle:
 SECTION "Sfx_Potion", ROMX
 
 Sfx_Potion:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -45,7 +48,8 @@ Sfx_Potion:
 SECTION "Sfx_FullHeal", ROMX
 
 Sfx_FullHeal:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -61,7 +65,8 @@ Sfx_FullHeal:
 SECTION "Sfx_Menu", ROMX
 
 Sfx_Menu:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  2, $e2, $33
@@ -73,7 +78,8 @@ SECTION "Sfx_ReadText", ROMX
 
 Sfx_ReadText:
 Sfx_ReadText2:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -87,7 +93,8 @@ Sfx_ReadText2:
 SECTION "Sfx_Poison", ROMX
 
 Sfx_Poison:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 .loop:
@@ -103,7 +110,8 @@ Sfx_Poison:
 SECTION "Sfx_GotSafariBalls", ROMX
 
 Sfx_GotSafariBalls:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -117,7 +125,8 @@ Sfx_GotSafariBalls:
 SECTION "Sfx_BootPc", ROMX
 
 Sfx_BootPc:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -137,7 +146,8 @@ Sfx_BootPc:
 SECTION "Sfx_ShutDownPc", ROMX
 
 Sfx_ShutDownPc:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -151,7 +161,8 @@ Sfx_ShutDownPc:
 SECTION "Sfx_ChoosePcOption", ROMX
 
 Sfx_ChoosePcOption:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -165,7 +176,8 @@ Sfx_ChoosePcOption:
 SECTION "Sfx_EscapeRope", ROMX
 
 Sfx_EscapeRope:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $1
@@ -182,7 +194,8 @@ Sfx_EscapeRope:
 SECTION "Sfx_PushButton", ROMX
 
 Sfx_PushButton:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -197,7 +210,8 @@ Sfx_PushButton:
 SECTION "Sfx_SecondPartOfItemfinder", ROMX
 
 Sfx_SecondPartOfItemfinder:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -213,7 +227,8 @@ Sfx_SecondPartOfItemfinder:
 SECTION "Sfx_WarpTo", ROMX
 
 Sfx_WarpTo:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $1
@@ -230,7 +245,8 @@ Sfx_WarpTo:
 SECTION "Sfx_WarpFrom", ROMX
 
 Sfx_WarpFrom:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $1
@@ -247,7 +263,8 @@ Sfx_WarpFrom:
 SECTION "Sfx_ChangeDexMode", ROMX
 
 Sfx_ChangeDexMode:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $1
@@ -260,7 +277,8 @@ Sfx_ChangeDexMode:
 SECTION "Sfx_JumpOverLedge", ROMX
 
 Sfx_JumpOverLedge:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -273,7 +291,8 @@ Sfx_JumpOverLedge:
 SECTION "Sfx_GrassRustle", ROMX
 
 Sfx_GrassRustle:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $f1, $32
@@ -286,7 +305,8 @@ Sfx_GrassRustle:
 SECTION "Sfx_Fly", ROMX
 
 Sfx_Fly:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $f1, $12
@@ -311,8 +331,9 @@ Sfx_Fly:
 SECTION "Sfx_Wrong", ROMX
 
 Sfx_Wrong:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 6, .Ch6
+	channel_count 2
+	channel 5, .Ch5
+	channel 6, .Ch6
 
 .Ch5:
 	dutycycle $3
@@ -336,7 +357,8 @@ Sfx_Wrong:
 SECTION "Sfx_Squeak", ROMX
 
 Sfx_Squeak:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $0
@@ -349,7 +371,8 @@ Sfx_Squeak:
 SECTION "Sfx_Strength", ROMX
 
 Sfx_Strength:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  5, $a2, $23
@@ -366,8 +389,9 @@ Sfx_Strength:
 SECTION "Sfx_Boat", ROMX
 
 Sfx_Boat:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 6, .Ch6
+	channel_count 2
+	channel 5, .Ch5
+	channel 6, .Ch6
 
 .Ch5:
 	dutycycle $2
@@ -395,7 +419,8 @@ Sfx_Boat:
 SECTION "Sfx_WallOpen", ROMX
 
 Sfx_WallOpen:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $1
@@ -414,7 +439,8 @@ Sfx_WallOpen:
 SECTION "Sfx_PlacePuzzlePieceDown", ROMX
 
 Sfx_PlacePuzzlePieceDown:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $f7, $24
@@ -428,7 +454,8 @@ Sfx_PlacePuzzlePieceDown:
 SECTION "Sfx_EnterDoor", ROMX
 
 Sfx_EnterDoor:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __, 10, $f1, $44
@@ -439,8 +466,9 @@ Sfx_EnterDoor:
 SECTION "Sfx_SwitchPokemon", ROMX
 
 Sfx_SwitchPokemon:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 6, .Ch6
+	channel_count 2
+	channel 5, .Ch5
+	channel 6, .Ch6
 
 .Ch5:
 	dutycycle $2
@@ -457,8 +485,9 @@ Sfx_SwitchPokemon:
 SECTION "Sfx_Tally", ROMX
 
 Sfx_Tally:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 6, .Ch6
+	channel_count 2
+	channel 5, .Ch5
+	channel 6, .Ch6
 
 .Ch5:
 	dutycycle $2
@@ -475,8 +504,9 @@ Sfx_Tally:
 SECTION "Sfx_Transaction", ROMX
 
 Sfx_Transaction:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 6, .Ch6
+	channel_count 2
+	channel 5, .Ch5
+	channel 6, .Ch6
 
 .Ch5:
 	dutycycle $2
@@ -495,7 +525,8 @@ Sfx_Transaction:
 SECTION "Sfx_Bump", ROMX
 
 Sfx_Bump:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -508,7 +539,8 @@ Sfx_Bump:
 SECTION "Sfx_ExitBuilding", ROMX
 
 Sfx_ExitBuilding:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $f1, $54
@@ -522,8 +554,9 @@ Sfx_ExitBuilding:
 SECTION "Sfx_Save", ROMX
 
 Sfx_Save:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 6, .Ch6
+	channel_count 2
+	channel 5, .Ch5
+	channel 6, .Ch6
 
 .Ch5:
 	dutycycle $2
@@ -552,7 +585,8 @@ Sfx_Save:
 SECTION "Sfx_Pokeflute", ROMX
 
 Sfx_Pokeflute:
-	musicheader 1, 7, .Ch7
+	channel_count 1
+	channel 7, .Ch7
 
 .Ch7:
 	tempo 256
@@ -583,7 +617,8 @@ Sfx_Pokeflute:
 SECTION "Sfx_ElevatorEnd", ROMX
 
 Sfx_ElevatorEnd:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -599,8 +634,9 @@ Sfx_ElevatorEnd:
 SECTION "Sfx_ThrowBall", ROMX
 
 Sfx_ThrowBall:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 6, .Ch6
+	channel_count 2
+	channel 5, .Ch5
+	channel 6, .Ch6
 
 .Ch5:
 	dutycycle $2
@@ -617,8 +653,9 @@ Sfx_ThrowBall:
 SECTION "Sfx_BallPoof", ROMX
 
 Sfx_BallPoof:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 8, .Ch8
+	channel_count 2
+	channel 5, .Ch5
+	channel 8, .Ch8
 
 .Ch5:
 	dutycycle $2
@@ -635,8 +672,9 @@ Sfx_BallPoof:
 SECTION "Sfx_Faint", ROMX
 
 Sfx_Faint:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 8, .Ch8
+	channel_count 2
+	channel 5, .Ch5
+	channel 8, .Ch8
 
 .Ch5:
 	sound __, 16, $d1, $0200
@@ -653,7 +691,8 @@ Sfx_Faint:
 SECTION "Sfx_Run", ROMX
 
 Sfx_Run:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $61, $23
@@ -673,8 +712,9 @@ Sfx_Run:
 SECTION "Sfx_SlotMachineStart", ROMX
 
 Sfx_SlotMachineStart:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 6, .Ch6
+	channel_count 2
+	channel 5, .Ch5
+	channel 6, .Ch6
 
 .Ch5:
 	dutycycle $2
@@ -695,7 +735,8 @@ Sfx_SlotMachineStart:
 SECTION "Sfx_Call", ROMX
 
 Sfx_Call:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	soundinput $67
@@ -712,7 +753,8 @@ Sfx_Call:
 SECTION "Sfx_Unknown60", ROMX
 
 Sfx_Unknown60:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  7, $20, $10
@@ -729,7 +771,8 @@ Sfx_Unknown60:
 SECTION "Sfx_Unknown61", ROMX
 
 Sfx_Unknown61:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  5, $d1, $41
@@ -739,7 +782,8 @@ Sfx_Unknown61:
 SECTION "Sfx_SwitchPockets", ROMX
 
 Sfx_SwitchPockets:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  5, $c1, $42
@@ -749,7 +793,8 @@ Sfx_SwitchPockets:
 SECTION "Sfx_Unknown63", ROMX
 
 Sfx_Unknown63:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $6f, $21
@@ -761,7 +806,8 @@ Sfx_Unknown63:
 SECTION "Sfx_Burn", ROMX
 
 Sfx_Burn:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $d2, $32
@@ -772,7 +818,8 @@ Sfx_Burn:
 SECTION "Sfx_TitleScreenEntrance", ROMX
 
 Sfx_TitleScreenEntrance:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $70, $22
@@ -787,7 +834,8 @@ Sfx_TitleScreenEntrance:
 SECTION "Sfx_Unknown66", ROMX
 
 Sfx_Unknown66:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -800,7 +848,8 @@ Sfx_Unknown66:
 SECTION "Sfx_GetCoinFromSlots", ROMX
 
 Sfx_GetCoinFromSlots:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -812,8 +861,9 @@ Sfx_GetCoinFromSlots:
 SECTION "Sfx_PayDay", ROMX
 
 Sfx_PayDay:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 6, .Ch6
+	channel_count 2
+	channel 5, .Ch5
+	channel 6, .Ch6
 
 .Ch5:
 	dutycycle $3
@@ -833,7 +883,8 @@ Sfx_PayDay:
 SECTION "Sfx_Metronome", ROMX
 
 Sfx_Metronome:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -854,7 +905,8 @@ Sfx_Metronome:
 SECTION "Sfx_Peck", ROMX
 
 Sfx_Peck:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $a1, $12
@@ -864,7 +916,8 @@ Sfx_Peck:
 SECTION "Sfx_Kinesis", ROMX
 
 Sfx_Kinesis:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $1
@@ -877,7 +930,8 @@ Sfx_Kinesis:
 SECTION "Sfx_Lick", ROMX
 
 Sfx_Lick:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $1
@@ -890,7 +944,8 @@ Sfx_Lick:
 SECTION "Sfx_Pound", ROMX
 
 Sfx_Pound:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $a1, $22
@@ -900,7 +955,8 @@ Sfx_Pound:
 SECTION "Sfx_MovePuzzlePiece", ROMX
 
 Sfx_MovePuzzlePiece:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  9, $f1, $54
@@ -910,7 +966,8 @@ Sfx_MovePuzzlePiece:
 SECTION "Sfx_CometPunch", ROMX
 
 Sfx_CometPunch:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __, 16, $8f, $11
@@ -922,7 +979,8 @@ Sfx_CometPunch:
 SECTION "Sfx_MegaPunch", ROMX
 
 Sfx_MegaPunch:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __, 16, $8f, $34
@@ -934,7 +992,8 @@ Sfx_MegaPunch:
 SECTION "Sfx_Scratch", ROMX
 
 Sfx_Scratch:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __, 16, $9f, $23
@@ -945,7 +1004,8 @@ Sfx_Scratch:
 SECTION "Sfx_Vicegrip", ROMX
 
 Sfx_Vicegrip:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $e1, $4b
@@ -958,7 +1018,8 @@ Sfx_Vicegrip:
 SECTION "Sfx_RazorWind", ROMX
 
 Sfx_RazorWind:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $f4, $44
@@ -970,7 +1031,8 @@ Sfx_RazorWind:
 SECTION "Sfx_Cut", ROMX
 
 Sfx_Cut:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  5, $8f, $55
@@ -983,7 +1045,8 @@ Sfx_Cut:
 SECTION "Sfx_WingAttack", ROMX
 
 Sfx_WingAttack:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 .branch8:
@@ -997,7 +1060,8 @@ Sfx_WingAttack:
 SECTION "Sfx_Whirlwind", ROMX
 
 Sfx_Whirlwind:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  9, $4f, $33
@@ -1010,7 +1074,8 @@ Sfx_Whirlwind:
 SECTION "Sfx_Bind", ROMX
 
 Sfx_Bind:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  9, $ff, $32
@@ -1023,7 +1088,8 @@ Sfx_Bind:
 SECTION "Sfx_VineWhip", ROMX
 
 Sfx_VineWhip:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  2, $c2, $33
@@ -1040,7 +1106,8 @@ Sfx_VineWhip:
 SECTION "Sfx_DoubleKick", ROMX
 
 Sfx_DoubleKick:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  2, $94, $23
@@ -1052,7 +1119,8 @@ Sfx_DoubleKick:
 SECTION "Sfx_MegaKick", ROMX
 
 Sfx_MegaKick:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $94, $33
@@ -1065,7 +1133,8 @@ Sfx_MegaKick:
 SECTION "Sfx_Headbutt", ROMX
 
 Sfx_Headbutt:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  5, $ff, $55
@@ -1076,7 +1145,8 @@ Sfx_Headbutt:
 SECTION "Sfx_HornAttack", ROMX
 
 Sfx_HornAttack:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $84, $43
@@ -1088,7 +1158,8 @@ Sfx_HornAttack:
 SECTION "Sfx_Tackle", ROMX
 
 Sfx_Tackle:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  5, $f1, $34
@@ -1099,7 +1170,8 @@ Sfx_Tackle:
 SECTION "Sfx_PoisonSting", ROMX
 
 Sfx_PoisonSting:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $f1, $22
@@ -1110,7 +1182,8 @@ Sfx_PoisonSting:
 SECTION "Sfx_Powder", ROMX
 
 Sfx_Powder:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $c2, $1
@@ -1122,7 +1195,8 @@ Sfx_Powder:
 SECTION "Sfx_DoubleSlap", ROMX
 
 Sfx_DoubleSlap:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  9, $f1, $32
@@ -1133,8 +1207,9 @@ Sfx_DoubleSlap:
 SECTION "Sfx_Bite", ROMX
 
 Sfx_Bite:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 8, .Ch8
+	channel_count 2
+	channel 5, .Ch5
+	channel 8, .Ch8
 
 .Ch5:
 	dutycycle $0
@@ -1156,7 +1231,8 @@ Sfx_Bite:
 SECTION "Sfx_JumpKick", ROMX
 
 Sfx_JumpKick:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  4, $92, $31
@@ -1169,7 +1245,8 @@ Sfx_JumpKick:
 SECTION "Sfx_Stomp", ROMX
 
 Sfx_Stomp:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __, 13, $f1, $54
@@ -1180,7 +1257,8 @@ Sfx_Stomp:
 SECTION "Sfx_TailWhip", ROMX
 
 Sfx_TailWhip:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $f1, $33
@@ -1194,7 +1272,8 @@ Sfx_TailWhip:
 SECTION "Sfx_KarateChop", ROMX
 
 Sfx_KarateChop:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $d2, $32
@@ -1205,7 +1284,8 @@ Sfx_KarateChop:
 SECTION "Sfx_Submission", ROMX
 
 Sfx_Submission:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $f2, $43
@@ -1219,8 +1299,9 @@ Sfx_Submission:
 SECTION "Sfx_WaterGun", ROMX
 
 Sfx_WaterGun:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 8, .Ch8
+	channel_count 2
+	channel 5, .Ch5
+	channel 8, .Ch8
 
 .Ch5:
 	dutycycle $1
@@ -1238,7 +1319,8 @@ Sfx_WaterGun:
 SECTION "Sfx_SwordsDance", ROMX
 
 Sfx_SwordsDance:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __, 16, $4f, $41
@@ -1252,7 +1334,8 @@ Sfx_SwordsDance:
 SECTION "Sfx_Thunder", ROMX
 
 Sfx_Thunder:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __, 11, $ff, $50
@@ -1268,9 +1351,10 @@ Sfx_Thunder:
 SECTION "Sfx_Supersonic", ROMX
 
 Sfx_Supersonic:
-	musicheader 3, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 8, .Ch8
+	channel_count 3
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 8, .Ch8
 
 .Ch5:
 	dutycycle $2
@@ -1301,9 +1385,10 @@ Sfx_Supersonic:
 SECTION "Sfx_Leer", ROMX
 
 Sfx_Leer:
-	musicheader 3, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 8, .Ch8
+	channel_count 3
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 8, .Ch8
 
 .Ch5:
 .branch5:
@@ -1332,8 +1417,9 @@ Sfx_Leer:
 SECTION "Sfx_Ember", ROMX
 
 Sfx_Ember:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 8, .Ch8
+	channel_count 2
+	channel 5, .Ch5
+	channel 8, .Ch8
 
 .Ch5:
 .branch5:
@@ -1359,9 +1445,10 @@ Sfx_Ember:
 SECTION "Sfx_BubbleBeam", ROMX
 
 Sfx_BubbleBeam:
-	musicheader 3, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 8, .Ch8
+	channel_count 3
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 8, .Ch8
 
 .Ch5:
 .branch5:
@@ -1397,8 +1484,9 @@ Sfx_BubbleBeam:
 SECTION "Sfx_HydroPump", ROMX
 
 Sfx_HydroPump:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 8, .Ch8
+	channel_count 2
+	channel 5, .Ch5
+	channel 8, .Ch8
 
 .Ch5:
 .branch5:
@@ -1427,9 +1515,10 @@ Sfx_HydroPump:
 SECTION "Sfx_Surf", ROMX
 
 Sfx_Surf:
-	musicheader 3, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 8, .Ch8
+	channel_count 3
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 8, .Ch8
 
 .Ch5:
 .branch5:
@@ -1462,9 +1551,10 @@ Sfx_Surf:
 SECTION "Sfx_Psybeam", ROMX
 
 Sfx_Psybeam:
-	musicheader 3, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 8, .Ch8
+	channel_count 3
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 8, .Ch8
 
 .Ch5:
 .branch5:
@@ -1497,9 +1587,10 @@ Sfx_Psybeam:
 SECTION "Sfx_Charge", ROMX
 
 Sfx_Charge:
-	musicheader 3, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 8, .Ch8
+	channel_count 3
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 8, .Ch8
 
 .Ch5:
 .branch5:
@@ -1534,9 +1625,10 @@ Sfx_Charge:
 SECTION "Sfx_Thundershock", ROMX
 
 Sfx_Thundershock:
-	musicheader 3, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 8, .Ch8
+	channel_count 3
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 8, .Ch8
 
 .Ch5:
 .branch5:
@@ -1565,9 +1657,10 @@ Sfx_Thundershock:
 SECTION "Sfx_Psychic", ROMX
 
 Sfx_Psychic:
-	musicheader 3, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 8, .Ch8
+	channel_count 3
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 8, .Ch8
 
 .Ch5:
 	dutycycle $2
@@ -1604,8 +1697,9 @@ Sfx_Psychic:
 SECTION "Sfx_Screech", ROMX
 
 Sfx_Screech:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 6, .Ch6
+	channel_count 2
+	channel 5, .Ch5
+	channel 6, .Ch6
 
 .Ch5:
 	dutycycle $2
@@ -1629,8 +1723,9 @@ Sfx_Screech:
 SECTION "Sfx_BoneClub", ROMX
 
 Sfx_BoneClub:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 6, .Ch6
+	channel_count 2
+	channel 5, .Ch5
+	channel 6, .Ch6
 
 .Ch5:
 	dutycycle $2
@@ -1648,8 +1743,9 @@ Sfx_BoneClub:
 SECTION "Sfx_Sharpen", ROMX
 
 Sfx_Sharpen:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 6, .Ch6
+	channel_count 2
+	channel 5, .Ch5
+	channel 6, .Ch6
 
 .Ch5:
 	dutycycle $2
@@ -1673,9 +1769,10 @@ Sfx_Sharpen:
 SECTION "Sfx_EggBomb", ROMX
 
 Sfx_EggBomb:
-	musicheader 3, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 8, .Ch8
+	channel_count 3
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 8, .Ch8
 
 .Ch5:
 	sound_duty 1, 3, 2, 3
@@ -1702,8 +1799,9 @@ Sfx_EggBomb:
 SECTION "Sfx_Sing", ROMX
 
 Sfx_Sing:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 6, .Ch6
+	channel_count 2
+	channel 5, .Ch5
+	channel 6, .Ch6
 
 .Ch5:
 	togglesfx
@@ -1738,9 +1836,10 @@ Sfx_Sing:
 SECTION "Sfx_HyperBeam", ROMX
 
 Sfx_HyperBeam:
-	musicheader 3, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 8, .Ch8
+	channel_count 3
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 8, .Ch8
 
 .Ch5:
 	dutycycle $0
@@ -1793,7 +1892,8 @@ Sfx_HyperBeam:
 SECTION "Sfx_Shine", ROMX
 
 Sfx_Shine:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $0
@@ -1809,10 +1909,12 @@ Sfx_Shine:
 SECTION "Sfx_Unknown5F", ROMX
 
 Sfx_Unknown5F:
-	musicheader 3, 5, Sfx_Unknown5F_Ch5
-	musicheader 1, 6, Sfx_Unknown5F_Ch6
+	channel_count 3
+	channel 5, Sfx_Unknown5F_Ch5
+	channel 6, Sfx_Unknown5F_Ch6
 Sfx_Sandstorm:
-	musicheader 1, 8, Sfx_Sandstorm_Ch8
+	channel_count 1
+	channel 8, Sfx_Sandstorm_Ch8
 
 Sfx_Unknown5F_Ch5:
 .branch5:
@@ -1842,10 +1944,12 @@ Sfx_Sandstorm_Ch8:
 SECTION "Sfx_HangUp", ROMX
 
 Sfx_HangUp:
-	musicheader 1, 5, Sfx_HangUp_Ch5
+	channel_count 1
+	channel 5, Sfx_HangUp_Ch5
 
 Sfx_NoSignal:
-	musicheader 1, 5, Sfx_NoSignal_Ch5
+	channel_count 1
+	channel 5, Sfx_NoSignal_Ch5
 
 Sfx_HangUp_Ch5:
 	dutycycle $2
@@ -1864,10 +1968,11 @@ Sfx_NoSignal_Ch5:
 SECTION "Sfx_Elevator", ROMX
 
 Sfx_Elevator:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	dutycycle $2
@@ -1901,10 +2006,11 @@ SECTION "Sfx_LevelUp", ROMX
 
 Sfx_LevelUp:
 Sfx_DexFanfare5079:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -1961,10 +2067,11 @@ Sfx_DexFanfare5079:
 SECTION "Sfx_KeyItem", ROMX
 
 Sfx_KeyItem:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -2029,10 +2136,11 @@ Sfx_KeyItem:
 SECTION "Sfx_DexFanfare2049", ROMX
 
 Sfx_DexFanfare2049:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -2111,10 +2219,11 @@ Sfx_DexFanfare2049:
 SECTION "Sfx_Item", ROMX
 
 Sfx_Item:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -2188,10 +2297,11 @@ Sfx_Item:
 SECTION "Sfx_CaughtMon", ROMX
 
 Sfx_CaughtMon:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -2268,10 +2378,11 @@ Sfx_CaughtMon:
 SECTION "Sfx_DexFanfare80109", ROMX
 
 Sfx_DexFanfare80109:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -2361,9 +2472,10 @@ Sfx_DexFanfare80109:
 SECTION "Sfx_Fanfare2", ROMX
 
 Sfx_Fanfare2:
-	musicheader 3, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 8, .Ch8
+	channel_count 3
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -2434,10 +2546,11 @@ Sfx_Fanfare2:
 SECTION "UnknownSfx", ROMX
 
 UnknownSfx:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -2514,9 +2627,10 @@ UnknownSfx:
 SECTION "Sfx_Fanfare", ROMX
 
 Sfx_Fanfare:
-	musicheader 3, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 8, .Ch8
+	channel_count 3
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -2613,10 +2727,11 @@ Sfx_Fanfare:
 SECTION "Sfx_RegisterPhoneNumber", ROMX
 
 Sfx_RegisterPhoneNumber:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -2696,9 +2811,10 @@ Sfx_RegisterPhoneNumber:
 SECTION "Sfx_3RdPlace", ROMX
 
 Sfx_3RdPlace:
-	musicheader 3, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
+	channel_count 3
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
 
 .Ch5:
 	togglesfx
@@ -2752,10 +2868,11 @@ SECTION "Sfx_GetEggFromDayCareLady", ROMX
 
 Sfx_GetEggFromDayCareLady:
 Sfx_GetEggFromDayCareMan:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -2845,10 +2962,11 @@ Sfx_GetEggFromDayCareMan:
 SECTION "Sfx_MoveDeleted", ROMX
 
 Sfx_MoveDeleted:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -2951,10 +3069,11 @@ Sfx_MoveDeleted:
 SECTION "Sfx_2ndPlace", ROMX
 
 Sfx_2ndPlace:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -3063,10 +3182,11 @@ Sfx_2ndPlace:
 SECTION "Sfx_1stPlace", ROMX
 
 Sfx_1stPlace:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -3174,10 +3294,11 @@ Sfx_1stPlace:
 SECTION "Sfx_ChooseACard", ROMX
 
 Sfx_ChooseACard:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -3314,10 +3435,11 @@ Sfx_ChooseACard:
 SECTION "Sfx_GetTm", ROMX
 
 Sfx_GetTm:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -3415,10 +3537,11 @@ Sfx_GetTm:
 SECTION "Sfx_GetBadge", ROMX
 
 Sfx_GetBadge:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -3573,10 +3696,11 @@ Sfx_GetBadge:
 SECTION "Sfx_QuitSlots", ROMX
 
 Sfx_QuitSlots:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -3684,8 +3808,9 @@ Sfx_QuitSlots:
 SECTION "Sfx_Protect", ROMX
 
 Sfx_Protect:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 8, .Ch8
+	channel_count 2
+	channel 5, .Ch5
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -3736,7 +3861,8 @@ Sfx_Protect:
 SECTION "Sfx_Sketch", ROMX
 
 Sfx_Sketch:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $1
@@ -3754,7 +3880,8 @@ Sfx_Sketch:
 SECTION "Sfx_RainDance", ROMX
 
 Sfx_RainDance:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 .branch8:
@@ -3773,8 +3900,9 @@ Sfx_RainDance:
 SECTION "Sfx_Aeroblast", ROMX
 
 Sfx_Aeroblast:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 8, .Ch8
+	channel_count 2
+	channel 5, .Ch5
+	channel 8, .Ch8
 
 .Ch5:
 	sound_duty 2, 0, 3, 3
@@ -3794,7 +3922,8 @@ Sfx_Aeroblast:
 SECTION "Sfx_Spark", ROMX
 
 Sfx_Spark:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 .branch8:
@@ -3807,8 +3936,9 @@ Sfx_Spark:
 SECTION "Sfx_Curse", ROMX
 
 Sfx_Curse:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 8, .Ch8
+	channel_count 2
+	channel 5, .Ch5
+	channel 8, .Ch8
 
 .Ch5:
 	dutycycle $3
@@ -3826,8 +3956,9 @@ Sfx_Curse:
 SECTION "Sfx_Rage", ROMX
 
 Sfx_Rage:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 8, .Ch8
+	channel_count 2
+	channel 5, .Ch5
+	channel 8, .Ch8
 
 .Ch5:
 	dutycycle $0
@@ -3846,7 +3977,8 @@ Sfx_Rage:
 SECTION "Sfx_Thief", ROMX
 
 Sfx_Thief:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 .branch8:
@@ -3861,7 +3993,8 @@ Sfx_Thief:
 SECTION "Sfx_Thief2", ROMX
 
 Sfx_Thief2:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	togglesfx
@@ -3886,8 +4019,9 @@ Sfx_Thief2:
 SECTION "Sfx_SpiderWeb", ROMX
 
 Sfx_SpiderWeb:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 8, .Ch8
+	channel_count 2
+	channel 5, .Ch5
+	channel 8, .Ch8
 
 .Ch5:
 	dutycycle $0
@@ -3910,8 +4044,9 @@ Sfx_SpiderWeb:
 SECTION "Sfx_MindReader", ROMX
 
 Sfx_MindReader:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 8, .Ch8
+	channel_count 2
+	channel 5, .Ch5
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -3941,7 +4076,8 @@ Sfx_MindReader:
 SECTION "Sfx_Nightmare", ROMX
 
 Sfx_Nightmare:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $0
@@ -3965,7 +4101,8 @@ Sfx_Nightmare:
 SECTION "Sfx_Snore", ROMX
 
 Sfx_Snore:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $ea, $4b
@@ -3980,7 +4117,8 @@ Sfx_Snore:
 SECTION "Sfx_SweetKiss", ROMX
 
 Sfx_SweetKiss:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -3995,7 +4133,8 @@ Sfx_SweetKiss:
 SECTION "Sfx_SweetKiss2", ROMX
 
 Sfx_SweetKiss2:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $0
@@ -4014,8 +4153,9 @@ Sfx_SweetKiss2:
 SECTION "Sfx_BellyDrum", ROMX
 
 Sfx_BellyDrum:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 8, .Ch8
+	channel_count 2
+	channel 5, .Ch5
+	channel 8, .Ch8
 
 .Ch5:
 	dutycycle $2
@@ -4032,7 +4172,8 @@ Sfx_BellyDrum:
 SECTION "Sfx_Toxic", ROMX
 
 Sfx_Toxic:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -4047,8 +4188,9 @@ Sfx_Toxic:
 SECTION "Sfx_SludgeBomb", ROMX
 
 Sfx_SludgeBomb:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 8, .Ch8
+	channel_count 2
+	channel 5, .Ch5
+	channel 8, .Ch8
 
 .Ch5:
 	dutycycle $2
@@ -4070,7 +4212,8 @@ Sfx_SludgeBomb:
 SECTION "Sfx_Foresight", ROMX
 
 Sfx_Foresight:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	sound __,  4, $f4, $07b5
@@ -4086,7 +4229,8 @@ Sfx_Foresight:
 SECTION "Sfx_Spite", ROMX
 
 Sfx_Spite:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	togglesfx
@@ -4118,7 +4262,8 @@ Sfx_Spite:
 SECTION "Sfx_Outrage", ROMX
 
 Sfx_Outrage:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __, 12, $ea, $6c
@@ -4132,8 +4277,9 @@ Sfx_Outrage:
 SECTION "Sfx_PerishSong", ROMX
 
 Sfx_PerishSong:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 6, .Ch6
+	channel_count 2
+	channel 5, .Ch5
+	channel 6, .Ch6
 
 .Ch5:
 	togglesfx
@@ -4162,8 +4308,9 @@ Sfx_PerishSong:
 SECTION "Sfx_GigaDrain", ROMX
 
 Sfx_GigaDrain:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 8, .Ch8
+	channel_count 2
+	channel 5, .Ch5
+	channel 8, .Ch8
 
 .Ch5:
 	dutycycle $2
@@ -4193,7 +4340,8 @@ Sfx_GigaDrain:
 SECTION "Sfx_Attract", ROMX
 
 Sfx_Attract:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $0
@@ -4209,7 +4357,8 @@ Sfx_Attract:
 SECTION "Sfx_Kinesis2", ROMX
 
 Sfx_Kinesis2:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $0
@@ -4222,7 +4371,8 @@ Sfx_Kinesis2:
 SECTION "Sfx_ZapCannon", ROMX
 
 Sfx_ZapCannon:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 .branch8:
@@ -4236,7 +4386,8 @@ Sfx_ZapCannon:
 SECTION "Sfx_MeanLook", ROMX
 
 Sfx_MeanLook:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	soundinput $77
@@ -4259,7 +4410,8 @@ Sfx_MeanLook:
 SECTION "Sfx_HealBell", ROMX
 
 Sfx_HealBell:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $1
@@ -4273,7 +4425,8 @@ Sfx_HealBell:
 SECTION "Sfx_Return", ROMX
 
 Sfx_Return:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $0
@@ -4291,7 +4444,8 @@ Sfx_Return:
 SECTION "Sfx_ExpBar", ROMX
 
 Sfx_ExpBar:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -4312,7 +4466,8 @@ Sfx_ExpBar:
 SECTION "Sfx_MilkDrink", ROMX
 
 Sfx_MilkDrink:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -4331,7 +4486,8 @@ Sfx_MilkDrink:
 SECTION "Sfx_Present", ROMX
 
 Sfx_Present:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -4348,7 +4504,8 @@ Sfx_Present:
 SECTION "Sfx_MorningSun", ROMX
 
 Sfx_MorningSun:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $3
@@ -4367,7 +4524,8 @@ Sfx_MorningSun:
 SECTION "Sfx_Moonlight", ROMX
 
 Sfx_Moonlight:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -4384,8 +4542,9 @@ Sfx_Moonlight:
 SECTION "Sfx_Encore", ROMX
 
 Sfx_Encore:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 8, .Ch8
+	channel_count 2
+	channel 5, .Ch5
+	channel 8, .Ch8
 
 .Ch5:
 	dutycycle $2
@@ -4407,7 +4566,8 @@ Sfx_Encore:
 SECTION "Sfx_BeatUp", ROMX
 
 Sfx_BeatUp:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  3, $e8, $69
@@ -4421,7 +4581,8 @@ Sfx_BeatUp:
 SECTION "Sfx_SweetScent", ROMX
 
 Sfx_SweetScent:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -4437,8 +4598,9 @@ Sfx_SweetScent:
 SECTION "Sfx_BatonPass", ROMX
 
 Sfx_BatonPass:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 8, .Ch8
+	channel_count 2
+	channel 5, .Ch5
+	channel 8, .Ch8
 
 .Ch5:
 	dutycycle $2
@@ -4460,7 +4622,8 @@ Sfx_BatonPass:
 SECTION "Sfx_EggCrack", ROMX
 
 Sfx_EggCrack:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	togglesfx
@@ -4477,7 +4640,8 @@ Sfx_EggCrack:
 SECTION "Sfx_Evolved", ROMX
 
 Sfx_Evolved:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	togglesfx
@@ -4503,7 +4667,8 @@ Sfx_Evolved:
 SECTION "Sfx_MasterBall", ROMX
 
 Sfx_MasterBall:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	togglesfx
@@ -4539,7 +4704,8 @@ Sfx_MasterBall:
 SECTION "Sfx_EggHatch", ROMX
 
 Sfx_EggHatch:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	togglesfx
@@ -4563,7 +4729,8 @@ Sfx_EggHatch:
 SECTION "Sfx_GsIntroCharizardFireball", ROMX
 
 Sfx_GsIntroCharizardFireball:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  9, $cf, $4d
@@ -4584,7 +4751,8 @@ Sfx_GsIntroCharizardFireball:
 SECTION "Sfx_GsIntroPokemonAppears", ROMX
 
 Sfx_GsIntroPokemonAppears:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  2, $88, $4f
@@ -4600,7 +4768,8 @@ Sfx_GsIntroPokemonAppears:
 SECTION "Sfx_Flash", ROMX
 
 Sfx_Flash:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $1
@@ -4621,7 +4790,8 @@ Sfx_Flash:
 SECTION "Sfx_GameFreakLogoGs", ROMX
 
 Sfx_GameFreakLogoGs:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $3
@@ -4643,10 +4813,11 @@ Sfx_GameFreakLogoGs:
 SECTION "Sfx_DexFanfareLessThan20", ROMX
 
 Sfx_DexFanfareLessThan20:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -4723,10 +4894,11 @@ Sfx_DexFanfareLessThan20:
 SECTION "Sfx_DexFanfare140169", ROMX
 
 Sfx_DexFanfare140169:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -4830,10 +5002,11 @@ Sfx_DexFanfare140169:
 SECTION "Sfx_DexFanfare170199", ROMX
 
 Sfx_DexFanfare170199:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -4940,10 +5113,11 @@ Sfx_DexFanfare170199:
 SECTION "Sfx_DexFanfare200229", ROMX
 
 Sfx_DexFanfare200229:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -5064,10 +5238,11 @@ Sfx_DexFanfare200229:
 SECTION "Sfx_DexFanfare230Plus", ROMX
 
 Sfx_DexFanfare230Plus:
-	musicheader 4, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
-	musicheader 1, 8, .Ch8
+	channel_count 4
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
+	channel 8, .Ch8
 
 .Ch5:
 	togglesfx
@@ -5233,7 +5408,8 @@ Sfx_DexFanfare230Plus:
 SECTION "Sfx_NotVeryEffective", ROMX
 
 Sfx_NotVeryEffective:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  5, $f1, $5f
@@ -5245,7 +5421,8 @@ Sfx_NotVeryEffective:
 SECTION "Sfx_Damage", ROMX
 
 Sfx_Damage:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  5, $f1, $5e
@@ -5258,7 +5435,8 @@ Sfx_Damage:
 SECTION "Sfx_SuperEffective", ROMX
 
 Sfx_SuperEffective:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  4, $f1, $4f
@@ -5272,8 +5450,9 @@ Sfx_SuperEffective:
 SECTION "Sfx_BallBounce", ROMX
 
 Sfx_BallBounce:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 6, .Ch6
+	channel_count 2
+	channel 5, .Ch5
+	channel 6, .Ch6
 
 .Ch5:
 	dutycycle $2
@@ -5304,8 +5483,9 @@ Sfx_BallBounce:
 SECTION "Sfx_SweetScent2", ROMX
 
 Sfx_SweetScent2:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 8, .Ch8
+	channel_count 2
+	channel 5, .Ch5
+	channel 8, .Ch8
 
 .Ch5:
 	soundinput $af
@@ -5334,8 +5514,9 @@ Sfx_SweetScent2:
 SECTION "Sfx_HitEndOfExpBar", ROMX
 
 Sfx_HitEndOfExpBar:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 6, .Ch6
+	channel_count 2
+	channel 5, .Ch5
+	channel 6, .Ch6
 
 .Ch5:
 	dutycycle $2
@@ -5355,7 +5536,8 @@ Sfx_HitEndOfExpBar:
 SECTION "Sfx_GiveTrademon", ROMX
 
 Sfx_GiveTrademon:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	sound C#,  1, $0, 0
@@ -5376,7 +5558,8 @@ Sfx_GiveTrademon:
 SECTION "Sfx_GetTrademon", ROMX
 
 Sfx_GetTrademon:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	sound C#,  1, $0, 0
@@ -5397,9 +5580,10 @@ Sfx_GetTrademon:
 SECTION "Sfx_TrainArrived", ROMX
 
 Sfx_TrainArrived:
-	musicheader 3, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 8, .Ch8
+	channel_count 3
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 8, .Ch8
 
 .Ch6:
 	tone $0008
@@ -5430,7 +5614,8 @@ Sfx_TrainArrived:
 SECTION "Sfx_2Boops", ROMX
 
 Sfx_2Boops:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -5448,7 +5633,8 @@ Sfx_2Boops:
 SECTION "Sfx_TitleScreenIntro", ROMX
 
 Sfx_TitleScreenIntro:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  2, $10, $10
@@ -5466,7 +5652,8 @@ Sfx_TitleScreenIntro:
 SECTION "Sfx_StopSlot", ROMX
 
 Sfx_StopSlot:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -5478,7 +5665,8 @@ Sfx_StopSlot:
 SECTION "Sfx_GlassTing", ROMX
 
 Sfx_GlassTing:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -5489,8 +5677,9 @@ Sfx_GlassTing:
 SECTION "Sfx_GlassTing2", ROMX
 
 Sfx_GlassTing2:
-	musicheader 2, 5, .Ch5
-	musicheader 1, 6, .Ch6
+	channel_count 2
+	channel 5, .Ch5
+	channel 6, .Ch6
 
 .Ch5:
 	dutycycle $2
@@ -5506,7 +5695,8 @@ Sfx_GlassTing2:
 SECTION "Sfx_IntroUnown1", ROMX
 
 Sfx_IntroUnown1:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	vibrato $1, $a3
@@ -5519,7 +5709,8 @@ Sfx_IntroUnown1:
 SECTION "Sfx_IntroUnown2", ROMX
 
 Sfx_IntroUnown2:
-	musicheader 1, 6, .Ch6
+	channel_count 1
+	channel 6, .Ch6
 
 .Ch6:
 	vibrato $1, $73
@@ -5532,7 +5723,8 @@ Sfx_IntroUnown2:
 SECTION "Sfx_IntroUnown3", ROMX
 
 Sfx_IntroUnown3:
-	musicheader 1, 7, .Ch7
+	channel_count 1
+	channel 7, .Ch7
 
 .Ch7:
 	vibrato $1, $53
@@ -5548,7 +5740,8 @@ Sfx_IntroUnown3:
 SECTION "Sfx_DittoPopUp", ROMX
 
 Sfx_DittoPopUp:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -5564,7 +5757,8 @@ Sfx_DittoPopUp:
 SECTION "Sfx_DittoTransform", ROMX
 
 Sfx_DittoTransform:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $1
@@ -5579,7 +5773,8 @@ Sfx_DittoTransform:
 SECTION "Sfx_IntroSuicune1", ROMX
 
 Sfx_IntroSuicune1:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  2, $58, $59
@@ -5590,7 +5785,8 @@ Sfx_IntroSuicune1:
 SECTION "Sfx_IntroPichu", ROMX
 
 Sfx_IntroPichu:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $3
@@ -5605,7 +5801,8 @@ Sfx_IntroPichu:
 SECTION "Sfx_IntroSuicune2", ROMX
 
 Sfx_IntroSuicune2:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  2, $a7, $31
@@ -5630,7 +5827,8 @@ Sfx_IntroSuicune2:
 SECTION "Sfx_IntroSuicune3", ROMX
 
 Sfx_IntroSuicune3:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  2, $88, $31
@@ -5644,7 +5842,8 @@ Sfx_IntroSuicune3:
 SECTION "Sfx_DittoBounce", ROMX
 
 Sfx_DittoBounce:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -5659,7 +5858,8 @@ Sfx_DittoBounce:
 SECTION "Sfx_IntroSuicune4", ROMX
 
 Sfx_IntroSuicune4:
-	musicheader 1, 8, .Ch8
+	channel_count 1
+	channel 8, .Ch8
 
 .Ch8:
 	noise __,  2, $a1, $5c
@@ -5679,7 +5879,8 @@ Sfx_IntroSuicune4:
 SECTION "Sfx_GameFreakPresents", ROMX
 
 Sfx_GameFreakPresents:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	togglesfx
@@ -5707,7 +5908,8 @@ Sfx_GameFreakPresents:
 SECTION "Sfx_Tingle", ROMX
 
 Sfx_Tingle:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	togglesfx
@@ -5732,7 +5934,8 @@ Sfx_Tingle:
 SECTION "Sfx_TwoPcBeeps", ROMX
 
 Sfx_TwoPcBeeps:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $2
@@ -5746,9 +5949,10 @@ Sfx_TwoPcBeeps:
 SECTION "Sfx_4NoteDitty", ROMX
 
 Sfx_4NoteDitty:
-	musicheader 3, 5, .Ch5
-	musicheader 1, 6, .Ch6
-	musicheader 1, 7, .Ch7
+	channel_count 3
+	channel 5, .Ch5
+	channel 6, .Ch6
+	channel 7, .Ch7
 
 .Ch5:
 	togglesfx
@@ -5793,7 +5997,8 @@ Sfx_4NoteDitty:
 SECTION "Sfx_Twinkle", ROMX
 
 Sfx_Twinkle:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	togglesfx
@@ -5824,7 +6029,8 @@ Sfx_Twinkle:
 SECTION "Sfx_Puddle", ROMX
 
 Sfx_Puddle:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $1
@@ -5837,7 +6043,8 @@ Sfx_Puddle:
 SECTION "Sfx_AbilitySlideout", ROMX
 
 Sfx_AbilitySlideout:
-	musicheader 1, 5, .Ch5
+	channel_count 1
+	channel 5, .Ch5
 
 .Ch5:
 	dutycycle $1

--- a/macros/scripts/audio.asm
+++ b/macros/scripts/audio.asm
@@ -1,6 +1,15 @@
-MACRO musicheader
-	; number of tracks, track idx, address
-	dbw ((\1 - 1) << 6) + (\2 - 1), \3
+MACRO channel_count
+	assert 0 < (\1) && (\1) <= NUM_MUSIC_CHANS, \
+		"channel_count must be 1-{d:NUM_MUSIC_CHANS}"
+	DEF _num_channels = \1 - 1
+ENDM
+
+MACRO channel
+	assert 0 < (\1) && (\1) <= NUM_CHANNELS, \
+		"channel id must be 1-{d:NUM_CHANNELS}"
+	dn (_num_channels << 2), \1 - 1 ; channel id
+	dw \2 ; address
+	DEF _num_channels = 0
 ENDM
 
 MACRO note


### PR DESCRIPTION
Convert polished to use pokecrystal's new music headers `channel_count` and `channel`.

Verified the sha1 of the rom is unchanged.