### PR TITLE
Fix `GetScriptWordBC` endianness

### DIFF
--- a/engine/overworld/scripting.asm
+++ b/engine/overworld/scripting.asm
@@ -285,8 +285,8 @@ GetScriptWordBC::
 ; Return byte at hScriptBank:hScriptPos in bc.
 	push hl
 	call GetScriptWord
-	ld c, l
-	ld b, h
+	ld b, l
+	ld c, h
 	pop hl
 	ret
 


### PR DESCRIPTION
This should fix problems with `follow`, `follownotexact`, `checkmapscene`, and `setmapscene`.

This was broke in #808 and the fix identified by @ariscop