### PR TITLE
Big farcall refactor

### DIFF
--- a/engine/battle/abilities.asm
+++ b/engine/battle/abilities.asm
@@ -15,7 +15,7 @@ RunEnemyStatusHealAbilities:
 RunStatusHealAbilities:
 	ld hl, StatusHealAbilities
 UserAbilityJumptable:
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 AbilityJumptable:
 	; If we at some point make the AI learn abilities, keep this.
 	; For now it just jumps to the general jumptable function
@@ -253,7 +253,7 @@ IntimidateAbility:
 	ld a, [wFailedMessage]
 	and a
 	jr nz, .continue
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	cp RATTLED
 	ld b, SPEED
 	call z, StatUpAbility
@@ -461,7 +461,7 @@ ForewarnAbility:
 	inc a ; no-optimize inefficient WRAM increment/decrement
 	ld [wBuffer2], a
 	inc a
-	call BattleRandomRange
+	farcall BattleRandomRange
 	and a
 	jr z, .loop
 .replace
@@ -547,14 +547,14 @@ ScreenCleanerAbility:
 
 RunEnemyOwnTempoAbility:
 	call SwitchTurn
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	cp OWN_TEMPO
 	call z, OwnTempoAbility
 	jmp SwitchTurn
 
 RunEnemySynchronizeAbility:
 	call SwitchTurn
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	cp SYNCHRONIZE
 	call z, SynchronizeAbility
 	jmp SwitchTurn
@@ -597,7 +597,7 @@ ResolveOpponentBerserk_CheckMultihit:
 	ret nz
 
 	; Check if user has Parental Bond
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	cp PARENTAL_BOND
 	ret z
 
@@ -625,7 +625,7 @@ RunFaintAbilities:
 ; abilities that run after an attack faints an enemy
 	farcall GetFutureSightUser
 	ret nz
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	call _RunFaintUserAbilities
 	call GetOpponentAbilityAfterMoldBreaker
 	push af
@@ -644,7 +644,7 @@ AftermathAbility:
 	cp DAMP
 	ret z
 	; Only contact moves proc Aftermath
-	call CheckOpponentContactMove
+	farcall CheckOpponentContactMove
 	ret c
 .is_contact
 	call DisableAnimations
@@ -659,7 +659,7 @@ AftermathAbility:
 
 RunHitAbilities:
 ; abilities that run on hitting the enemy with an offensive attack
-	call CheckContactMove
+	farcall CheckContactMove
 	call nc, RunContactAbilities
 	; Store type and category (phy/spe/sta) so that abilities can check on them
 	ld a, BATTLE_VARS_MOVE_CATEGORY
@@ -701,7 +701,7 @@ CursedBodyAbility:
 	call SwitchTurn
 	ret nc
 	ld a, 10
-	call BattleRandomRange
+	farcall BattleRandomRange
 	cp 3
 	ret nc
 	call DisableAnimations
@@ -711,7 +711,7 @@ CursedBodyAbility:
 
 RunContactAbilities:
 ; turn perspective is from the attacker
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	ld hl, UserContactAbilities
 	call AbilityJumptable
 	call GetOpponentAbilityAfterMoldBreaker
@@ -740,7 +740,7 @@ CuteCharmAbility:
 
 	; Only works 30% of the time.
 	ld a, 10
-	call BattleRandomRange
+	farcall BattleRandomRange
 	cp 3
 	ret nc
 
@@ -795,7 +795,7 @@ EffectSporeAbility:
 	ld a, b
 	cp HELD_SAFETY_GOGGLES
 	ret z
-	call BattleRandom
+	farcall BattleRandom
 	cp 1 + 33 percent
 	jr c, PoisonPointAbility
 	cp 1 + 66 percent
@@ -830,7 +830,7 @@ AfflictStatusAbility:
 _AfflictStatusAbility:
 	; Only works 30% of the time.
 	ld a, 10
-	call BattleRandomRange
+	farcall BattleRandomRange
 	cp 3
 	ret nc
 
@@ -861,7 +861,7 @@ _AfflictStatusAbility:
 	call DisableAnimations
 	farcall DisplayStatusProblem
 	call UpdateOpponentInParty
-	call UpdateBattleHuds
+	farcall UpdateBattleHuds
 	farcall PostStatusWithSynchronize
 	jmp EnableAnimations
 
@@ -1063,7 +1063,7 @@ StatUpAbility:
 	jr z, .done
 
 ; Lightning Rod, Motor Drive and Sap Sipper prints a "doesn't affect" message instead.
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	cp LIGHTNING_ROD
 	jr z, .print_immunity
 	cp MOTOR_DRIVE
@@ -1134,7 +1134,7 @@ WaterAbsorbAbility:
 
 ApplySpeedAbilities:
 ; Passive speed boost abilities
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	cp UNBURDEN
 	jr z, .unburden
 	cp SWIFT_SWIM
@@ -1181,7 +1181,7 @@ ApplySpeedAbilities:
 	jmp MultiplyAndDivide
 
 ApplyAccuracyAbilities:
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	ld hl, UserAccuracyAbilities
 	call AbilityJumptable
 	call GetOpponentAbilityAfterMoldBreaker
@@ -1281,7 +1281,7 @@ WeatherRecoveryAbility:
 	ret z
 	call DisableAnimations
 	call ShowAbilityActivation
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	cp DRY_SKIN
 	jr z, .eighth_max_hp
 	call GetSixteenthMaxHP
@@ -1328,7 +1328,7 @@ HarvestAbility:
 	call GetWeatherAfterUserUmbrella
 	cp WEATHER_SUN
 	jr z, .ok
-	call BattleRandom
+	farcall BattleRandom
 	and 1
 	ret z
 
@@ -1519,7 +1519,7 @@ SelectRandomStat:
 ; Randomizes values until we get one matching a nonmaxed stat
 .loop1
 	ld a, 5 ; don't raise acc/eva, only 0-4 (atk/def/spe/sat/sdf)
-	call BattleRandomRange
+	farcall BattleRandomRange
 	lb de, 1, 0 ; e = counter
 .loop2
 	cp e
@@ -1558,7 +1558,7 @@ MoodyAbility:
 	farjp CheckMirrorHerb
 
 ApplyDamageAbilities_AfterTypeMatchup:
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	ld hl, OffensiveDamageAbilities_AfterTypeMatchup
 	call AbilityJumptable
 	call GetOpponentAbilityAfterMoldBreaker
@@ -1575,7 +1575,7 @@ DefensiveDamageAbilities_AfterTypeMatchup:
 	dbw -1, -1
 
 ApplyDamageAbilities:
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	ld hl, OffensiveDamageAbilities
 	call AbilityJumptable
 	call GetOpponentAbilityAfterMoldBreaker
@@ -1712,7 +1712,7 @@ SolarPowerAbility:
 	jmp ApplySpecialAttackDamageMod
 
 ToughClawsAbility:
-	call CheckContactMove
+	farcall CheckContactMove
 	ret c
 	ln a, 13, 10 ; x1.3
 	jmp MultiplyAndDivide
@@ -1889,7 +1889,7 @@ HydrationAbility:
 	jr HealAllStatusAbility
 ShedSkinAbility:
 ; Cure a non-volatile status 30% of the time
-	call BattleRandom
+	farcall BattleRandom
 	cp 1 + (30 percent)
 	ret nc
 	; fallthrough
@@ -1916,7 +1916,7 @@ AngerPointAbility:
 
 RunSwitchAbilities:
 ; abilities that activate when you switch out
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	cp NATURAL_CURE
 	jr z, NaturalCureAbility
 	cp REGENERATOR
@@ -1935,14 +1935,14 @@ RegeneratorAbility:
 	jmp z, UpdateBattleMonInParty
 	jmp UpdateEnemyMonInParty
 
-_GetOpponentAbilityAfterMoldBreaker::
+GetOpponentAbilityAfterMoldBreaker::
 ; Returns an opponent's ability unless Mold Breaker
 ; will suppress it. Preserves bc/de/hl.
 	push de
 	push bc
 	call GetOpponentAbility
 	ld b, a
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	cp MOLD_BREAKER
 	ld a, b
 	jr nz, .done
@@ -2058,7 +2058,7 @@ RunPostBattleAbilities::
 
 	; Get a random value between 1-20.
 	ld a, 20
-	call BattleRandomRange
+	farcall BattleRandomRange
 	inc a ; BattleRandomRange returns 0-19.
 	ld c, a
 
@@ -2079,7 +2079,7 @@ RunPostBattleAbilities::
 
 .Pickup:
 	ld a, 10
-	call BattleRandomRange
+	farcall BattleRandomRange
 	and a
 	ret nz
 

--- a/engine/battle/ai/scoring.asm
+++ b/engine/battle/ai/scoring.asm
@@ -65,7 +65,7 @@ INCLUDE "data/battle/ai/status_only_effects.asm"
 AI_Conversion:
 ; not a layer, called by Conversion to allow the AI to select a good move type
 ; TODO: implement
-	call BattleRandom
+	farcall BattleRandom
 	and %11
 	ret
 
@@ -1186,7 +1186,7 @@ AI_Smart_SleepTalk:
 ; Greatly discourage this move otherwise.
 ; TODO: sleep talk is typically used with rest, but we shouldn't
 ; know how long we sleep for if it's randomly 1-3 turns...
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	cp EARLY_BIRD
 	ld b, 3
 	jr z, .got_wakeup_time
@@ -1537,7 +1537,7 @@ AI_Smart_PerishSong:
 	and a
 	jr nz, .no
 
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp SOUNDPROOF
 	jr z, .no
 
@@ -1932,10 +1932,10 @@ AI_Smart_JumpKick:
 ; Greatly discourage this move if the player is semi-invulnerable and the enemy
 ; is faster and neither Pokémon has No Guard.
 	; Do nothing if anyone has No Guard.
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp NO_GUARD
 	ret z
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	cp NO_GUARD
 	ret z
 
@@ -2416,7 +2416,7 @@ AIDamageCalc:
 
 .multihit
 	; Multiply base power by 5 if Skill Link, 3 otherwise
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	cp SKILL_LINK
 	ld b, 5
 	jr z, .multihit_boost
@@ -2575,7 +2575,7 @@ AI_Status:
 	jr .checkstatus
 .sleep
 	; has 2 abilities, check one of them here
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp VITAL_SPIRIT
 	jr z, .pop_and_discourage
 
@@ -2629,7 +2629,7 @@ AI_Status:
 .checkstatus_after_items
 	; Check opponent ability
 	push bc
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	pop bc
 	cp b
 	jr z, .pop_and_discourage

--- a/engine/battle/battle_transition.asm
+++ b/engine/battle/battle_transition.asm
@@ -203,7 +203,7 @@ StartTrainerBattle_Flash:
 	ldh a, [hBattlePalFadeMode]
 	ld [wPalFadeMode], a
 	ld c, 10
-	call DoFadePalettes
+	farcall DoFadePalettes
 	; fallthrough
 
 StartTrainerBattle_NextScene:

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -8389,7 +8389,7 @@ InitBattleDisplay:
 	hlcoord 1, 5
 	lb bc, 3, 7
 	call ClearBox
-	call LoadStandardFont
+	farcall LoadStandardFont
 	call _LoadBattleFontsHPBar
 	call .BlankBGMap
 	xor a

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -321,7 +321,7 @@ BattleCommand_checkturn:
 	jr z, .thaw
 
 	; Check for defrosting
-	call BattleRandom
+	farcall BattleRandom
 	cp 1 + (20 percent)
 	jr c, .thaw
 	ld hl, FrozenSolidText
@@ -367,7 +367,7 @@ BattleCommand_checkturn:
 	call FarPlayBattleAnimation
 
 	; 33% chance of hitting itself (updated from 50% in Gen VII)
-	call BattleRandom
+	farcall BattleRandom
 	cp 1 + (33 percent)
 	jr nc, .not_confused
 
@@ -396,7 +396,7 @@ BattleCommand_checkturn:
 	call FarPlayBattleAnimation
 
 	; 50% chance of infatuation
-	call BattleRandom
+	farcall BattleRandom
 	cp 1 + (50 percent)
 	jr c, .not_infatuated
 
@@ -437,7 +437,7 @@ BattleCommand_checkturn:
 	ret z
 
 	; 25% chance to be fully paralyzed
-	call BattleRandom
+	farcall BattleRandom
 	cp 1 + (25 percent)
 	ret nc
 
@@ -761,7 +761,7 @@ BattleCommand_checkobedience:
 
 ; Random number from 0 to obedience level + monster level
 .rand1
-	call BattleRandom
+	farcall BattleRandom
 	swap a
 	cp b
 	jr nc, .rand1
@@ -778,7 +778,7 @@ BattleCommand_checkobedience:
 
 ; Another random number from 0 to obedience level + monster level
 .rand2
-	call BattleRandom
+	farcall BattleRandom
 	cp b
 	jr nc, .rand2
 
@@ -794,7 +794,7 @@ BattleCommand_checkobedience:
 	ld b, a
 
 ; The chance of napping is the difference out of 256.
-	call BattleRandom
+	farcall BattleRandom
 	swap a
 	sub b
 	jr c, .Nap
@@ -809,7 +809,7 @@ BattleCommand_checkobedience:
 	jmp .EndDisobedience
 
 .Nap:
-	call BattleRandom
+	farcall BattleRandom
 	add a
 	swap a
 	and SLP_MASK
@@ -821,7 +821,7 @@ BattleCommand_checkobedience:
 	jr .Print
 
 .DoNothing:
-	call BattleRandom
+	farcall BattleRandom
 	and %11
 
 	ld hl, LoafingAroundText
@@ -899,7 +899,7 @@ BattleCommand_checkobedience:
 	push af
 
 .RandomMove:
-	call BattleRandom
+	farcall BattleRandom
 	and %11 ; NUM_MOVES - 1
 
 	cp b
@@ -1102,7 +1102,7 @@ BattleCommand_critical:
 	and a
 	ret z
 
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp BATTLE_ARMOR
 	ret z
 	cp SHELL_ARMOR
@@ -1173,7 +1173,7 @@ BattleCommand_critical:
 	ld hl, CriticalHitChances
 	ld b, 0
 	add hl, bc
-	call BattleRandom
+	farcall BattleRandom
 	cp [hl]
 	ret nc
 .guranteed_crit
@@ -1434,7 +1434,7 @@ BattleCommand_stab:
 CheckAirborneAfterMoldBreaker:
 	push de
 	call SwitchTurn
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	ld b, a
 	call SwitchTurn
 	jr CheckAirborne_GotAbility
@@ -1561,7 +1561,7 @@ _CheckTypeMatchup:
 	ld a, [hl]
 	cp GRASS
 	jmp z, .Immune
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp OVERCOAT
 	jr nz, .skip_powder
 	ld a, ATKFAIL_ABILITY
@@ -1746,7 +1746,7 @@ endc
 
 	; Multiply by 85-100%...
 	ld a, 16
-	call BattleRandomRange
+	farcall BattleRandomRange
 	add 85
 	ldh [hMultiplier], a
 	farcall Multiply
@@ -1866,7 +1866,7 @@ BattleCommand_checkhit:
 .reset_evasion
 	ld c, 7
 .check_opponent_unaware
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp UNAWARE
 	jr nz, .no_opponent_unaware
 	ld b, 7
@@ -1937,7 +1937,7 @@ BattleCommand_checkhit:
 	ldh a, [hMultiplicand + 2]
 	ld b, a
 	ld a, 100
-	call BattleRandomRange
+	farcall BattleRandomRange
 	cp b
 	ret c
 	ld a, ATKFAIL_ACCMISS
@@ -2136,7 +2136,7 @@ BattleCommand_checkpriority:
 	cp $81
 	jr c, .check_prankster
 	; Armor Tail blocks moves with priority > 0 (so does not block moves like Prankster Roar)
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp ARMOR_TAIL
 	ld b, ATKFAIL_ABILITY
 	jr z, .attack_fails
@@ -2171,7 +2171,7 @@ BattleCommand_effectchance:
 	call CheckSubstituteOpp
 	jr nz, EffectChanceFailed
 
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp SHIELD_DUST
 	jr z, EffectChanceFailed
 	call GetOpponentItemAfterUnnerve
@@ -2207,7 +2207,7 @@ _CheckEffectChance:
 
 .skip_serene_grace
 	ld a, 100
-	call BattleRandomRange
+	farcall BattleRandomRange
 	cp b
 	jr c, EffectChanceEnd
 	; fallthrough
@@ -2456,7 +2456,7 @@ BattleCommand_applydamage:
 	ld b, $4
 	cp HELD_FOCUS_SASH
 	jr z, .sturdy
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	ld b, $2
 	cp STURDY
 	jr nz, .no_endure
@@ -2467,7 +2467,7 @@ BattleCommand_applydamage:
 	jr nz, .no_endure
 	jr .enduring
 .focus_band
-	call BattleRandom
+	farcall BattleRandom
 	cp c
 	jr nc, .no_endure
 .enduring
@@ -2681,7 +2681,7 @@ BattleCommand_criticaltext:
 	jr z, .wait
 
 	; Activate Anger Point here to get proper message order
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp ANGER_POINT
 	jr nz, .wait
 	call SwitchTurn
@@ -2726,7 +2726,7 @@ BattleCommand_startloop:
 	ld a, b
 	cp HELD_LOADED_DICE
 	jr nz, .not_loaded_dice
-	call BattleRandom
+	farcall BattleRandom
 	and 1
 	add 4
 	jr .got_count
@@ -2735,7 +2735,7 @@ BattleCommand_startloop:
 	; Hit 2-5 times with 2 and 3 being twice as common.
 	; So randomize a number 0-5, take (result mod 4) + 2.
 	ld a, 6
-	call BattleRandomRange
+	farcall BattleRandomRange
 	cp 4
 	jr c, .random_ok
 	sub 4
@@ -3095,7 +3095,7 @@ BattleCommand_posthiteffects:
 	call GetEighthMaxHP
 	jr .got_hurt_item_damage
 .rocky_helmet
-	call CheckContactMove
+	farcall CheckContactMove
 	jr c, .rocky_helmet_done
 	call GetSixthMaxHP
 .got_hurt_item_damage
@@ -3166,7 +3166,7 @@ BattleCommand_posthiteffects:
 	; Ensure that the move doesn't already have a flinch rate.
 	call HasOpponentFainted
 	ret z
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp SHIELD_DUST
 	ret z
 	ld a, BATTLE_VARS_MOVE_EFFECT
@@ -3187,7 +3187,7 @@ BattleCommand_posthiteffects:
 .no_serene_grace
 	; Flinch items procs even after Rocky Helmet fainting
 	ld a, 100
-	call BattleRandomRange
+	farcall BattleRandomRange
 	cp c
 	call c, FlinchTarget
 	ret
@@ -3399,10 +3399,10 @@ EndMoveDamageChecks:
 	; At this point, we can safely reset wEffectFailed (This runs after everything else)
 	xor a
 	ld [wEffectFailed], a
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp PICKPOCKET
 	ret nz
-	call CheckContactMove
+	farcall CheckContactMove
 	ret c
 .is_contact
 	call SwitchTurn
@@ -3900,7 +3900,7 @@ GetStatBoost:
 ApplyStatBoostDamageAfterUnaware:
 	call GetFutureSightUser
 	ret nz
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp UNAWARE
 	ret z
 ApplyStatBoostDamage:
@@ -4424,7 +4424,7 @@ TakeOpponentDamage:
 	ld b, [hl]
 	farcall SubtractHPFromUser
 .did_no_damage
-	jmp RefreshBattleHuds
+	farjp RefreshBattleHuds
 
 TakeDamage:
 ; opponent takes damage
@@ -4449,7 +4449,7 @@ TakeDamage:
 	ld b, [hl]
 	farcall DealDamageToOpponent
 .did_no_damage
-	jmp RefreshBattleHuds
+	farjp RefreshBattleHuds
 
 SelfInflictDamageToSubstitute:
 	ld hl, SubTookDamageText
@@ -4507,7 +4507,7 @@ SelfInflictDamageToSubstitute:
 	xor a
 	ld [hl], a
 .ok
-	jmp RefreshBattleHuds
+	farjp RefreshBattleHuds
 
 UpdateMoveData:
 	ld a, BATTLE_VARS_MOVE_ANIM
@@ -4570,7 +4570,7 @@ IsOpponentLeafGuardActive:
 	jr DoLeafGuardCheck
 IsLeafGuardActive:
 ; returns z if leaf guard applies for enemy
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 DoLeafGuardCheck:
 	cp LEAF_GUARD
 	ret nz
@@ -4613,12 +4613,12 @@ BattleCommand_sleep:
 	; 1-3 turns of sleep, rnd(0-2) + 2 since Pokémon wake up once it ticks to 0.
 	push hl
 	ld a, 3
-	call BattleRandomRange
+	farcall BattleRandomRange
 	add 2
 	pop hl
 	ld [hl], a
 	call UpdateOpponentInParty
-	call UpdateBattleHuds
+	farcall UpdateBattleHuds
 	ld hl, FellAsleepText
 	call StdBattleTextbox
 	jr PostStatus
@@ -4745,7 +4745,7 @@ CanStatusTarget:
 	call CheckSubstituteOpp
 	ld hl, ButItFailedText
 	jr nz, .end
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	jr .got_ability
 .no_mold_breaker
 	call GetOpponentAbility
@@ -4818,7 +4818,7 @@ BattleCommand_poisontarget:
 	call PoisonOpponent
 	ld de, ANIM_PSN
 	call PlayOpponentBattleAnim
-	call RefreshBattleHuds
+	farcall RefreshBattleHuds
 
 	ld hl, WasPoisonedText
 	call StdBattleTextbox
@@ -4836,7 +4836,7 @@ BattleCommand_draintarget:
 	; fallthrough
 SapHealth:
 	; Don't do anything if HP is full unless opponent has Liquid Ooze
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp LIQUID_OOZE
 	jr z, .continue
 	push hl
@@ -4870,7 +4870,7 @@ SapHealth:
 
 	; check for Liquid Ooze
 	push bc
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	pop bc
 	cp LIQUID_OOZE
 	jr z, .damage
@@ -4946,7 +4946,7 @@ BattleCommand_burntarget:
 	call UpdateOpponentInParty
 	ld de, ANIM_BRN
 	call PlayOpponentBattleAnim
-	call RefreshBattleHuds
+	farcall RefreshBattleHuds
 
 	ld hl, WasBurnedText
 	call StdBattleTextbox
@@ -4998,7 +4998,7 @@ BattleCommand_freezetarget:
 	ld a, b
 	cp HELD_PREVENT_FREEZE
 	ret z
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp MAGMA_ARMOR
 	ret z
 	call IsLeafGuardActive
@@ -5014,7 +5014,7 @@ BattleCommand_freezetarget:
 	call UpdateOpponentInParty
 	ld de, ANIM_FRZ
 	call PlayOpponentBattleAnim
-	call RefreshBattleHuds
+	farcall RefreshBattleHuds
 
 	ld hl, WasFrozenText
 	call StdBattleTextbox
@@ -5039,7 +5039,7 @@ BattleCommand_paralyzetarget:
 	call UpdateOpponentInParty
 	ld de, ANIM_PAR
 	call PlayOpponentBattleAnim
-	call RefreshBattleHuds
+	farcall RefreshBattleHuds
 	call PrintParalyze
 	jmp PostStatusWithSynchronize
 
@@ -5239,7 +5239,7 @@ StatusTargetVerbose:
 	ld [hl], a
 	call DisplayStatusProblem
 	call UpdateOpponentInParty
-	call UpdateBattleHuds
+	farcall UpdateBattleHuds
 	call PostStatusWithSynchronize
 	xor a
 	ret
@@ -5300,7 +5300,7 @@ BattleCommand_rampage:
 	jr nz, .already_rampaging
 	set SUBSTATUS_RAMPAGE, [hl]
 ; Rampage for 1 or 2 more turns
-	call BattleRandom
+	farcall BattleRandom
 	and %00000001
 	inc a
 	ld [de], a
@@ -5333,7 +5333,7 @@ HandleRampage_ConfuseUser:
 
 	set SUBSTATUS_CONFUSED, [hl]
 	inc de ; ConfuseCount
-	call BattleRandom
+	farcall BattleRandom
 	and %11
 	inc a
 	inc a
@@ -5677,7 +5677,7 @@ BattleCommand_traptarget:
 	pop de
 	pop bc
 	jr z, .seven_turns
-	call BattleRandom
+	farcall BattleRandom
 	and 1
 	add 4
 	jr .got_count
@@ -5774,7 +5774,7 @@ BattleCommand_confusetarget:
 	ld a, b
 	cp HELD_PREVENT_CONFUSE
 	ret z
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp OWN_TEMPO
 	ret z
 	ld a, [wEffectFailed]
@@ -5804,7 +5804,7 @@ BattleCommand_confuse:
 	jmp StdBattleTextbox
 
 .no_item_protection
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp OWN_TEMPO
 	jr nz, .no_ability_protection
 	farcall DisableAnimations
@@ -5837,7 +5837,7 @@ FinishConfusingTarget:
 
 .got_confuse_count
 	set SUBSTATUS_CONFUSED, [hl]
-	call BattleRandom
+	farcall BattleRandom
 	and %11
 	inc a
 	inc a
@@ -5943,7 +5943,7 @@ BattleCommand_heal:
 	call AnimateCurrentMove
 	farcall RestoreHP
 	call UpdateUserInParty
-	call RefreshBattleHuds
+	farcall RefreshBattleHuds
 	ld hl, RegainedHealthText
 	jmp StdBattleTextbox
 
@@ -6122,7 +6122,7 @@ BattleCommand_defrost:
 	res FRZ, [hl]
 
 .done
-	call RefreshBattleHuds
+	farcall RefreshBattleHuds
 	ld hl, WasDefrostedText
 	jmp StdBattleTextbox
 
@@ -6292,7 +6292,7 @@ BattleCommand_doubleminimizedamage:
 	ld [hl], a
 	ret
 
-_GetTrueUserAbility::
+GetTrueUserAbility::
 ; Returns current user's ability, or 0 (no ability) for external future sight user
 ; Also returns 0 (no ability) if opponent has Neutralizing Gas and user doesn't
 	call GetFutureSightUser

--- a/engine/battle/endturn.asm
+++ b/engine/battle/endturn.asm
@@ -296,7 +296,7 @@ HandleWeather:
 	call GetBattleVar
 	bit SUBSTATUS_UNDERGROUND, a
 	ret nz
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	cp MAGIC_GUARD
 	ret z
 	cp OVERCOAT
@@ -337,7 +337,7 @@ HandleWeather:
 	call GetBattleVar
 	bit SUBSTATUS_UNDERGROUND, a
 	ret nz
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	cp MAGIC_GUARD
 	ret z
 	cp OVERCOAT
@@ -463,7 +463,7 @@ HandleLeftovers:
 
 PreventEndturnDamage:
 ; returns z if residual damage at endturn is prevented
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	cp MAGIC_GUARD
 	call nz, HasUserFainted
 	ret
@@ -530,7 +530,7 @@ HandlePoison:
 	ld hl, HurtByPoisonText
 	ld de, ANIM_PSN
 	ret z
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	cp POISON_HEAL
 	jr nz, DoPoisonBurnDamage
 	; check if we are at full HP
@@ -984,7 +984,7 @@ HandleStatusOrbs:
 	xor a
 	ld [wNumHits], a
 	farcall PlayOpponentBattleAnim
-	call RefreshBattleHuds
+	farcall RefreshBattleHuds
 	pop hl
 	jmp StdBattleTextbox
 

--- a/engine/battle/misc.asm
+++ b/engine/battle/misc.asm
@@ -1,4 +1,6 @@
-_CheckContactMove::
+CheckOpponentContactMove::
+	call CallOpponentTurn
+CheckContactMove::
 ; Check if user's move made contact. Returns nc if it is
 	predef GetUserItemAfterUnnerve
 	ld a, b

--- a/engine/battle/move_effects/attract.asm
+++ b/engine/battle/move_effects/attract.asm
@@ -11,7 +11,7 @@ BattleCommand_attract:
 	call GetBattleVarAddr
 	bit SUBSTATUS_IN_LOVE, [hl]
 	jr nz, .failed
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp OBLIVIOUS
 	jr nz, .no_ability_protection
 

--- a/engine/battle/move_effects/bug_bite.asm
+++ b/engine/battle/move_effects/bug_bite.asm
@@ -1,6 +1,6 @@
 BattleCommand_bugbite:
 	; these abilities prevent us from eating it
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp UNNERVE
 	ret z
 	call CheckStickyHold

--- a/engine/battle/move_effects/conversion.asm
+++ b/engine/battle/move_effects/conversion.asm
@@ -95,7 +95,7 @@ BattleCommand_conversion:
 	ld a, [wMenuCursorY]
 	ld [wCurMoveNum], a
 
-	call UpdateBattleHuds
+	farcall UpdateBattleHuds
 	call Call_LoadTempTileMapToTileMap
 
 	ld a, [wLinkMode]
@@ -159,7 +159,7 @@ BattleCommand_conversion:
 	jr .validate_choice
 .not_smart
 .enemy_wild
-	call BattleRandom
+	farcall BattleRandom
 	and %11 ; NUM_MOVES - 1
 .validate_choice
 	pop de

--- a/engine/battle/move_effects/explosion.asm
+++ b/engine/battle/move_effects/explosion.asm
@@ -1,5 +1,5 @@
 BattleCommand_selfdestruct:
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp DAMP
 	ret z ; nullification ability checks handle messages
 	ld hl, wWhichMonFaintedFirst
@@ -36,4 +36,4 @@ BattleCommand_selfdestruct:
 	farcall DrawPlayerHUD
 	farcall DrawEnemyHUD
 	call ApplyTilemapInVBlank
-	jmp RefreshBattleHuds
+	farjp RefreshBattleHuds

--- a/engine/battle/move_effects/low_kick.asm
+++ b/engine/battle/move_effects/low_kick.asm
@@ -15,7 +15,7 @@ BattleCommand_lowkick:
 	ld d, h
 	ld e, l
 
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp LIGHT_METAL
 	jr nz, .not_light_metal
 	srl d

--- a/engine/battle/move_effects/magic_bounce.asm
+++ b/engine/battle/move_effects/magic_bounce.asm
@@ -1,6 +1,6 @@
 BattleCommand_bounceback:
 ; Possibly bounce back an attack with Magic Bounce
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp MAGIC_BOUNCE
 	ret nz
 

--- a/engine/battle/move_effects/magnitude.asm
+++ b/engine/battle/move_effects/magnitude.asm
@@ -1,6 +1,6 @@
 BattleCommand_getmagnitude:
 	push bc
-	call BattleRandom
+	farcall BattleRandom
 	ld b, a
 	ld hl, MagnitudePower
 .loop

--- a/engine/battle/move_effects/metronome.asm
+++ b/engine/battle/move_effects/metronome.asm
@@ -13,7 +13,7 @@ BattleCommand_metronome:
 	call LoadMoveAnim
 
 .GetMove:
-	call BattleRandom
+	farcall BattleRandom
 
 ; None of the moves in MetronomeExcepts.
 	push af

--- a/engine/battle/move_effects/perish_song.asm
+++ b/engine/battle/move_effects/perish_song.asm
@@ -23,7 +23,7 @@ BattleCommand_perishsong:
 	jr nz, .opponent_done
 
 	; Check if opponent Soundproof immunity applies
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp SOUNDPROOF
 	jr z, .soundproof
 	ld a, 4

--- a/engine/battle/move_effects/protect.asm
+++ b/engine/battle/move_effects/protect.asm
@@ -40,7 +40,7 @@ ProtectChance:
 .done
 
 .rand
-	call BattleRandom
+	farcall BattleRandom
 	and a
 	jr z, .rand
 

--- a/engine/battle/move_effects/roar.asm
+++ b/engine/battle/move_effects/roar.asm
@@ -2,7 +2,7 @@ BattleCommand_roar:
 	ld a, [wBattleType]
 	cp BATTLETYPE_TRAP ; or BATTLETYPE_FORCEITEM, BATTLETYPE_RED_GYARADOS, BATTLETYPE_LEGENDARY
 	jr nc, .but_it_failed
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp SUCTION_CUPS
 	ld a, ATKFAIL_ABILITY
 	jr z, .fail

--- a/engine/battle/move_effects/substitute.asm
+++ b/engine/battle/move_effects/substitute.asm
@@ -53,7 +53,7 @@ BattleCommand_substitute:
 .finish
 	ld hl, MadeSubstituteText
 	call StdBattleTextbox
-	jmp RefreshBattleHuds
+	farjp RefreshBattleHuds
 
 .already_has_sub
 	call CheckUserIsCharging

--- a/engine/battle/move_effects/thief.asm
+++ b/engine/battle/move_effects/thief.asm
@@ -47,7 +47,7 @@ CheckStickyHold:
 ; Returns nz if opponent Sticky Hold is in effect.
 	call HasOpponentFainted
 	ret z
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp STICKY_HOLD
 	jr nz, .no_sticky_hold
 
@@ -78,7 +78,7 @@ CanStealItem:
 	ret nz
 
 	; Sticky Hold prevents item theft
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp STICKY_HOLD
 	jr z, .cant_ability
 

--- a/engine/battle/move_effects/tri_attack.asm
+++ b/engine/battle/move_effects/tri_attack.asm
@@ -3,7 +3,7 @@ BattleCommand_tristatuschance:
 
 ; 1/3 chance of each status
 .loop
-	call BattleRandom
+	farcall BattleRandom
 	swap a
 	and %11
 	jr z, .loop

--- a/engine/battle/move_effects/trick.asm
+++ b/engine/battle/move_effects/trick.asm
@@ -6,7 +6,7 @@ BattleCommand_trick:
 	call CheckSubstituteOpp
 	jr nz, .failed
 
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp STICKY_HOLD
 	jr z, .ability_failed
 

--- a/engine/battle/stats.asm
+++ b/engine/battle/stats.asm
@@ -48,7 +48,7 @@ FarChangeStat:
 	; Do target-only checks
 	bit STAT_TARGET_F, b
 	jr nz, .is_target
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	cp CONTRARY
 	jmp nz, .perform_change
 	ld a, b
@@ -57,7 +57,7 @@ FarChangeStat:
 	jmp .perform_change
 
 .is_target
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp CONTRARY
 	jr nz, .no_target_contrary
 	ld a, b
@@ -91,7 +91,7 @@ FarChangeStat:
 	jr nz, .mist_or_item_fail
 
 .check_ability
-	call GetOpponentAbilityAfterMoldBreaker
+	farcall GetOpponentAbilityAfterMoldBreaker
 	cp CLEAR_BODY
 	jr z, .ability_immune
 	cp WHITE_SMOKE

--- a/engine/battle/trainer_huds.asm
+++ b/engine/battle/trainer_huds.asm
@@ -215,7 +215,7 @@ INCBIN "gfx/battle/balls.2bpp"
 
 _ShowLinkBattleParticipants:
 	call ClearBGPalettes
-	call LoadFrame
+	farcall LoadFrame
 	hlcoord 2, 3
 	lb bc, 9, 14
 	call Textbox

--- a/engine/battle_anims/anim_commands.asm
+++ b/engine/battle_anims/anim_commands.asm
@@ -169,7 +169,7 @@ BattleAnimRestoreHUDs:
 	ld a, $1
 	ldh [rSVBK], a
 
-	call UpdateBattleHuds
+	farcall UpdateBattleHuds
 
 	pop af
 	ldh [rSVBK], a

--- a/engine/events/bug_contest/display_stats.asm
+++ b/engine/events/bug_contest/display_stats.asm
@@ -2,7 +2,7 @@ DisplayCaughtContestMonStats:
 	call ClearBGPalettes
 	call ClearTileMap
 	call ClearSprites
-	call LoadFontsBattleExtra
+	farcall LoadFontsBattleExtra
 
 	ld hl, wOptions1
 	ld a, [hl]

--- a/engine/events/celebi.asm
+++ b/engine/events/celebi.asm
@@ -18,7 +18,7 @@ Special_CelebiShrineEvent:
 
 	depixel 0, 10, 7, 0
 	ld a, SPRITE_ANIM_INDEX_CELEBI
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld hl, SPRITEANIMSTRUCT_TILE_ID
 	add hl, bc
 	ld [hl], $84
@@ -169,20 +169,20 @@ UpdateCelebiPosition:
 	ld hl, SPRITEANIMSTRUCT_FRAMESET_ID
 	add hl, bc
 	ld a, SPRITE_ANIM_FRAMESET_CELEBI_RIGHT
-	jmp ReinitSpriteAnimFrame
+	farjp ReinitSpriteAnimFrame
 
 .left
 	ld hl, SPRITEANIMSTRUCT_FRAMESET_ID
 	add hl, bc
 	ld a, SPRITE_ANIM_FRAMESET_CELEBI_LEFT
-	jmp ReinitSpriteAnimFrame
+	farjp ReinitSpriteAnimFrame
 
 .FreezeCelebiPosition:
 	pop af
 	ld hl, SPRITEANIMSTRUCT_FRAMESET_ID
 	add hl, bc
 	ld a, SPRITE_ANIM_FRAMESET_CELEBI_LEFT
-	jmp ReinitSpriteAnimFrame
+	farjp ReinitSpriteAnimFrame
 
 GetCelebiSpriteTile:
 	push hl

--- a/engine/events/daycare.asm
+++ b/engine/events/daycare.asm
@@ -880,7 +880,7 @@ DayCare_GenerateEgg:
 	cp 3
 	jr z, .no_ha_boost
 	sla a
-	call BattleRandomRange
+	farcall BattleRandomRange
 	and a
 	jr nz, .no_ha_boost
 	ld a, HIDDEN_ABILITY

--- a/engine/events/field_moves.asm
+++ b/engine/events/field_moves.asm
@@ -59,7 +59,7 @@ ShakeHeadbuttTree:
 	xor a
 	rst ByteFill
 	call DelayFrame
-	jmp UpdatePlayerSprite
+	farjp UpdatePlayerSprite
 
 HideHeadbuttTree:
 	xor a

--- a/engine/events/field_moves.asm
+++ b/engine/events/field_moves.asm
@@ -49,7 +49,7 @@ ShakeHeadbuttTree:
 	jr .loop
 
 .done
-	call LoadMapPart
+	farcall LoadMapPart
 	call ApplyTilemapInVBlank
 	xor a
 	ldh [hBGMapMode], a

--- a/engine/events/halloffame.asm
+++ b/engine/events/halloffame.asm
@@ -283,7 +283,7 @@ HOF_SlideBackpic:
 	jr .backpicloop
 
 _HallOfFamePC:
-	call LoadFontsBattleExtra
+	farcall LoadFontsBattleExtra
 	xor a
 	ld [wJumptableIndex], a
 .MasterLoop:

--- a/engine/events/judge_machine.asm
+++ b/engine/events/judge_machine.asm
@@ -426,7 +426,7 @@ SparkleMaxStatOrShowBottleCap:
 	ret nc
 InitSpriteAnimStruct_PreserveHL:
 	push hl
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	pop hl
 	scf
 	ret

--- a/engine/events/overworld.asm
+++ b/engine/events/overworld.asm
@@ -303,7 +303,7 @@ CutDownGrass:
 	ld [hl], a
 	xor a
 	ldh [hBGMapMode], a
-	call LoadMapPart
+	farcall LoadMapPart
 	call UpdateSprites
 	call DelayFrame
 	ld a, 1 ; Animation type
@@ -369,7 +369,7 @@ CutDownTree:
 	farcall CopyBGGreenToOBPal7
 	xor a
 	ldh [hBGMapMode], a
-	call LoadMapPart
+	farcall LoadMapPart
 	call UpdateSprites
 	call DelayFrame
 	xor a ; Animation type

--- a/engine/events/overworld.asm
+++ b/engine/events/overworld.asm
@@ -378,7 +378,7 @@ CutDownTree:
 	call GetMovementPermissions
 	call UpdateSprites
 	call DelayFrame
-	jmp LoadStandardFont
+	farjp LoadStandardFont
 
 TryFlashOW::
 	ld a, [wTimeOfDayPalset]
@@ -788,7 +788,7 @@ FlyFunction:
 	farcall ClearSavedObjPals
 	farcall CheckForUsedObjPals
 	call DelayFrame
-	jmp UpdatePlayerSprite
+	farjp UpdatePlayerSprite
 
 WaterfallFunction:
 	call .TryWaterfall
@@ -1777,7 +1777,7 @@ PutTheRodAway:
 	ld a, $1
 	ld [wPlayerAction], a
 	call UpdateSprites
-	jmp UpdatePlayerSprite
+	farjp UpdatePlayerSprite
 
 CurItemToScriptVar:
 	ld a, [wCurItem]

--- a/engine/events/poisonstep.asm
+++ b/engine/events/poisonstep.asm
@@ -205,4 +205,4 @@ endc
 	ldh [hCGBPalUpdate], a
 	ld c, 4
 	call DelayFrames
-	farjp _UpdateTimePals
+	farjp UpdateTimePals

--- a/engine/events/pokecenter_pc.asm
+++ b/engine/events/pokecenter_pc.asm
@@ -168,7 +168,7 @@ _PlayersHousePC:
 	call _PlayersPC
 	and a
 	jr nz, .asm_156f9
-	call LoadMapPart
+	farcall LoadMapPart
 	call ApplyTilemap
 	call UpdateSprites
 	call PC_PlayShutdownSound
@@ -200,7 +200,7 @@ _PlayersPC:
 	ld hl, PlayersPCMenuData
 	call LoadMenuHeader
 .asm_15722
-	call UpdateTimePals
+	farcall UpdateTimePals
 	call DoNthMenu
 	jr c, .asm_15731
 	call MenuJumptable

--- a/engine/events/pokepic.asm
+++ b/engine/events/pokepic.asm
@@ -15,7 +15,7 @@ Pokepic::
 	call GetPartyParamLocationAndValue
 	ld [wCurForm], a
 .got_palette
-	call UpdateTimePals
+	farcall UpdateTimePals
 	xor a
 	ldh [hBGMapMode], a
 	ld a, [wCurPartySpecies]
@@ -45,7 +45,7 @@ Trainerpic::
 	call UpdateSprites
 	call SafeCopyTilemapAtOnce
 	farcall LoadTrainerPalette
-	call UpdateTimePals
+	farcall UpdateTimePals
 	xor a
 	ldh [hBGMapMode], a
 	ld a, [wTrainerClass]
@@ -55,7 +55,7 @@ Trainerpic::
 
 Paintingpic::
 	farcall LoadPaintingPalette
-	call UpdateTimePals
+	farcall UpdateTimePals
 	ld de, PaintingFrameGFX
 	ld hl, vTiles0 tile ("┌" - 3)
 	lb bc, BANK(PaintingFrameGFX), 11
@@ -85,7 +85,7 @@ ClosePokepic::
 	call GetMemCGBLayout
 	xor a
 	ldh [hBGMapMode], a
-	call LoadMapPart
+	farcall LoadMapPart
 	call UpdateSprites
 	ld b, 1
 	call SafeCopyTilemapAtOnce

--- a/engine/games/card_flip.asm
+++ b/engine/games/card_flip.asm
@@ -12,8 +12,8 @@ _CardFlip:
 ;	call PlayMusic
 	call DelayFrame
 	call DisableLCD
-	call LoadStandardFont
-	call LoadFrame
+	farcall LoadStandardFont
+	farcall LoadFrame
 
 	ld hl, CardFlipLZ01
 	ld de, vTiles2 tile $00

--- a/engine/games/slot_machine.asm
+++ b/engine/games/slot_machine.asm
@@ -918,7 +918,7 @@ ReelAction_InitGolem:
 	push af
 	depixel 12, 13
 	ld a, SPRITE_ANIM_INDEX_SLOTS_GOLEM
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld hl, SPRITEANIMSTRUCT_VAR3
 	add hl, bc
 	pop af
@@ -973,7 +973,7 @@ Slots_InitChansey:
 	push bc
 	depixel 12, 0
 	ld a, SPRITE_ANIM_INDEX_SLOTS_CHANSEY
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	pop bc
 	xor a
 	ld [wSlotsDelay], a
@@ -1837,7 +1837,7 @@ Slots_AnimateChansey:
 	push bc
 	depixel 12, 13, 0, 4
 	ld a, SPRITE_ANIM_INDEX_SLOTS_EGG
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	pop bc
 	ret
 

--- a/engine/gfx/fade.asm
+++ b/engine/gfx/fade.asm
@@ -1,4 +1,34 @@
-_DoFadePalettes::
+; Functions to fade the screen in and out.
+
+;FadeBGPalettes::
+;	ld a, PALFADE_BG
+;	ld [wPalFadeMode], a
+;	jr DoFadePalettes
+
+;FadeOBPalettes::
+;	ld a, PALFADE_OBJ
+;	ld [wPalFadeMode], a
+;	jr DoFadePalettes
+
+FadeToWhite::
+	push bc
+	call SetWhitePals
+	pop bc
+	jr FadePalettes
+
+FadeToBlack::
+	push bc
+	call SetBlackPals
+	pop bc
+	; fallthrough
+
+FadePalettes::
+; Fades active palettes in wBGPals2/wOBPals2 to new ones in wBGPals1/wOBPals1 in c frames
+	xor a
+	ld [wPalFadeMode], a
+	; fallthrough
+
+DoFadePalettes::
 ; w(BG|OB)Pals: Current palettes
 ; wUnkn(BG|OB)Pals: Palettes we're fading towards
 ; b: Controls partial fading gradient

--- a/engine/gfx/load_font.asm
+++ b/engine/gfx/load_font.asm
@@ -1,15 +1,15 @@
 INCLUDE "gfx/font.asm"
 
-_LoadStandardOpaqueFont::
+LoadStandardOpaqueFont::
 	ld a, TRUE
-	call _LoadStandardMaybeOpaqueFont
+	call LoadStandardMaybeOpaqueFont
 	ld hl, vTiles2 tile " "
 	ld de, TextboxSpaceGFX
 	jmp GetOpaque1bppFontTile
 
-_LoadStandardFont::
+LoadStandardFont::
 	xor a
-_LoadStandardMaybeOpaqueFont:
+LoadStandardMaybeOpaqueFont:
 	push af
 	call LoadStandardFontPointer
 	ld d, h
@@ -54,13 +54,14 @@ LoadStandardFontPointer::
 	dw FontUnown
 	assert_table_length NUM_FONTS
 
-_LoadFontsBattleExtra::
+LoadFontsBattleExtra::
 	ld hl, BattleExtrasGFX
 	ld de, vTiles2 tile BATTLEEXTRA_GFX_START
 	lb bc, BANK(BattleExtrasGFX), 32
 	call DecompressRequest2bpp
+	; fallthrough
 
-_LoadFrame::
+LoadFrame::
 	ld a, [wTextboxFrame]
 	ld bc, TEXTBOX_FRAME_TILES * LEN_1BPP_TILE
 	ld hl, Frames
@@ -76,7 +77,8 @@ _LoadFrame::
 	jmp Get1bpp
 
 LoadBattleFontsHPBar:
-	call _LoadFontsBattleExtra
+	call LoadFontsBattleExtra
+	; fallthrough
 
 LoadPlayerStatusIcon:
 	push de

--- a/engine/gfx/mon_icons.asm
+++ b/engine/gfx/mon_icons.asm
@@ -316,7 +316,7 @@ endr
 
 	pop de
 	ld a, SPRITE_ANIM_INDEX_PARTY_MON
-	call _InitSpriteAnimStruct
+	call InitSpriteAnimStruct
 	ld hl, SPRITEANIMSTRUCT_ANIM_SEQ_ID
 	add hl, bc
 	ld [hl], SPRITE_ANIM_SEQ_NULL
@@ -355,7 +355,7 @@ InitPartyMenuMini:
 	ld e, $10
 ; type is partymon icon
 	ld a, SPRITE_ANIM_INDEX_PARTY_MON
-	call _InitSpriteAnimStruct
+	call InitSpriteAnimStruct
 	pop af
 	ld hl, SPRITEANIMSTRUCT_TILE_ID
 	add hl, bc

--- a/engine/gfx/sprite_anims.asm
+++ b/engine/gfx/sprite_anims.asm
@@ -139,7 +139,7 @@ AnimSeq_SlotsChansey:
 	ret nz
 	ld [hl], 3
 	ld a, SPRITE_ANIM_FRAMESET_SLOTS_CHANSEY_2
-	jmp _ReinitSpriteAnimFrame
+	jmp ReinitSpriteAnimFrame
 
 AnimSeq_SlotsChanseyEgg:
 	ld hl, SPRITEANIMSTRUCT_JUMPTABLE_INDEX
@@ -194,7 +194,7 @@ AnimSeq_TradePokeBall:
 
 .zero
 	ld a, SPRITE_ANIM_FRAMESET_TRADE_POKE_BALL_0
-	call _ReinitSpriteAnimFrame
+	call ReinitSpriteAnimFrame
 
 	ld hl, SPRITEANIMSTRUCT_JUMPTABLE_INDEX
 	add hl, bc
@@ -520,7 +520,7 @@ AnimSeq_IntroSuicune:
 	add hl, bc
 	ld [hl], a
 	ld a, SPRITE_ANIM_FRAMESET_INTRO_SUICUNE_2
-	jmp _ReinitSpriteAnimFrame
+	jmp ReinitSpriteAnimFrame
 
 AnimSeq_IntroPichuWooper:
 	ld hl, SPRITEANIMSTRUCT_VAR1
@@ -572,7 +572,7 @@ AnimSeq_IntroUnownF:
 	cp $40
 	ret nz
 	ld a, SPRITE_ANIM_FRAMESET_INTRO_UNOWN_F_2
-	jmp _ReinitSpriteAnimFrame
+	jmp ReinitSpriteAnimFrame
 
 AnimSeq_IntroSuicuneAway:
 	ld hl, SPRITEANIMSTRUCT_YCOORD

--- a/engine/gfx/sprites.asm
+++ b/engine/gfx/sprites.asm
@@ -86,7 +86,7 @@ DoNextFrameForFirst16Sprites:
 	ld [hli], a
 	jr .loop2
 
-_InitSpriteAnimStruct::
+InitSpriteAnimStruct::
 ; Initialize animation a at pixel x=e, y=d
 ; Find if there's any room in the wSpriteAnimationStructs array, which is 10x16
 	push de
@@ -370,7 +370,7 @@ GetSpriteAnimVTile:
 	pop hl
 	ret
 
-_ReinitSpriteAnimFrame::
+ReinitSpriteAnimFrame::
 	ld hl, SPRITEANIMSTRUCT_FRAMESET_ID
 	add hl, bc
 	ld [hl], a

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -615,7 +615,7 @@ endc
 	ld c, 15
 	call FadeToWhite
 
-	call LoadStandardFont
+	farcall LoadStandardFont
 
 	pop hl
 	ld de, wStringBuffer1
@@ -702,7 +702,7 @@ endc
 	ld c, 15
 	call FadeToWhite
 
-	call LoadStandardFont
+	farcall LoadStandardFont
 	jr .return_from_capture
 
 .catch_bug_contest_mon

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -613,7 +613,7 @@ endc
 	farcall NamingScreen
 
 	ld c, 15
-	call FadeToWhite
+	farcall FadeToWhite
 
 	farcall LoadStandardFont
 
@@ -700,7 +700,7 @@ endc
 	call PrintTextNoBox
 
 	ld c, 15
-	call FadeToWhite
+	farcall FadeToWhite
 
 	farcall LoadStandardFont
 	jr .return_from_capture

--- a/engine/items/tmhm2.asm
+++ b/engine/items/tmhm2.asm
@@ -45,7 +45,7 @@ TMHM_PocketLoop:
 	jr TMHM_ShowTMMoveDescription
 
 TMHM_JoypadLoop:
-	call DoMenuJoypadLoop
+	farcall DoMenuJoypadLoop
 	ld b, a
 	push hl
 	ld hl, wTMHMPocketCursor

--- a/engine/link/link.asm
+++ b/engine/link/link.asm
@@ -307,7 +307,7 @@ LinkTimeout:
 	bccoord 1, 14
 	call PlaceWholeStringInBoxAtOnce
 	ld c, 15
-	call FadeToWhite
+	farcall FadeToWhite
 	call ClearScreen
 	ld a, CGB_PLAIN
 	call GetCGBLayout
@@ -1302,7 +1302,7 @@ LinkTradePartymonMenuCheckCancel:
 	jr nz, .loop1
 ExitLinkCommunications:
 	ld c, 15
-	call FadeToWhite
+	farcall FadeToWhite
 	call ClearScreen
 	ld a, CGB_PLAIN
 	call GetCGBLayout

--- a/engine/link/link.asm
+++ b/engine/link/link.asm
@@ -12,8 +12,8 @@ LinkCommunications:
 	call DelayFrames
 	call ClearScreen
 	call UpdateSprites
-	call LoadStandardFont
-	call LoadFontsBattleExtra
+	farcall LoadStandardFont
+	farcall LoadFontsBattleExtra
 	call LoadTradeScreenGFX
 	call ApplyAttrAndTilemapInVBlank
 	hlcoord 3, 8
@@ -1600,7 +1600,7 @@ LinkTrade:
 	ld c, 100
 	call DelayFrames
 	call ClearTileMap
-	call LoadFontsBattleExtra
+	farcall LoadFontsBattleExtra
 	ld a, CGB_PLAIN
 	call GetCGBLayout
 	ldh a, [hSerialConnectionStatus]

--- a/engine/link/link.asm
+++ b/engine/link/link.asm
@@ -1066,7 +1066,7 @@ LinkTrade_TradeStatsMenu:
 	xor a
 	ld [w2DMenuFlags1], a
 	ld [w2DMenuFlags2], a
-	call DoMenuJoypadLoop
+	farcall DoMenuJoypadLoop
 	bit D_RIGHT_F, a
 	jr nz, .d_right
 	bit B_BUTTON_F, a
@@ -1098,9 +1098,9 @@ LinkTrade_TradeStatsMenu:
 	xor a
 	ld [w2DMenuFlags1], a
 	ld [w2DMenuFlags2], a
-	call DoMenuJoypadLoop
+	farcall DoMenuJoypadLoop
 	bit D_LEFT_F, a
-	jr nz, .joy_loop
+	jmp nz, .joy_loop
 	bit B_BUTTON_F, a
 	jr nz, .b_button
 	jr .try_trade
@@ -1393,7 +1393,7 @@ LinkTrade:
 	ld [wMenuCursorY], a
 	ld [wMenuCursorX], a
 	call Link_WaitBGMap
-	call DoMenuJoypadLoop
+	farcall DoMenuJoypadLoop
 	push af
 	call ExitMenu
 	call ApplyAttrAndTilemapInVBlank

--- a/engine/menus/delete_save.asm
+++ b/engine/menus/delete_save.asm
@@ -2,8 +2,8 @@ _DeleteSaveData:
 	farcall BlankScreen
 	ld a, CGB_PLAIN
 	call GetCGBLayout
-	call LoadStandardFont
-	call LoadFrame
+	farcall LoadStandardFont
+	farcall LoadFrame
 	call BlackOutScreen
 	ld de, MUSIC_MAIN_MENU
 	call PlayMusic
@@ -41,8 +41,8 @@ _ResetInitialOptions:
 	farcall BlankScreen
 	ld a, CGB_PLAIN
 	call GetCGBLayout
-	call LoadStandardFont
-	call LoadFrame
+	farcall LoadStandardFont
+	farcall LoadFrame
 	call BlackOutScreen
 	ld de, MUSIC_MAIN_MENU
 	call PlayMusic

--- a/engine/menus/init_options.asm
+++ b/engine/menus/init_options.asm
@@ -11,7 +11,7 @@ SetInitialOptions:
 	call DelayFrames
 
 	call ClearBGPalettes
-	call LoadFrame
+	farcall LoadFrame
 
 	hlcoord 0, 0
 	ld bc, SCREEN_HEIGHT * SCREEN_WIDTH

--- a/engine/menus/intro_menu.asm
+++ b/engine/menus/intro_menu.asm
@@ -39,8 +39,8 @@ NewGame_ClearTileMapEtc:
 	ldh [hMapAnims], a
 	ld a, "<BLACK>"
 	call FillTileMap
-	call LoadFrame
-	call LoadStandardFont
+	farcall LoadFrame
+	farcall LoadStandardFont
 	jmp ClearWindowData
 
 NewGamePlus:
@@ -434,14 +434,14 @@ DisplayNormalContinueData:
 	call Continue_LoadMenuHeader
 	call Continue_DisplayBadgesDexPlayerName
 	call Continue_PrintGameTime
-	call LoadFrame
+	farcall LoadFrame
 	jmp UpdateSprites
 
 DisplayContinueDataWithRTCError:
 	call Continue_LoadMenuHeader
 	call Continue_DisplayBadgesDexPlayerName
 	call Continue_UnknownGameTime
-	call LoadFrame
+	farcall LoadFrame
 	jmp UpdateSprites
 
 Continue_LoadMenuHeader:
@@ -638,7 +638,7 @@ endc
 	call NamePlayer
 
 	call ClearTileMap
-	call LoadFrame
+	farcall LoadFrame
 	call ApplyTilemapInVBlank
 	call DrawIntroPlayerPic
 
@@ -966,7 +966,7 @@ ShrinkPlayer:
 	call DelayFrames
 
 	call Intro_PlacePlayerSprite
-	call LoadFrame
+	farcall LoadFrame
 
 	ld c, 50
 	call DelayFrames
@@ -1352,7 +1352,7 @@ ResetInitialOptions:
 
 Copyright:
 	call ClearTileMap
-	call LoadFrame
+	farcall LoadFrame
 	ld hl, CopyrightGFX
 	ld de, vTiles2 tile $60
 	lb bc, BANK(CopyrightGFX), $1d

--- a/engine/menus/intro_menu.asm
+++ b/engine/menus/intro_menu.asm
@@ -1104,7 +1104,7 @@ StartTitleScreen:
 	ldh [hWY], a
 	ld a, CGB_PLAIN
 	call GetCGBLayout
-	call UpdateTimePals
+	farcall UpdateTimePals
 	ld a, [wIntroSceneFrameCounter]
 	cp $6
 	jr c, .ok

--- a/engine/menus/intro_menu.asm
+++ b/engine/menus/intro_menu.asm
@@ -556,14 +556,14 @@ Continue_DisplayGameTime:
 ProfElmSpeech:
 	farcall InitClock
 	ld c, 31
-	call FadeToBlack
+	farcall FadeToBlack
 	call ClearTileMap
 
 	ld de, MUSIC_ROUTE_30
 	call PlayMusic
 
 	ld c, 31
-	call FadeToWhite
+	farcall FadeToWhite
 
 	xor a
 	ld [wCurPartySpecies], a
@@ -580,7 +580,7 @@ ProfElmSpeech:
 	call PrintText
 if !DEF(DEBUG)
 	ld c, 15
-	call FadeToWhite
+	farcall FadeToWhite
 	call ClearTileMap
 
 	ld a, LOW(GLACEON)
@@ -609,7 +609,7 @@ if !DEF(DEBUG)
 	ld hl, ElmText4
 	call PrintText
 	ld c, 15
-	call FadeToWhite
+	farcall FadeToWhite
 	call ClearTileMap
 
 	xor a
@@ -688,7 +688,7 @@ ElmText7:
 
 InitGender:
 	ld c, 15
-	call FadeToWhite
+	farcall FadeToWhite
 	call ClearTileMap
 
 	call InitGenderGraphics
@@ -705,7 +705,7 @@ InitGender:
 	call GenderMenu
 
 	ld c, 15
-	call FadeToWhite
+	farcall FadeToWhite
 	call ClearTileMap
 	call ClearTileMap
 
@@ -972,7 +972,7 @@ ShrinkPlayer:
 	call DelayFrames
 
 	ld c, 15
-	call FadeToWhite
+	farcall FadeToWhite
 	jmp ClearTileMap
 
 Intro_RotatePalettesLeftFrontpic:

--- a/engine/menus/menu.asm
+++ b/engine/menus/menu.asm
@@ -204,6 +204,10 @@ Init2DMenuCursorPosition:
 	ld [wMenuJoypadFilter], a
 	ret
 
+DoMenuJoypadLoop::
+	call _DoMenuJoypadLoop
+	jmp GetMenuJoypad
+
 _DoMenuJoypadLoop::
 	ld hl, w2DMenuFlags2
 	res 7, [hl]
@@ -694,7 +698,7 @@ Error_Cant_ExitMenu:
 	text_far _WindowPoppingErrorText
 	text_end
 
-_InitVerticalMenuCursor::
+InitVerticalMenuCursor::
 	ld a, [wMenuDataFlags]
 	ld b, a
 	ld hl, w2DMenuCursorInitY

--- a/engine/menus/naming_screen.asm
+++ b/engine/menus/naming_screen.asm
@@ -150,7 +150,7 @@ NamingScreen:
 	ld [hl], a
 	depixel 4, 4, 4, 0
 	ld a, SPRITE_ANIM_INDEX_RED_WALK
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld hl, SPRITEANIMSTRUCT_FRAMESET_ID
 	add hl, bc
 	ld [hl], SPRITE_ANIM_FRAMESET_NULL
@@ -178,7 +178,7 @@ NamingScreen:
 	ld [hl], a
 	ld a, c
 	depixel 4, 4, 4, 0
-	jmp InitSpriteAnimStruct
+	farjp InitSpriteAnimStruct
 
 .StoreMonIconParams:
 	ld a, MON_NAME_LENGTH - 1
@@ -302,7 +302,7 @@ NamingScreenJoypadLoop:
 .got_cursor
 	ld a, d
 	depixel 8, 3
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld a, c
 	ld [wNamingScreenCursorObjectPointer], a
 	ld a, b
@@ -841,7 +841,7 @@ _ComposeMailMessage:
 	; init mail icon
 	depixel 3, 2
 	ld a, SPRITE_ANIM_INDEX_PARTY_MON
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 
 	ld hl, SPRITEANIMSTRUCT_ANIM_SEQ_ID
 	add hl, bc
@@ -956,7 +956,7 @@ INCBIN "gfx/naming_screen/mail.2bpp.lz"
 .got_cursor
 	ld a, d
 	depixel 8, 2
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld a, c
 	ld [wNamingScreenCursorObjectPointer], a
 	ld a, b

--- a/engine/menus/naming_screen.asm
+++ b/engine/menus/naming_screen.asm
@@ -746,8 +746,8 @@ NamingScreen_GetLastCharacter:
 LoadNamingScreenGFX:
 	call ClearSprites
 	call ClearSpriteAnims
-	call LoadStandardFont
-	call LoadFrame
+	farcall LoadStandardFont
+	farcall LoadFrame
 
 	ld hl, NamingScreenGFX_Border
 	ld de, vTiles2 tile NAMINGSCREEN_BORDER

--- a/engine/menus/options_menu.asm
+++ b/engine/menus/options_menu.asm
@@ -328,7 +328,7 @@ UpdateFrame:
 	ld [hld], a
 	lb bc, PRINTNUM_LEFTALIGN, 2
 	call PrintNumFromReg
-	call LoadFrame
+	farcall LoadFrame
 	and a
 	ret
 
@@ -547,7 +547,7 @@ Options_Typeface:
 	ld [hl], a
 	call .NonePressed
 	call ApplyTilemapInVBlank
-	jmp LoadStandardFont
+	farjp LoadStandardFont
 
 .NonePressed:
 	ld b, 0

--- a/engine/menus/start_menu.asm
+++ b/engine/menus/start_menu.asm
@@ -73,7 +73,7 @@ StartMenu::
 	push af
 	ld a, 1
 	ldh [hOAMUpdate], a
-	call LoadFrame
+	farcall LoadFrame
 	pop af
 	ldh [hOAMUpdate], a
 .ReturnEnd:

--- a/engine/menus/start_menu.asm
+++ b/engine/menus/start_menu.asm
@@ -36,12 +36,12 @@ StartMenu::
 	call BGMapAnchorTopLeft
 	farcall LoadFonts_NoOAMUpdate
 	call .DrawBugContestStatus
-	call UpdateTimePals
+	farcall UpdateTimePals
 	jr .Select
 
 .Reopen:
 	call UpdateSprites
-	call UpdateTimePals
+	farcall UpdateTimePals
 	call .SetUpMenuItems
 	ld a, [wBattleMenuCursorBuffer]
 	ld [wMenuCursorBuffer], a
@@ -80,7 +80,7 @@ StartMenu::
 	call ExitMenu
 .ReturnEnd2:
 	call CloseText
-	jmp UpdateTimePals
+	farjp UpdateTimePals
 
 .GetInput:
 ; Return carry on exit, and no-carry on selection.

--- a/engine/movie/evolution_animation.asm
+++ b/engine/movie/evolution_animation.asm
@@ -292,7 +292,7 @@ EvolutionAnimation:
 	push de
 	depixel 9, 11
 	ld a, SPRITE_ANIM_INDEX_EVOLUTION_BALL_OF_LIGHT
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld hl, SPRITEANIMSTRUCT_JUMPTABLE_INDEX
 	add hl, bc
 	ld a, [wJumptableIndex]

--- a/engine/movie/init_hof_credits.asm
+++ b/engine/movie/init_hof_credits.asm
@@ -28,8 +28,8 @@ ClearDisplayForEndgame:
 	call ClearTileMap
 	call ClearSprites
 	call DisableLCD
-	call LoadStandardFont
-	call LoadFontsBattleExtra
+	farcall LoadStandardFont
+	farcall LoadFontsBattleExtra
 	hlbgcoord 0, 0
 	ld bc, vBGMap1 - vBGMap0
 	ld a, " "

--- a/engine/movie/intro.asm
+++ b/engine/movie/intro.asm
@@ -318,7 +318,7 @@ IntroScene7:
 	call ClearSpriteAnims
 	depixel 13, 27, 4, 0
 	ld a, SPRITE_ANIM_INDEX_INTRO_SUICUNE
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld a, $f0
 	ld [wGlobalAnimXOffset], a
 	call Intro_SetCGBPalUpdate
@@ -411,7 +411,7 @@ IntroScene10:
 	depixel 22, 6
 	ld a, SPRITE_ANIM_INDEX_INTRO_WOOPER
 .got_anim
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld de, SFX_INTRO_PICHU
 	jmp PlaySFX
 
@@ -552,7 +552,7 @@ IntroScene13:
 	call ClearSpriteAnims
 	depixel 13, 11, 4, 0
 	ld a, SPRITE_ANIM_INDEX_INTRO_SUICUNE
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld de, MUSIC_CRYSTAL_OPENING
 	call PlayMusic
 	xor a
@@ -657,10 +657,10 @@ IntroScene15:
 	call Intro_SetCGBPalUpdate
 	depixel 8, 5
 	ld a, SPRITE_ANIM_INDEX_INTRO_UNOWN_F
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	depixel 12, 0
 	ld a, SPRITE_ANIM_INDEX_INTRO_SUICUNE_AWAY
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	xor a
 	ld [wIntroSceneFrameCounter], a
 	ld [wIntroSceneTimer], a
@@ -801,7 +801,7 @@ IntroScene19:
 	call Intro_SetCGBPalUpdate
 	depixel 12, 0
 	ld a, SPRITE_ANIM_INDEX_INTRO_SUICUNE_AWAY
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	xor a
 	ld [wIntroSceneFrameCounter], a
 	ld [wIntroSceneTimer], a
@@ -1021,41 +1021,41 @@ INCLUDE "gfx/intro/fade.pal"
 CrystalIntro_InitUnownAnim:
 	push de
 	ld a, SPRITE_ANIM_INDEX_INTRO_UNOWN
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld hl, SPRITEANIMSTRUCT_VAR1
 	add hl, bc
 	ld [hl], $8
 	ld a, SPRITE_ANIM_FRAMESET_INTRO_UNOWN_4
-	call ReinitSpriteAnimFrame
+	farcall ReinitSpriteAnimFrame
 	pop de
 
 	push de
 	ld a, SPRITE_ANIM_INDEX_INTRO_UNOWN
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld hl, SPRITEANIMSTRUCT_VAR1
 	add hl, bc
 	ld [hl], $18
 	ld a, SPRITE_ANIM_FRAMESET_INTRO_UNOWN_3
-	call ReinitSpriteAnimFrame
+	farcall ReinitSpriteAnimFrame
 	pop de
 
 	push de
 	ld a, SPRITE_ANIM_INDEX_INTRO_UNOWN
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld hl, SPRITEANIMSTRUCT_VAR1
 	add hl, bc
 	ld [hl], $28
 	ld a, SPRITE_ANIM_FRAMESET_INTRO_UNOWN_1
-	call ReinitSpriteAnimFrame
+	farcall ReinitSpriteAnimFrame
 	pop de
 
 	ld a, SPRITE_ANIM_INDEX_INTRO_UNOWN
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld hl, SPRITEANIMSTRUCT_VAR1
 	add hl, bc
 	ld [hl], $38
 	ld a, SPRITE_ANIM_FRAMESET_INTRO_UNOWN_2
-	jmp ReinitSpriteAnimFrame
+	farjp ReinitSpriteAnimFrame
 
 CrystalIntro_UnownFade:
 	add a

--- a/engine/movie/splash.asm
+++ b/engine/movie/splash.asm
@@ -24,12 +24,12 @@ SplashScreen:
 	farcall BSOD
 	call ApplyTilemapInVBlank
 	ld c, 15
-	call FadePalettes
+	farcall FadePalettes
 	ld c, 80
 	call DelayFrames
 	call SetBlackPals
 	ld c, 15
-	call FadePalettes
+	farcall FadePalettes
 	call ClearTileMap
 	ld a, CGB_GAMEFREAK_LOGO
 	call GetCGBLayout

--- a/engine/movie/splash.asm
+++ b/engine/movie/splash.asm
@@ -90,7 +90,7 @@ GameFreakPresentsInit:
 	call ClearSpriteAnims
 	depixel 10, 11, 4, 0
 	ld a, SPRITE_ANIM_INDEX_GAMEFREAK_LOGO
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld hl, SPRITEANIMSTRUCT_YOFFSET
 	add hl, bc
 	ld [hl], 160

--- a/engine/movie/trade_animation.asm
+++ b/engine/movie/trade_animation.asm
@@ -150,7 +150,7 @@ RunTradeAnimSequence:
 	call ClearSprites
 	call ClearTileMap
 	call DisableLCD
-	call LoadFontsBattleExtra
+	farcall LoadFontsBattleExtra
 	call ClearSpriteAnims
 	ld a, $1
 	ldh [rVBK], a
@@ -210,7 +210,7 @@ DoTradeAnimation:
 	ret
 
 .finished
-	call LoadStandardFont
+	farcall LoadStandardFont
 	scf
 	ret
 

--- a/engine/movie/trade_animation.asm
+++ b/engine/movie/trade_animation.asm
@@ -348,7 +348,7 @@ TradeAnim_InitTubeAnim:
 
 	pop de
 	ld a, SPRITE_ANIM_INDEX_TRADEMON_ICON
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 
 	ld hl, SPRITEANIMSTRUCT_JUMPTABLE_INDEX
 	add hl, bc
@@ -357,7 +357,7 @@ TradeAnim_InitTubeAnim:
 
 	pop de
 	ld a, SPRITE_ANIM_INDEX_TRADEMON_BUBBLE
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 
 	ld hl, SPRITEANIMSTRUCT_JUMPTABLE_INDEX
 	add hl, bc
@@ -949,7 +949,7 @@ TrademonStats_PrintTrademonID:
 TradeAnim_RockingBall:
 	depixel 10, 11, 4, 0
 	ld a, SPRITE_ANIM_INDEX_TRADE_POKE_BALL
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	call TradeAnim_AdvanceScriptPointer
 	ld a, $20
 	ld [wFrameCounter], a
@@ -958,7 +958,7 @@ TradeAnim_RockingBall:
 TradeAnim_DropBall:
 	depixel 10, 11, 4, 0
 	ld a, SPRITE_ANIM_INDEX_TRADE_POKE_BALL
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld hl, SPRITEANIMSTRUCT_JUMPTABLE_INDEX
 	add hl, bc
 	ld [hl], $1
@@ -973,7 +973,7 @@ TradeAnim_DropBall:
 TradeAnim_Poof:
 	depixel 10, 11, 4, 0
 	ld a, SPRITE_ANIM_INDEX_TRADE_POOF
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	call TradeAnim_AdvanceScriptPointer
 	ld a, $10
 	ld [wFrameCounter], a
@@ -985,7 +985,7 @@ TradeAnim_BulgeThroughTube:
 	call DmgToCgbObjPal0
 	depixel 5, 11
 	ld a, SPRITE_ANIM_INDEX_TRADE_TUBE_BULGE
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	call TradeAnim_AdvanceScriptPointer
 	ld a, $40
 	ld [wFrameCounter], a

--- a/engine/overworld/events.asm
+++ b/engine/overworld/events.asm
@@ -168,7 +168,7 @@ HandleMapTimeAndJoypad:
 
 	call UpdateTime
 	call GetJoypad
-	jmp TimeOfDayPals
+	farjp TimeOfDayPals
 
 HandleMapObjects:
 	farcall HandleNPCStep ; engine/map_objects.asm

--- a/engine/overworld/init_map.asm
+++ b/engine/overworld/init_map.asm
@@ -49,11 +49,11 @@ LoadFonts_NoOAMUpdate::
 	ld a, $1
 	ldh [hOAMUpdate], a
 
-	call LoadFrame
+	farcall LoadFrame
 	ld a, $90
 	ldh [hWY], a
 	call SafeUpdateSprites
-	call LoadStandardFont
+	farcall LoadStandardFont
 
 	pop af
 	ldh [hOAMUpdate], a

--- a/engine/overworld/init_map.asm
+++ b/engine/overworld/init_map.asm
@@ -12,7 +12,7 @@ ReanchorBGMap_NoOAMUpdate::
 	ldh [hLCDCPointer], a
 	ld a, $90
 	ldh [hWY], a
-	call LoadMapPart
+	farcall LoadMapPart
 
 	ld a, HIGH(vBGMap1)
 	ldh [hBGMapAddress + 1], a
@@ -73,7 +73,7 @@ ReanchorBGMap_NoOAMUpdate_NoDelay::
 	ldh [hLCDCPointer], a
 	ld a, $90
 	ldh [hWY], a
-	call LoadMapPart
+	farcall LoadMapPart
 
 	ld a, HIGH(vBGMap1)
 	ldh [hBGMapAddress + 1], a

--- a/engine/overworld/load_map_part.asm
+++ b/engine/overworld/load_map_part.asm
@@ -27,7 +27,7 @@ MACRO subtractfromhl
 .noCarry\@
 ENDM
 
-_LoadMapPart::
+LoadMapPart::
 	ldh a, [rSVBK]
 	push af
 	ld a, [wOverworldMapAnchor]
@@ -50,14 +50,14 @@ _LoadMapPart::
 	ldh [rSVBK], a
 	push de
 	push bc
-	call _LoadMapPart_TileMap
+	call LoadMapPart_TileMap
 	pop bc
 	pop de
 	ld a, c
 	ldh [hMapWidthPlus6], a
 	ld a, BANK(wDecompressedAttributes)
 	ldh [rSVBK], a
-	call _LoadMapPart_AttrMap
+	call LoadMapPart_AttrMap
 	pop af
 	ldh [rSVBK], a
 	ret
@@ -903,8 +903,8 @@ MACRO loadmappart_function_macro
 	ret
 ENDM
 
-_LoadMapPart_TileMap:
+LoadMapPart_TileMap:
 	loadmappart_function_macro wTilemap
 
-_LoadMapPart_AttrMap:
+LoadMapPart_AttrMap:
 	loadmappart_function_macro wAttrmap

--- a/engine/overworld/map_setup.asm
+++ b/engine/overworld/map_setup.asm
@@ -222,7 +222,7 @@ FadeOutMapMusic:
 	jmp SkipMusic
 
 ApplyMapPalettes:
-	farjp _UpdateTimePals
+	farjp UpdateTimePals
 
 FadeMapMusicAndPalettes:
 	xor a

--- a/engine/overworld/overworld.asm
+++ b/engine/overworld/overworld.asm
@@ -1,4 +1,4 @@
-_UpdatePlayerSprite::
+UpdatePlayerSprite::
 	call GetPlayerSprite
 	ld a, [wPlayerSprite]
 	ldh [hUsedSpriteIndex], a

--- a/engine/overworld/player_movement.asm
+++ b/engine/overworld/player_movement.asm
@@ -889,7 +889,7 @@ endc
 	push bc
 	ld a, PLAYER_NORMAL
 	ld [wPlayerState], a
-	call UpdatePlayerSprite ; UpdateSprites
+	farcall UpdatePlayerSprite ; UpdateSprites
 	pop bc
 	ret
 

--- a/engine/overworld/player_step.asm
+++ b/engine/overworld/player_step.asm
@@ -91,19 +91,19 @@ UpdateOverworldMap:
 	ret nz
 ; step right
 	call .ScrollOverworldMapRight
-	call _LoadMapPart
+	call LoadMapPart
 	jmp ScrollMapLeft
 .stepDown
 	call .ScrollOverworldMapDown
-	call _LoadMapPart
+	call LoadMapPart
 	jmp ScrollMapUp
 .stepUp
 	call .ScrollOverworldMapUp
-	call _LoadMapPart
+	call LoadMapPart
 	jmp ScrollMapDown
 .stepLeft
 	call .ScrollOverworldMapLeft
-	call _LoadMapPart
+	call LoadMapPart
 	jmp ScrollMapRight
 
 .ScrollOverworldMapDown:

--- a/engine/overworld/scripting.asm
+++ b/engine/overworld/scripting.asm
@@ -2501,14 +2501,14 @@ Script_unowntypeface:
 	and ~FONT_MASK
 	or UNOWN_FONT
 	ld [wOptions2], a
-	jmp LoadStandardFont
+	farjp LoadStandardFont
 
 Script_restoretypeface:
 	ld a, [wOptionsBuffer]
 	ld [wOptions2], a
 	xor a
 	ld [wOptionsBuffer], a
-	jmp LoadStandardFont
+	farjp LoadStandardFont
 
 Script_iftrue_endtext:
 	ldh a, [hScriptVar]

--- a/engine/overworld/scripting.asm
+++ b/engine/overworld/scripting.asm
@@ -1029,7 +1029,7 @@ ApplyPersonFacing::
 	ld hl, wVramState
 	bit 6, [hl]
 	jr nz, .text_state
-	call LoadMapPart
+	farcall LoadMapPart
 	hlcoord 0, 0
 	ld bc, SCREEN_WIDTH * SCREEN_HEIGHT
 .loop
@@ -2229,7 +2229,7 @@ Script_changeblock:
 Script_reloadmappart::
 	xor a
 	ldh [hBGMapMode], a
-	call LoadMapPart
+	farcall LoadMapPart
 	call GetMovementPermissions
 	farcall ReloadMapPart
 	jmp UpdateSprites

--- a/engine/overworld/select_menu.asm
+++ b/engine/overworld/select_menu.asm
@@ -123,7 +123,7 @@ GetRegisteredItem:
 	farcall ReanchorBGMap_NoOAMUpdate
 	call SafeUpdateSprites
 	call BGMapAnchorTopLeft
-	call LoadStandardOpaqueFont
+	farcall LoadStandardOpaqueFont
 	ld hl, InvertedTextPalette
 	ld de, wBGPals1 palette PAL_BG_TEXT
 	ld bc, 1 palettes

--- a/engine/overworld/warp_connection.asm
+++ b/engine/overworld/warp_connection.asm
@@ -269,7 +269,7 @@ LoadMapTimeOfDay:
 	ld [wSpriteUpdatesEnabled], a
 	farcall ReplaceTimeOfDayPals
 	farcall UpdateTimeOfDayPal
-	call LoadMapPart
+	farcall LoadMapPart
 	call .ClearBGMap
 	decoord 0, 0
 	call .copy

--- a/engine/pc/bills_pc_ui.asm
+++ b/engine/pc/bills_pc_ui.asm
@@ -131,7 +131,7 @@ BillsPC_LoadUI:
 	; Cursor sprite OAM
 	lb de, -18, 0 ; fixed up by the animseq code
 	ld a, SPRITE_ANIM_INDEX_PC_CURSOR
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld a, PCANIM_ANIMATE
 	ld [wBillsPC_CursorAnimFlag], a
 
@@ -139,10 +139,10 @@ BillsPC_LoadUI:
 	lb de, $98, $10
 	ld a, SPRITE_ANIM_INDEX_PC_MODE
 	push de
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	pop af
 	ld a, SPRITE_ANIM_INDEX_PC_MODE2
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 
 	; Pack icon.
 	; TODO: Instead of a hack where we prevent the pack from claiming a slot,
@@ -152,7 +152,7 @@ BillsPC_LoadUI:
 	push hl
 	lb de, $58, $30
 	ld a, SPRITE_ANIM_INDEX_PC_PACK
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	pop hl
 	dec [hl]
 
@@ -1871,7 +1871,7 @@ BillsPC_PrepareQuickAnim:
 
 	lb de, 0, 0
 	ld a, SPRITE_ANIM_INDEX_PC_QUICK
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 
 	call BillsPC_UpdateCursorLocation
 	pop bc

--- a/engine/pokedex/pokedex.asm
+++ b/engine/pokedex/pokedex.asm
@@ -1557,7 +1557,7 @@ Pokedex_Main:
 	call ClearSpriteAnims
 	lb de, $50, $09
 	ld a, SPRITE_ANIM_INDEX_DEX_CURSOR
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 
 	ld a, [wPokedex_InSearchMode]
 	and a
@@ -2397,7 +2397,7 @@ _Pokedex_Search:
 	call ClearSpriteAnims
 	lb de, 120, 120
 	ld a, SPRITE_ANIM_INDEX_DEX_SLOWPOKE
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 
 	; Set a search timer.
 	ldh a, [hVBlankCounter]

--- a/engine/pokedex/unown_dex.asm
+++ b/engine/pokedex/unown_dex.asm
@@ -16,7 +16,7 @@ Pokedex_Unown:
 	call ClearSpriteAnims
 	lb de, $5c, $24
 	ld a, SPRITE_ANIM_INDEX_DEX_UNOWN_CURSOR
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 
 	; fallthrough
 _Pokedex_Unown:

--- a/engine/pokegear/pokegear.asm
+++ b/engine/pokegear/pokegear.asm
@@ -177,7 +177,7 @@ INCBIN "gfx/town_map/arrow.2bpp.lz"
 InitPokegearModeIndicatorArrow:
 	depixel 4, 2, 4, 0
 	ld a, SPRITE_ANIM_INDEX_POKEGEAR_MODE_ARROW
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld hl, SPRITEANIMSTRUCT_TILE_ID
 	add hl, bc
 	ld [hl], $0
@@ -508,7 +508,7 @@ PokegearMap_Init:
 	ld e, 13 * 8 ; depixel 18, 13, 0, 0
 .got_coords
 	ld a, SPRITE_ANIM_INDEX_TOWN_MAP_FLY
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 .no_fly
 	ld hl, wJumptableIndex
 	inc [hl]
@@ -682,7 +682,7 @@ PokegearMap_InitCursor:
 	push af
 	depixel 0, 0
 	ld a, SPRITE_ANIM_INDEX_POKEGEAR_MODE_ARROW
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld hl, SPRITEANIMSTRUCT_TILE_ID
 	add hl, bc
 	ld [hl], $4
@@ -767,7 +767,7 @@ PokegearRadio_Init:
 	call InitPokegearTilemap
 	depixel 4, 10, 4, 4
 	ld a, SPRITE_ANIM_INDEX_RADIO_TUNING_KNOB
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld hl, SPRITEANIMSTRUCT_TILE_ID
 	add hl, bc
 	ld [hl], $8
@@ -1970,7 +1970,7 @@ TownMapMon:
 ; Animation/palette
 	depixel 0, 0
 	ld a, SPRITE_ANIM_INDEX_PARTY_MON
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld hl, SPRITEANIMSTRUCT_TILE_ID
 	add hl, bc
 	ld [hl], $8
@@ -2026,7 +2026,7 @@ InitializePokegearPlayerIcon:
 	ld b, SPRITE_ANIM_INDEX_GREEN_WALK
 .got_gender
 	ld a, b
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld hl, SPRITEANIMSTRUCT_TILE_ID
 	add hl, bc
 	ld [hl], $10

--- a/engine/pokemon/breeding.asm
+++ b/engine/pokemon/breeding.asm
@@ -780,7 +780,7 @@ EggHatch_CrackShell:
 	ld d, a
 	ld e, 11 * 8
 	ld a, SPRITE_ANIM_INDEX_EGG_CRACK
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 	ld hl, SPRITEANIMSTRUCT_TILE_ID
 	add hl, bc
 	ld [hl], $0
@@ -808,7 +808,7 @@ Hatch_InitShellFragments:
 	push bc
 
 	ld a, SPRITE_ANIM_INDEX_EGG_HATCH
-	call InitSpriteAnimStruct
+	farcall InitSpriteAnimStruct
 
 	ld hl, SPRITEANIMSTRUCT_TILE_ID
 	add hl, bc

--- a/engine/pokemon/mail_2.asm
+++ b/engine/pokemon/mail_2.asm
@@ -11,8 +11,8 @@ ReadAnyMail:
 	call ClearSprites
 	call ClearTileMap
 	call DisableLCD
-	call LoadStandardFont
-	call LoadFrame
+	farcall LoadStandardFont
+	farcall LoadFrame
 	pop de
 	call .LoadGFX
 	call EnableLCD
@@ -25,7 +25,7 @@ ReadAnyMail:
 	call .loop
 	call ClearBGPalettes
 	call DisableLCD
-	call LoadStandardFont
+	farcall LoadStandardFont
 	jmp EnableLCD
 
 .loop

--- a/engine/pokemon/mon_menu.asm
+++ b/engine/pokemon/mon_menu.asm
@@ -201,7 +201,7 @@ GiveTakePartyMonItem:
 	call ClearPalettes
 	call .GiveItem
 	call ClearPalettes
-	call LoadFontsBattleExtra
+	farcall LoadFontsBattleExtra
 	call ExitMenu
 	xor a
 	ret
@@ -832,7 +832,7 @@ ChooseMoveToDelete:
 	ld a, [hl]
 	push af
 	set NO_TEXT_SCROLL, [hl]
-	call LoadFontsBattleExtra
+	farcall LoadFontsBattleExtra
 	ld a, MOVESCREEN_DELETER
 	ld [wMoveScreenMode], a
 	call MoveScreen
@@ -850,7 +850,7 @@ ChooseMoveToForget:
 	push af
 	set NO_TEXT_SCROLL, [hl]
 	call LoadTileMapToTempTileMap
-	call LoadFontsBattleExtra
+	farcall LoadFontsBattleExtra
 	ld a, MOVESCREEN_NEWMOVE
 	ld [wMoveScreenMode], a
 	call MoveScreen
@@ -894,7 +894,7 @@ ChooseMoveToRelearn:
 	ld a, [hl]
 	push af
 	set NO_TEXT_SCROLL, [hl]
-	call LoadFontsBattleExtra
+	farcall LoadFontsBattleExtra
 	ld a, MOVESCREEN_REMINDER
 	ld [wMoveScreenMode], a
 	call MoveScreen
@@ -1390,7 +1390,7 @@ SetUpMoveScreenBG:
 	ldh [hBGMapMode], a
 	ld a, CGB_PARTY_MENU
 	call GetCGBLayout
-	call LoadFontsBattleExtra
+	farcall LoadFontsBattleExtra
 	call ClearSpriteAnims2
 	ld a, [wTempMonSpecies]
 	ld [wTempIconSpecies], a

--- a/engine/pokemon/move_mon.asm
+++ b/engine/pokemon/move_mon.asm
@@ -309,7 +309,7 @@ endr
 	cp CUTE_CHARM
 	jr nz, .not_cute_charm
 	ld a, 3
-	call BattleRandomRange
+	farcall BattleRandomRange
 	and a
 	jr z, .not_cute_charm
 	ld a, [wPartyMon1Gender]

--- a/engine/pokemon/party_menu.asm
+++ b/engine/pokemon/party_menu.asm
@@ -532,7 +532,7 @@ InitPartyMenuLayout:
 	jmp PrintPartyMenuText
 
 LoadPartyMenuGFX:
-	call LoadFontsBattleExtra
+	farcall LoadFontsBattleExtra
 	farcall InitPartyMenuPalettes ; engine/color.asm
 	jmp ClearSpriteAnims2
 

--- a/engine/pokemon/party_menu.asm
+++ b/engine/pokemon/party_menu.asm
@@ -385,10 +385,10 @@ BT_DisplayMenu:
 	bit 7, a
 	scf
 	ret z
-	call InitVerticalMenuCursor
+	farcall InitVerticalMenuCursor
 	ld hl, w2DMenuFlags1
 	set 6, [hl]
-	call DoMenuJoypadLoop
+	farcall DoMenuJoypadLoop
 	ld de, SFX_READ_TEXT_2
 	call PlaySFX
 	ldh a, [hJoyPressed]
@@ -1197,7 +1197,7 @@ PartyMenuAttributes:
 
 PartyMenuSelect:
 ; sets carry if exitted menu.
-	call DoMenuJoypadLoop
+	farcall DoMenuJoypadLoop
 	call PlaceHollowCursor
 	ld a, [wPartyCount]
 	inc a

--- a/engine/pokemon/stats_screen.asm
+++ b/engine/pokemon/stats_screen.asm
@@ -14,7 +14,7 @@ StatsScreenInit:
 	call ClearBGPalettes
 	call ClearTileMap
 	call UpdateSprites
-	call LoadFontsBattleExtra
+	farcall LoadFontsBattleExtra
 	ld hl, GFX_Stats
 	ld de, vTiles2 tile $31
 	lb bc, BANK(GFX_Stats), 41

--- a/engine/rtc/reset_password.asm
+++ b/engine/rtc/reset_password.asm
@@ -2,8 +2,8 @@ _ResetClock:
 	farcall BlankScreen
 	ld a, CGB_PLAIN
 	call GetCGBLayout
-	call LoadStandardFont
-	call LoadFrame
+	farcall LoadStandardFont
+	farcall LoadFrame
 	call BlackOutScreen
 	ld de, MUSIC_MAIN_MENU
 	call PlayMusic

--- a/engine/rtc/restart_clock.asm
+++ b/engine/rtc/restart_clock.asm
@@ -90,7 +90,7 @@ RestartClock:
 	ld [wStringBuffer2 + 2], a
 	xor a
 	ld [wStringBuffer2 + 3], a
-	call InitTime
+	farcall InitTime
 	call .PrintTime
 	ld hl, .Text_ClockReset
 	call PrintText

--- a/engine/rtc/rtc.asm
+++ b/engine/rtc/rtc.asm
@@ -123,7 +123,23 @@ ClockContinue:
 	xor a
 	ret
 
-_InitTime::
+SetTimeOfDay::
+	xor a
+	ld [wStringBuffer2], a
+	ld [wStringBuffer2 + 3], a
+	jr InitTime
+
+SetDayOfWeek::
+	call UpdateTime
+	ldh a, [hHours]
+	ld [wStringBuffer2 + 1], a
+	ldh a, [hMinutes]
+	ld [wStringBuffer2 + 2], a
+	ldh a, [hSeconds]
+	ld [wStringBuffer2 + 3], a
+	; fallthrough
+
+InitTime::
 	call GetClock
 	call FixDays
 	ld hl, hRTCSeconds

--- a/engine/rtc/timeset.asm
+++ b/engine/rtc/timeset.asm
@@ -20,7 +20,7 @@ InitClock:
 	call GetCGBLayout
 	xor a
 	ldh [hBGMapMode], a
-	call LoadStandardFont
+	farcall LoadStandardFont
 	call BlackOutScreen
 	call ApplyTilemapInVBlank
 	call SetPalettes
@@ -348,7 +348,7 @@ Special_SetDayOfWeek:
 	ld a, [wTempDayOfWeek]
 	ld [wStringBuffer2], a
 	farcall SetDayOfWeek
-	call LoadStandardFont
+	farcall LoadStandardFont
 	pop af
 	ldh [hInMenu], a
 	ret

--- a/engine/rtc/timeset.asm
+++ b/engine/rtc/timeset.asm
@@ -13,7 +13,7 @@ InitClock:
 	ld [wMusicFadeIDLo], a
 	ld [wMusicFadeIDHi], a
 	ld c, 31
-	call FadeToBlack
+	farcall FadeToBlack
 	call ClearTileMap
 	call ClearSprites
 	ld a, CGB_PLAIN

--- a/engine/rtc/timeset.asm
+++ b/engine/rtc/timeset.asm
@@ -85,7 +85,7 @@ endc
 	jr .loop
 
 .done:
-	call SetTimeOfDay
+	farcall SetTimeOfDay
 	ld hl, OakText_ResponseToSetTime
 	call PrintText
 	call WaitPressAorB_BlinkCursor
@@ -347,7 +347,7 @@ Special_SetDayOfWeek:
 	jr c, .loop
 	ld a, [wTempDayOfWeek]
 	ld [wStringBuffer2], a
-	call SetDayOfWeek
+	farcall SetDayOfWeek
 	call LoadStandardFont
 	pop af
 	ldh [hInMenu], a

--- a/engine/tilesets/timeofday_pals.asm
+++ b/engine/tilesets/timeofday_pals.asm
@@ -6,7 +6,7 @@ UpdateTimeOfDayPal::
 	ld [wTimeOfDayPal], a
 	ret
 
-_TimeOfDayPals::
+TimeOfDayPals::
 ; return carry if pals are changed
 
 ; forced pals?
@@ -90,7 +90,7 @@ _TimeOfDayPals::
 	ldh [rSVBK], a
 
 ; update palettes
-	call _UpdateTimePals
+	call UpdateTimePals
 	call DelayFrame
 
 ; successful change
@@ -102,7 +102,7 @@ _TimeOfDayPals::
 	and a
 	ret
 
-_UpdateTimePals::
+UpdateTimePals::
 	ld c, $9 ; normal
 	call GetTimePalFade
 	jmp DmgToCgbTimePals

--- a/engine/tilesets/timeofday_pals.asm
+++ b/engine/tilesets/timeofday_pals.asm
@@ -109,11 +109,11 @@ UpdateTimePals::
 
 FadeInPalettes::
 	ld c, 10
-	jmp FadePalettes
+	farjp FadePalettes
 
 FadeOutPalettes::
 	ld c, 10
-	jmp FadeToWhite
+	farjp FadeToWhite
 
 Special_FadeInQuickly:
 	ld c, $0

--- a/home/battle.asm
+++ b/home/battle.asm
@@ -240,15 +240,6 @@ UpdateEnemyMonInParty::
 	rst CopyBytes
 	ret
 
-RefreshBattleHuds::
-	call UpdateBattleHuds
-	call Delay2
-	jmp ApplyTilemapInVBlank
-
-UpdateBattleHuds::
-	farcall UpdatePlayerHUD
-	farjp UpdateEnemyHUD
-
 GetBackupItemAddr::
 ; Returns address of backup item for current mon in hl
 	push bc
@@ -502,16 +493,6 @@ GetOpponentAbility::
 	xor a
 	ret
 
-GetTrueUserAbility::
-; Get true user ability after Neutralizing Gas.
-; A "true" user might be external, if Future Sight is active.
-	farjp _GetTrueUserAbility
-
-GetOpponentAbilityAfterMoldBreaker::
-; Returns an opponent's ability unless Mold Breaker
-; will suppress it. Preserves bc/de/hl.
-	farjp _GetOpponentAbilityAfterMoldBreaker
-
 ; These routines return z if the user is of the given type
 CheckIfTargetIsGrassType::
 	ld a, GRASS
@@ -599,11 +580,6 @@ CompareHP::
 	pop hl
 	ret
 
-CheckOpponentContactMove::
-	call CallOpponentTurn
-CheckContactMove::
-; Check if user's move made contact. Returns nc if it is
-	farjp _CheckContactMove
 
 HasUserFainted::
 	ldh a, [hBattleTurn]
@@ -694,7 +670,7 @@ CheckMoveSpeed::
 	push de
 
 	; Quick Draw works like Quick Claw except 30% of the time
-	call GetTrueUserAbility
+	farcall GetTrueUserAbility
 	cp QUICK_DRAW
 	jr nz, .quick_draw_done
 	ld b, a
@@ -742,7 +718,7 @@ CheckMoveSpeed::
 
 .quick_claw
 	ld a, 100
-	call BattleRandomRange
+	farcall BattleRandomRange
 	cp c
 	pop de
 	ret nc
@@ -807,7 +783,7 @@ _CheckSpeed::
 	jr z, .secondary_player
 	inc b
 .secondary_player
-	call BattleRandom
+	farcall BattleRandom
 	and $1
 	xor b
 	scf

--- a/home/fade.asm
+++ b/home/fade.asm
@@ -38,32 +38,3 @@ else
 	jr nz, .loop
 endc
 	ret
-
-;FadeBGPalettes::
-;	ld a, PALFADE_BG
-;	ld [wPalFadeMode], a
-;	jr DoFadePalettes
-
-;FadeOBPalettes::
-;	ld a, PALFADE_OBJ
-;	ld [wPalFadeMode], a
-;	jr DoFadePalettes
-
-FadeToWhite::
-	push bc
-	call SetWhitePals
-	pop bc
-	jr FadePalettes
-
-FadeToBlack::
-	push bc
-	call SetBlackPals
-	pop bc
-	; fallthrough
-
-FadePalettes::
-; Fades active palettes in wBGPals2/wOBPals2 to new ones in wBGPals1/wOBPals1 in c frames
-	xor a
-	ld [wPalFadeMode], a
-DoFadePalettes::
-	farjp _DoFadePalettes

--- a/home/gfx.asm
+++ b/home/gfx.asm
@@ -1,18 +1,3 @@
-UpdatePlayerSprite::
-	farjp _UpdatePlayerSprite
-
-LoadStandardOpaqueFont::
-	farjp _LoadStandardOpaqueFont
-
-LoadStandardFont::
-	farjp _LoadStandardFont
-
-LoadFontsBattleExtra::
-	farjp _LoadFontsBattleExtra
-
-LoadFrame::
-	farjp _LoadFrame
-
 ApplyTilemap::
 ; Tell VBlank to update BG Map
 	ld a, 1

--- a/home/header.asm
+++ b/home/header.asm
@@ -6,7 +6,8 @@
 SECTION "rst00 EntryPoint", ROM0[$0000]
 EntryPoint::
 	di
-	jmp Rst0Crash
+	xor a ; ld a, ERR_RST_0
+	jmp Crash
 
 SECTION "rst08 FarCall", ROM0[$0008]
 FarCall:: ; no-optimize Stub jump

--- a/home/init.asm
+++ b/home/init.asm
@@ -19,8 +19,6 @@ SoftReset::
 	jr Init
 
 
-Rst0Crash:
-	xor a ; ld a, ERR_RST_0
 Crash::
 	ld b, b ; no-optimize no-ops (BGB breakpoint)
 

--- a/home/init.asm
+++ b/home/init.asm
@@ -46,6 +46,14 @@ Init::
 
 	di
 
+	ld a, BANK(_Init)
+	ld [MBC3RomBank], a
+	jmp _Init ; far-ok
+
+pushs
+SECTION "Init", ROMX
+
+_Init::
 	xor a
 	ldh [rIF], a
 	ldh [rIE], a
@@ -101,6 +109,8 @@ Init::
 	ldh [hCGB], a
 	pop af
 	ldh [hCrashCode], a
+	ld a, BANK(@)
+	ldh [hROMBank], a
 
 	call ClearWRAM
 	ld a, 1
@@ -130,10 +140,7 @@ Init::
 	ld [hli], a
 	ld [hl], "!"
 
-	ld a, BANK(GameInit) ; aka BANK(WriteOAMDMACodeToHRAM)
-	rst Bankswitch
-
-	call WriteOAMDMACodeToHRAM ; far-ok
+	call WriteOAMDMACodeToHRAM
 
 	xor a
 	ldh [hMapAnims], a
@@ -204,9 +211,9 @@ Init::
 	call InitSound
 	xor a
 	ld [wMapMusic], a
-	jmp GameInit ; far-ok
+	jmp GameInit
 
-ClearVRAM::
+ClearVRAM:
 ; Wipe VRAM banks 0 and 1
 
 	ld a, 1
@@ -222,9 +229,8 @@ ClearVRAM::
 	rst ByteFill
 	ret
 
-ClearWRAM::
+ClearWRAM:
 ; Wipe swappable WRAM banks (1-7)
-
 	ld a, 1
 .bank_loop
 	push af
@@ -238,3 +244,5 @@ ClearWRAM::
 	cp 8
 	jr c, .bank_loop
 	ret
+
+pops

--- a/home/map.asm
+++ b/home/map.asm
@@ -1695,8 +1695,8 @@ ReloadTilesetAndPalettes::
 	call DisableLCD
 	call ClearSprites
 	farcall RefreshSprites
-	call LoadStandardFont
-	call LoadFrame
+	farcall LoadStandardFont
+	farcall LoadFrame
 	ldh a, [hROMBank]
 	push af
 	call SwitchToMapAttributesBank

--- a/home/map.asm
+++ b/home/map.asm
@@ -70,9 +70,6 @@ GetMapSceneID::
 	pop hl
 	ret
 
-LoadMapPart::
-	farjp _LoadMapPart
-
 ReturnToMapFromSubmenu::
 	ld a, MAPSETUP_SUBMENU
 	ldh [hMapEntryMethod], a
@@ -1686,7 +1683,7 @@ ReturnToMapWithSpeechTextbox::
 	ld a, CGB_MAPPALS
 	call GetCGBLayout
 	farcall LoadBlindingFlashPalette
-	call UpdateTimePals
+	farcall UpdateTimePals
 	farcall EnableDynPalUpdates
 	call DelayFrame
 	ld a, $1
@@ -1704,7 +1701,7 @@ ReloadTilesetAndPalettes::
 	push af
 	call SwitchToMapAttributesBank
 	farcall UpdateTimeOfDayPal
-	call LoadMapPart
+	farcall LoadMapPart
 	call LoadTilesetGFX
 	ld a, 9
 	call SkipMusic

--- a/home/menu.asm
+++ b/home/menu.asm
@@ -1,6 +1,3 @@
-InitVerticalMenuCursor::
-	farjp _InitVerticalMenuCursor
-
 MenuTextboxBackup::
 	call MenuTextbox
 CloseWindow::
@@ -251,8 +248,8 @@ VerticalMenu::
 	ld a, [wMenuDataFlags]
 	bit 7, a
 	jr z, .cancel
-	call InitVerticalMenuCursor
-	call DoMenuJoypadLoop
+	farcall InitVerticalMenuCursor
+	farcall DoMenuJoypadLoop
 	call MenuClickSound
 	ld b, a
 	ld a, [wMenuFlags]
@@ -477,7 +474,7 @@ RunMenuItemPrintingFunction::
 	jr .loop
 
 InitMenuCursorAndButtonPermissions::
-	call InitVerticalMenuCursor
+	farcall InitVerticalMenuCursor
 	ld hl, wMenuJoypadFilter
 	ld a, [wMenuDataFlags]
 	bit 3, a
@@ -492,7 +489,7 @@ InitMenuCursorAndButtonPermissions::
 	ret
 
 ReadMenuJoypad::
-	call DoMenuJoypadLoop
+	farcall DoMenuJoypadLoop
 GetVariableDataMenuResult:
 	ld hl, wMenuJoypadFilter
 	and [hl]
@@ -501,7 +498,7 @@ GetVariableDataMenuResult:
 GetStaticMenuJoypad::
 	xor a
 	ld [wMenuJoypad], a
-	call DoMenuJoypadLoop
+	farcall DoMenuJoypadLoop
 
 ContinueGettingMenuJoypad:
 	bit A_BUTTON_F, a
@@ -684,9 +681,6 @@ SetMenuAttributes::
 	pop bc
 	pop hl
 	ret
-
-DoMenuJoypadLoop::
-	farcall _DoMenuJoypadLoop
 
 GetMenuJoypad::
 	push bc

--- a/home/random.asm
+++ b/home/random.asm
@@ -137,11 +137,6 @@ AdvanceRNGState::
 	ld [hl], e ; wRNGState[3]
 	ret
 
-BattleRandom::
-; Handles all RNG calls in the battle engine, allowing
-; link battles to remain in sync using a shared PRNG.
-	farjp _BattleRandom
-
 RandomRange::
 ; Return a random number between 0 and a (non-inclusive).
 
@@ -224,28 +219,3 @@ RandomRange16::
 	ld c, a
 	ret
 
-BattleRandomRange::
-; battle friendly RandomRange
-	push bc
-	ld b, a
-
-	; ensure even distribution by cutting off the top
-.loop
-	add b
-	jr nc, .loop
-	sub b
-	ld c, a
-.loop2
-	call BattleRandom
-	cp c
-	jr nc, .loop2
-
-	; now we have a random number without the uneven top, get mod of it
-.loop3
-	sub b
-	jr nc, .loop3
-	add b
-
-	; return the result
-	pop bc
-	ret

--- a/home/scrolling_menu.asm
+++ b/home/scrolling_menu.asm
@@ -19,8 +19,8 @@ ScrollingMenu::
 .UpdatePalettes:
 	ld hl, wVramState
 	bit 0, [hl]
-	jmp nz, UpdateTimePals
-	; fallthrough
+	jr z, SetPalettes
+	farjp UpdateTimePals
 
 SetPalettes::
 	push de

--- a/home/sprite_anims.asm
+++ b/home/sprite_anims.asm
@@ -1,8 +1,3 @@
-InitSpriteAnimStruct::
-	farjp _InitSpriteAnimStruct
-
-ReinitSpriteAnimFrame::
-	farjp _ReinitSpriteAnimFrame
 
 ClearSpriteAnims::
 	ld hl, wSpriteAnimDict

--- a/home/time.asm
+++ b/home/time.asm
@@ -168,24 +168,6 @@ FixTime::
 	ld [wCurDay], a
 	ret
 
-SetTimeOfDay::
-	xor a
-	ld [wStringBuffer2], a
-	ld [wStringBuffer2 + 3], a
-	jr InitTime
-
-SetDayOfWeek::
-	call UpdateTime
-	ldh a, [hHours]
-	ld [wStringBuffer2 + 1], a
-	ldh a, [hMinutes]
-	ld [wStringBuffer2 + 2], a
-	ldh a, [hSeconds]
-	ld [wStringBuffer2 + 3], a
-
-InitTime::
-	farjp _InitTime
-
 PanicResetClock::
 	xor a
 	ldh [hRTCSeconds], a

--- a/home/time_palettes.asm
+++ b/home/time_palettes.asm
@@ -12,10 +12,4 @@ RTC::
 	ld a, [wVramState]
 	bit 0, a ; obj update
 	ret z
-	; fallthrough
-
-TimeOfDayPals::
-	farjp _TimeOfDayPals
-
-UpdateTimePals::
-	farjp _UpdateTimePals
+	farjp TimeOfDayPals

--- a/home/window.asm
+++ b/home/window.asm
@@ -45,7 +45,7 @@ CloseText::
 	farcall RefreshSprites
 	ld a, $90
 	ldh [hWY], a
-	call UpdatePlayerSprite
+	farcall UpdatePlayerSprite
 	xor a
 	ldh [hBGMapMode], a
 

--- a/home/window.asm
+++ b/home/window.asm
@@ -37,7 +37,7 @@ CloseText::
 	call ClearWindowData
 	xor a
 	ldh [hBGMapMode], a
-	call LoadMapPart
+	farcall LoadMapPart
 	call BGMapAnchorTopLeft
 	xor a
 	ldh [hBGMapMode], a

--- a/layout.link
+++ b/layout.link
@@ -36,6 +36,7 @@ ROM0
 
 ROMX $01
 	"bank1"
+	"Init"
 	"Effect Command Pointers"
 
 ROMX $02


### PR DESCRIPTION
Stub farcalls in home, a artefact from earlier in the codes history, obscured the extent of farcall usage and allowed useless farcalls to escape detection

GetTrueUserAbility and GetOpponentAbilityAfterMoldBreaker were the bigest offenders, with almost half the call sites being from their own bank, but silently farcalling due to stubs in home

Outside of those there's no obvious issues but this has allowed the removal of some farcalls through changes to bank allocation

Some changes to the script engine were also made in hopes of allowing more overworld related code to live in the same bank, as well as relocating 3 bytes to hram