### PR TITLE
Allow Heal Bell to Trigger Throat Spray Buff

### DIFF
--- a/data/moves/sound_moves.asm
+++ b/data/moves/sound_moves.asm
@@ -8,4 +8,5 @@ SoundMoves::
 	db SCREECH
 	db SING
 	db SUPERSONIC
+	db HEAL_BELL
 	db -1


### PR DESCRIPTION
Heal Bell, as a sound based move in the mainline games, should be able to trigger throat spray's +1 SpA buff when used by a pokemon holding the item. As heal bell was not currently in the db for sound moves, it currently does not do so. This PR aims to fix that.

Possible Issues:
-This might interact weirdly if a pokemon with soundproof uses heal bell? The vanilla games already have a somewhat weird soundproof+heal bell interaction anyways