### PR TITLE
Fix CopySpritePal wrong order pops

### DIFF
--- a/engine/gfx/sprite_palettes.asm
+++ b/engine/gfx/sprite_palettes.asm
@@ -89,9 +89,9 @@ CopySpritePal::
 	ld a, TRUE
 	ldh [hCGBPalUpdate], a
 .skip_apply
-	pop af
-	pop bc
 	pop hl
+	pop bc
+	pop af
 	ret
 
 ApplyOBPals:


### PR DESCRIPTION
Doesn't seem to affect anything.. but should be corrected just in case.