### PR TITLE
Some Dynamic Pal Improvements

### DIFF
--- a/data/maps/setup_scripts.asm
+++ b/data/maps/setup_scripts.asm
@@ -94,6 +94,7 @@ MapSetupScript_Connection:
 	mapsetup LoadMapObjects
 	mapsetup FadeToMapMusic
 	mapsetup LoadMapPalettes
+	mapsetup EnableDynPalUpdates
 	mapsetup InitMapNameSign
 	mapsetup ApplyMapPalettes
 	mapsetup LoadWildMonData
@@ -122,6 +123,7 @@ MapSetupScript_Train:
 	mapsetup EnableLCD
 	mapsetup LoadMapObjects
 	mapsetup LoadMapPalettes
+	mapsetup RefreshMapSprites
 	mapsetup EnableDynPalUpdates
 	mapsetup RefreshMapSprites
 	mapsetup FadeToMapMusic

--- a/engine/battle/battle_transition.asm
+++ b/engine/battle/battle_transition.asm
@@ -652,6 +652,7 @@ StartTrainerBattle_LoadPokeBallGraphics:
 	ldh [rSVBK], a
 	farcall ClearSavedObjPals
 	farcall CheckForUsedObjPals
+	farcall _UpdateSprites
 	ld a, $1
 	ldh [hCGBPalUpdate], a
 	call DelayFrame

--- a/engine/events/overworld.asm
+++ b/engine/events/overworld.asm
@@ -766,6 +766,7 @@ FlyFunction:
 .FlyScript:
 	reloadmappart
 	callasm HideSprites
+	callasm ClearSavedObjPals
 	callasm CopyBGGreenToOBPal7
 	special UpdateTimePals
 	callasm PrepareOverworldMove

--- a/engine/gfx/color.asm
+++ b/engine/gfx/color.asm
@@ -941,9 +941,6 @@ LoadMapPals:
 
 .got_pals
 	farcall ClearSavedObjPals
-	ld hl, wPalFlags
-	set NO_DYN_PAL_APPLY_F, [hl]
-	farcall CheckForUsedObjPals
 
 	ld a, [wMapTileset]
 	cp TILESET_SNOWTOP_MOUNTAIN

--- a/engine/gfx/dynamic_pals.asm
+++ b/engine/gfx/dynamic_pals.asm
@@ -42,7 +42,7 @@ CheckForUsedObjPals::
 
 	ld hl, wPalFlags
 	bit DISABLE_DYN_PAL_F, [hl]
-	jmp nz, .done
+	jr nz, .done
 
 	; reset all wUsedObjectPals bits
 	xor a
@@ -66,7 +66,7 @@ CheckForUsedObjPals::
 
 .done
 	pop af
-	ldh a, [rSVBK]
+	ldh [rSVBK], a
 	jmp PopAFBCDEHL
 
 ScanObjectStructPals:

--- a/engine/gfx/dynamic_pals.asm
+++ b/engine/gfx/dynamic_pals.asm
@@ -1,20 +1,32 @@
 ClearSavedObjPals::
+	ldh a, [rSVBK]
+	push af
+	ld a, BANK(wUsedObjectPals)
+	ldh [rSVBK], a
+
 	xor a
 	ld [wUsedObjectPals], a
 	ld hl, wUsedObjectPals
 	ld bc, wNeededPalIndex - wUsedObjectPals
 	ld a, -1
 	rst ByteFill
+
+	pop af
+	ldh [rSVBK], a
 	ret
 
 DisableDynPalUpdates::
+	push hl
 	ld hl, wPalFlags
 	set DISABLE_DYN_PAL_F, [hl]
+	pop hl
 	ret
 
 EnableDynPalUpdates::
+	push hl
 	ld hl, wPalFlags
 	res DISABLE_DYN_PAL_F, [hl]
+	pop hl
 	; fallthrough to manually run CheckForUsedObjPals
 
 CheckForUsedObjPals::
@@ -23,9 +35,14 @@ CheckForUsedObjPals::
 	push bc
 	push af
 
+	ldh a, [rSVBK]
+	push af
+	ld a, BANK(wUsedObjectPals)
+	ldh [rSVBK], a
+
 	ld hl, wPalFlags
 	bit DISABLE_DYN_PAL_F, [hl]
-	jmp nz, PopAFBCDEHL
+	jmp nz, .done
 
 	; reset all wUsedObjectPals bits
 	xor a
@@ -46,6 +63,10 @@ CheckForUsedObjPals::
 	; If this flag was set, it's time to reset it
 	ld hl, wPalFlags
 	res NO_DYN_PAL_APPLY_F, [hl]
+
+.done
+	pop af
+	ldh a, [rSVBK]
 	jmp PopAFBCDEHL
 
 ScanObjectStructPals:
@@ -70,6 +91,7 @@ ScanObjectStructPals:
 	call MarkUsedPal
 	; Then load the return into OBJECT_PALETTE, which corresponds
 	; to OBJ 0 - OBJ 7
+	jr nc, .skip
 	and PALETTE_MASK
 	ld c, a
 	ld hl, OBJECT_PALETTE
@@ -109,6 +131,8 @@ MarkUsedPal:
 	; load any pals yet, just mark the still active pals
 	ld hl, wPalFlags
 	bit SCAN_OBJECTS_FIRST_F, [hl]
+	scf
+	ccf
 	jr nz, .done
 
 	ld b, a
@@ -169,7 +193,7 @@ MarkUsedPal:
 	ld [hl], a
 	pop bc
 	ld a, c
-
+	scf
 .done
 	jmp PopBCDEHL
 

--- a/engine/menus/start_menu.asm
+++ b/engine/menus/start_menu.asm
@@ -123,6 +123,8 @@ StartMenu::
 	jr .ReturnEnd2
 
 .ReturnRedraw:
+	farcall ClearSavedObjPals
+	farcall DisableDynPalUpdates
 	call ClearBGPalettes
 	call ExitMenu
 	call ReloadTilesetAndPalettes

--- a/home/map.asm
+++ b/home/map.asm
@@ -1640,6 +1640,8 @@ ReturnToMapWithSpeechTextbox::
 	ld [wSpriteUpdatesEnabled], a
 	call ClearBGPalettes
 	call ClearSprites
+	farcall ClearSavedObjPals
+	farcall DisableDynPalUpdates
 	call ReloadTilesetAndPalettes
 	hlcoord 0, 12
 	lb bc, 4, 18
@@ -1652,6 +1654,7 @@ ReturnToMapWithSpeechTextbox::
 	call GetCGBLayout
 	farcall LoadBlindingFlashPalette
 	call UpdateTimePals
+	farcall EnableDynPalUpdates
 	call DelayFrame
 	ld a, $1
 	ldh [hMapAnims], a

--- a/home/menu.asm
+++ b/home/menu.asm
@@ -17,7 +17,6 @@ MenuTextboxWaitButton::
 ExitMenu::
 	push af
 	farcall _ExitMenu
-	farcall ClearSavedObjPals
 	pop af
 	ret
 

--- a/home/sprite_updates.asm
+++ b/home/sprite_updates.asm
@@ -15,6 +15,8 @@ DisableSpriteUpdates::
 	ret
 
 CloseSubmenu::
+	farcall ClearSavedObjPals
+	farcall DisableDynPalUpdates
 	call ClearBGPalettes
 	call ReloadTilesetAndPalettes
 	call UpdateSprites
@@ -22,6 +24,8 @@ CloseSubmenu::
 	jr FinishExitMenu
 
 ExitAllMenus::
+	farcall ClearSavedObjPals
+	farcall DisableDynPalUpdates
 	call ClearBGPalettes
 	call ExitMenu
 	call ReloadTilesetAndPalettes
@@ -32,6 +36,7 @@ FinishExitMenu::
 	farcall LoadBlindingFlashPalette
 	call ApplyAttrAndTilemapInVBlank
 	farcall FadeInPalettes
+	farcall EnableDynPalUpdates
 	; fallthrough
 EnableSpriteUpdates::
 	ld a, $1


### PR DESCRIPTION
* No longer run Dynamic Pal in `LoadMapPals`
* Don't update `OBJECT_PALETTE` during the first dyn pal pass.
* Better Menu exit hook (Doesn't corrupt BG)
* Ensure the correct Wram bank is loaded.
* Preserve more registers, just in case.
* Re-fix Battle Transitions
* Re-fix sprites appearing before warp is complete
* Fix sprite problems when activating surf (Menu problem).
* Verified pals updating correctly when crossing map connections with different map conditions (Example: Overcast)