### PR TITLE
Fix DynPal compat with pal fade

### DIFF
--- a/data/maps/setup_script_pointers.asm
+++ b/data/maps/setup_script_pointers.asm
@@ -54,3 +54,4 @@ MapSetupCommands:
 	add_mapsetup LoadMapTilesetGFX ; 2f
 	add_mapsetup DisableDynPalUpdates ; 30
 	add_mapsetup EnableDynPalUpdates ; 31
+	add_mapsetup EnableDynPalUpdatesNoApply ; 32

--- a/data/maps/setup_scripts.asm
+++ b/data/maps/setup_scripts.asm
@@ -43,8 +43,8 @@ MapSetupScript_Warp:
 	mapsetup LoadMapObjects
 	mapsetup EnableLCD
 	mapsetup LoadMapPalettes
-	mapsetup EnableDynPalUpdates
 	mapsetup SpawnInFacingDown
+	mapsetup EnableDynPalUpdatesNoApply
 	mapsetup RefreshMapSprites
 	mapsetup PlayMapMusicBike
 	mapsetup FadeInToMusic
@@ -71,8 +71,8 @@ MapSetupScript_BadWarp:
 	mapsetup EnableLCD
 	mapsetup LoadMapObjects
 	mapsetup LoadMapPalettes
-	mapsetup EnableDynPalUpdates
 	mapsetup SpawnInFacingDown
+	mapsetup EnableDynPalUpdatesNoApply
 	mapsetup RefreshMapSprites
 	mapsetup FadeToMapMusic
 	mapsetup FadeInPalettes
@@ -123,8 +123,7 @@ MapSetupScript_Train:
 	mapsetup EnableLCD
 	mapsetup LoadMapObjects
 	mapsetup LoadMapPalettes
-	mapsetup RefreshMapSprites
-	mapsetup EnableDynPalUpdates
+	mapsetup EnableDynPalUpdatesNoApply
 	mapsetup RefreshMapSprites
 	mapsetup FadeToMapMusic
 	mapsetup FadeInPalettes
@@ -146,7 +145,7 @@ MapSetupScript_ReloadMap:
 	mapsetup LoadMapTimeOfDay
 	mapsetup EnableLCD
 	mapsetup LoadMapPalettes
-	mapsetup EnableDynPalUpdates
+	mapsetup EnableDynPalUpdatesNoApply
 	mapsetup RefreshMapSprites
 	mapsetup ForceMapMusic
 	mapsetup FadeInPalettes
@@ -167,7 +166,7 @@ MapSetupScript_LinkReturn:
 	mapsetup LoadMapTimeOfDay
 	mapsetup EnableLCD
 	mapsetup LoadMapPalettes
-	mapsetup EnableDynPalUpdates
+	mapsetup EnableDynPalUpdatesNoApply
 	mapsetup RefreshMapSprites
 	mapsetup PlayMapMusicBike
 	mapsetup FadeInPalettes
@@ -190,7 +189,7 @@ MapSetupScript_Continue:
 	mapsetup LoadMapTimeOfDay
 	mapsetup EnableLCD
 	mapsetup LoadMapPalettes
-	mapsetup EnableDynPalUpdates
+	mapsetup EnableDynPalUpdatesNoApply
 	mapsetup RefreshMapSprites
 	mapsetup PlayMapMusicBike
 	mapsetup FadeInPalettes

--- a/engine/gfx/dynamic_pals.asm
+++ b/engine/gfx/dynamic_pals.asm
@@ -22,6 +22,14 @@ DisableDynPalUpdates::
 	pop hl
 	ret
 
+EnableDynPalUpdatesNoApply::
+	push hl
+	ld hl, wPalFlags
+	set NO_DYN_PAL_APPLY_F, [hl]
+	res DISABLE_DYN_PAL_F, [hl]
+	pop hl
+	jr CheckForUsedObjPals
+
 EnableDynPalUpdates::
 	push hl
 	ld hl, wPalFlags


### PR DESCRIPTION
As the title suggests.. this allows dynamic pal system to only write pals to `wOBPals1` and not `wOBPals2` during warps/doors/ect.. allowing compatibility with the pal fading. This way the npc's/objects fade in properly and smoothly from white, and don't "pop in" early.