### PR TITLE
Compressor changes

### DIFF
--- a/home/decompress.asm
+++ b/home/decompress.asm
@@ -170,9 +170,6 @@ DEF LZ_LONG_HI       EQU %00000011
 	ld [hli], a
 	pop de
 
-	; assume count >= 3, because < 3 is nonsense
-	dec bc
-	dec bc
 	jr .lz_copy_repeat
 
 .lz_copy
@@ -288,6 +285,7 @@ DEF LZ_LONG_HI       EQU %00000011
 
 .lz_iterate
 	ld a, [de]
+	ld [hli], a
 	inc de
 	jr .fill
 

--- a/home/decompress.asm
+++ b/home/decompress.asm
@@ -90,17 +90,15 @@ DEF LZ_LONG_HI       EQU %00000011
 	jmp SwapHLDE
 
 .lz_copy_flip
-	inc b
-	ld a, b
-
-.lz_copy_flip_outer_loop
-	push af
-
-.lz_copy_flip_inner_loop
-	ld a, [de]
-	inc de
+	srl b
+	rr c
+	inc c
+	jr nc, .lz_copy_flip_skip
 
 ; https://github.com/pret/pokecrystal/wiki/Optimizing-assembly-code#reverse-the-bits-of-a
+.lz_copy_flip_loop
+	ld a, [de]
+	inc de
 	ld b, a
 	rlca
 	rlca
@@ -113,45 +111,49 @@ DEF LZ_LONG_HI       EQU %00000011
 	and $33
 	xor b
 	rrca
-
 	ld [hli], a
-	dec c
-	jr nz, .lz_copy_flip_inner_loop
 
-	pop af
-	dec a
-	jr nz, .lz_copy_flip_outer_loop
+.lz_copy_flip_skip
+	ld a, [de]
+	inc de
+	ld b, a
+	rlca
+	rlca
+	xor b
+	and $aa
+	xor b
+	ld b, a
+	swap b
+	xor b
+	and $33
+	xor b
+	rrca
+	ld [hli], a
+
+	dec c
+	jr nz, .lz_copy_flip_loop
 
 	pop de
 	inc de
 	jr .Main
 
 .lz_copy_reverse
-	inc b
-	srl c
+	srl b
+	rr c
+	inc c
 	jr nc, .lz_copy_reverse_skip
-	ld a, [de]
-	ld [hli], a
-	dec de
 
-.lz_copy_reverse_skip
-	jr z, .lz_copy_reverse_loop2
-.lz_copy_reverse_loop1
+.lz_copy_reverse_loop
 	ld a, [de]
 	ld [hli], a
 	dec de
+.lz_copy_reverse_skip
 	ld a, [de]
 	ld [hli], a
 	dec de
 
 	dec c
-	jr nz, .lz_copy_reverse_loop1
-
-.lz_copy_reverse_loop2
-	dec b
-	ld c, $80
-	jr nz, .lz_copy_reverse_loop1
-
+	jr nz, .lz_copy_reverse_loop
 	pop de
 	inc de
 	jr .Main
@@ -174,9 +176,6 @@ DEF LZ_LONG_HI       EQU %00000011
 	jr .lz_copy_repeat
 
 .lz_copy
-	; stash command
-	ld [hl], a
-
 	ld a, [de]
 	bit 7, a
 	jr nz, .relative
@@ -212,62 +211,74 @@ DEF LZ_LONG_HI       EQU %00000011
 	ld e, l
 	pop hl
 
-	; unstash command
-	ld a, [hl]
-	cp (LZ_COPY_FLIPPED << 1) & $ff
+	; grab command from b
+	ld a, b
+	and LZ_CMD
+	cp LZ_COPY_FLIPPED
 	jr z, .lz_copy_flip
 	jr nc, .lz_copy_reverse
 
 .lz_copy_repeat
-	call CopyBytes_hl_de
-	pop de
-	inc de
-	jr .Main
-
-.lz_data_short
-	ld c, a
+	srl b
+	rr c
 	inc c
-.lz_data_short_no_inc
-	srl c
-	jr nc, .lz_data_short_skip
-	ld a, [de]
-	ld [hli], a
-	inc de
+	jr nc, .lz_copy_repeat_skip
 
-.lz_data_short_skip
-	jr z, .Main
-.lz_data_short_loop
+.lz_copy_repeat_loop
 	ld a, [de]
 	ld [hli], a
 	inc de
+.lz_copy_repeat_skip
 	ld a, [de]
 	ld [hli], a
 	inc de
 
 	dec c
-	jr nz, .lz_data_short_loop
+	jr nz, .lz_copy_repeat_loop
+	pop de
+	inc de
+	jr .Main
+
+.lz_data
+	srl b
+.lz_data_short
+	rr c ; and LZ_CMD leaves the carry clear
+	inc c
+	jr nc, .lz_data_skip
+
+.lz_data_loop
+	ld a, [de]
+	ld [hli], a
+	inc de
+.lz_data_skip
+	ld a, [de]
+	ld [hli], a
+	inc de
+
+	dec c
+	jr nz, .lz_data_loop
 ; fallthrough
 
 ; Where the magic starts
 .Main
 	ld a, [de]
 	inc de
-	cp LZ_LEN + 1
+	ld c, a
+	and LZ_CMD
 	; For lzdata no more work is needed
-	jr c, .lz_data_short
-	ld b, a
+	jr z, .lz_data_short
+	ld b, c
 	cp LZ_LONG
 	jr nc, .long
 
-	and LZ_LEN
-	ld c, a
-	inc c
 	xor b
-	ld b, 0
+	ld c, a
+	xor b
+	ld b, a
 
 .cont
 	; command in a
-	; length in bc
+	; length in bc, upper 7 bits of b ignored
 	rla
 	jr c, .lz_copy
 
@@ -283,79 +294,37 @@ DEF LZ_LONG_HI       EQU %00000011
 .lz_zero
 	xor a
 .fill
-	inc b
-	srl c
+	srl b
+	rr c
+	inc c
 	jr nc, .fill_skip
-	ld [hli], a
 
-.fill_skip
-	jr z, .fill_next
 .fill_loop
 	ld [hli], a
+.fill_skip
 	ld [hli], a
 	dec c
 	jr nz, .fill_loop
-
-.fill_next
-	dec b
-	jr z, .Main
-	ld c, $80
-	jr .fill_loop
+	jr .Main
 
 .long
-	inc a
+	inc b
 	ret z ; LZ_END
-	ld a, b
+	ld b, c
 
-	and LZ_LONG_HI
-	ld [hl], a
 	ld a, [de]
 	inc de
 	ld c, a
-	ld a, b
-	and LZ_LONG_CMD
-	ld b, [hl]
-	inc bc
-	add a
-	add a
-	add a
+	; b =  111ccc0l
+	ld a, %00111100
+	and b
+	rlca
+	rlca
+	rlca
+	; a = ccc00001
+	and b
+	; a = ccc0000l
+	ld b, a
+	and LZ_CMD
 	jr nz, .cont
-
-.lz_data
-	; for short runs (<256) we can avoid a call
-	; given that most graphics are <1k this will be practically
-	; all of them
-	or b
-	jr z, .lz_data_short_no_inc
-	call CopyBytes_hl_de
-	jr .Main
-
-; CopyBytes copies from hl to de
-; For performance reasons, we need de to hl
-CopyBytes_hl_de:
-	inc b
-
-	srl c
-	jr nc, .skip
-	ld a, [de]
-	ld [hli], a
-	inc de
-
-.skip
-	jr z, .next
-.loop
-rept 2
-	ld a, [de]
-	ld [hli], a
-	inc de
-endr
-
-	dec c
-	jr nz, .loop
-
-.next
-	dec b
-	ret z
-
-	ld c, $80
-	jr .loop
+	jr .lz_data

--- a/tools/lz/dpcomp.c
+++ b/tools/lz/dpcomp.c
@@ -67,7 +67,8 @@ void process_input(void) {
         unsigned count = 0;
         do {
             count++;
-            consider(plen, (struct command) {
+            if (!current_byte || count >= 2)
+                consider(plen, (struct command) {
                 .command = current_byte ? LZ_REPEAT : LZ_ZERO,
                 .count = count,
                 .value = current_byte,
@@ -78,7 +79,8 @@ void process_input(void) {
             count = 1;
             do {
                 count++;
-                consider(plen, (struct command) {
+                if (count >= 3)
+                    consider(plen, (struct command) {
                     .command = LZ_ALTERNATE,
                     .count = count,
                     .value = (data[plen - count + 1] << 8) | (data[plen - count]),

--- a/tools/lz/dpcomp.c
+++ b/tools/lz/dpcomp.c
@@ -58,7 +58,7 @@ void process_input(void) {
         unsigned char current_byte = data[plen - 1];
         for (unsigned prev = plen > MAX_COMMAND_COUNT ? plen - MAX_COMMAND_COUNT : 0; prev < plen; prev++) {
             consider(plen, (struct command) {
-                .command = 0,
+                .command = LZ_DATA,
                 .count = plen - prev,
                 .value = prev,
             });
@@ -68,7 +68,7 @@ void process_input(void) {
         do {
             count++;
             consider(plen, (struct command) {
-                .command = current_byte ? 1 : 3,
+                .command = current_byte ? LZ_REPEAT : LZ_ZERO,
                 .count = count,
                 .value = current_byte,
             });
@@ -79,7 +79,7 @@ void process_input(void) {
             do {
                 count++;
                 consider(plen, (struct command) {
-                    .command = 2,
+                    .command = LZ_ALTERNATE,
                     .count = count,
                     .value = (data[plen - count + 1] << 8) | (data[plen - count]),
                 });
@@ -90,7 +90,7 @@ void process_input(void) {
             unsigned k = min(MAX_COMMAND_COUNT, match_right(plen - 1, at));
             for (unsigned i = 2; i <= k; i++) {
                 consider(plen + i - 1, (struct command) {
-                    .command = 4,
+                    .command = LZ_COPY_NORMAL,
                     .count = i,
                     .value = encode_delta(plen - 1, at),
                 });
@@ -99,7 +99,7 @@ void process_input(void) {
             k = min(MAX_COMMAND_COUNT, match_left(plen - 1, at));
             for (unsigned i = 2; i <= k; i++) {
                 consider(plen + i - 1, (struct command) {
-                    .command = 6,
+                    .command = LZ_COPY_REVERSED,
                     .count = i,
                     .value = encode_delta(plen - 1, at),
                 });
@@ -108,7 +108,7 @@ void process_input(void) {
             k = min(MAX_COMMAND_COUNT, match_flipped(plen - 1, at));
             for (unsigned i = 2; i <= k; i++) {
                 consider(plen + i - 1, (struct command) {
-                    .command = 5,
+                    .command = LZ_COPY_FLIPPED,
                     .count = i,
                     .value = encode_delta(plen - 1, at),
                 });

--- a/tools/lz/output.c
+++ b/tools/lz/output.c
@@ -101,11 +101,15 @@ void write_commands_to_file (const char * file, const struct command * commands,
 }
 
 void write_command_to_file (FILE * fp, struct command command, const unsigned char * input_stream) {
-  if ((!command.count) || (command.count > MAX_COMMAND_COUNT)) error_exit(2, "invalid command in output stream");
   unsigned char buf[4];
   unsigned char * pos = buf;
   int n;
-  command.count --;
+
+  command.count -= minimum_count(command.command);
+
+  /* Check for over and under sized commands */
+  if (command.count > MAX_COMMAND_COUNT - 1) error_exit(2, "invalid command in output stream");
+
   if (command.count < SHORT_COMMAND_COUNT)
     *(pos ++) = (command.command << 5) + command.count;
   else {

--- a/tools/lz/proto.h
+++ b/tools/lz/proto.h
@@ -66,6 +66,7 @@ unsigned char * get_uncompressed_data(const struct command *, const unsigned cha
 // util.c
 noreturn error_exit(int, const char *, ...);
 unsigned char * read_file_into_buffer(const char *, unsigned short *);
+unsigned minimum_count(unsigned command);
 short command_size(struct command);
 unsigned short compressed_length(const struct command *, unsigned short);
 

--- a/tools/lz/proto.h
+++ b/tools/lz/proto.h
@@ -5,7 +5,7 @@
 
 #define MAX_FILE_SIZE            32768
 #define SHORT_COMMAND_COUNT         32
-#define MAX_COMMAND_COUNT         1024
+#define MAX_COMMAND_COUNT          512
 #define LOOKBACK_LIMIT             128 /* highest negative valid count for a copy command */
 
 #if __STDC_VERSION__ >= 201112L

--- a/tools/lz/proto.h
+++ b/tools/lz/proto.h
@@ -8,6 +8,15 @@
 #define MAX_COMMAND_COUNT          512
 #define LOOKBACK_LIMIT             128 /* highest negative valid count for a copy command */
 
+#define LZ_DATA          0 /* Read literal data for n bytes.   */
+#define LZ_REPEAT        1 /* Write the same byte for n bytes. */
+#define LZ_ALTERNATE     2 /* Alternate two bytes for n bytes. */
+#define LZ_ZERO          3 /* Write 0 for n bytes.             */
+#define LZ_COPY_NORMAL   4 /* Repeat n bytes from the offset.  */
+#define LZ_COPY_FLIPPED  5 /* Repeat n bitflipped bytes.       */
+#define LZ_COPY_REVERSED 6 /* Repeat n bytes in reverse.       */
+#define LZ_LONG          7 /* Expand n to 9 bits               */
+
 #if __STDC_VERSION__ >= 201112L
 	// <noreturn.h> forces "noreturn void", which is silly and redundant; this is simpler
 	#define noreturn _Noreturn void

--- a/tools/lz/uncomp.c
+++ b/tools/lz/uncomp.c
@@ -20,7 +20,7 @@ struct command * get_commands_from_file (const unsigned char * data, unsigned sh
       if (!(remaining --)) goto error;
       current -> count |= *(rp ++);
     }
-    current -> count ++;
+    current -> count += minimum_count(current -> command);
     switch (current -> command) {
       case LZ_DATA:
         if (remaining <= current -> count) goto error;

--- a/tools/lz/util.c
+++ b/tools/lz/util.c
@@ -22,8 +22,19 @@ unsigned char * read_file_into_buffer (const char * file, unsigned short * size)
   return buf;
 }
 
+unsigned minimum_count (unsigned command) {
+  switch (command) {
+    case LZ_ALTERNATE:
+        return 3;
+    case LZ_REPEAT:
+        return 2;
+    default:
+        return 1;
+  }
+}
+
 short command_size (struct command command) {
-  short header_size = 1 + (command.count > SHORT_COMMAND_COUNT);
+  short header_size = 1 + (command.count - minimum_count(command.command) > SHORT_COMMAND_COUNT - 1);
   if (command.command & 4) return header_size + 1 + (command.value >= 0);
   return header_size + command.command[(short []) {command.count, 1, 2, 0}];
 }


### PR DESCRIPTION
Reducing the max length costs a few bytes due to split commands, but growing the minimum size also saves a few

Net result is a smaller faster decompress and a slight reduction in rom usage