### PR TITLE
DynPal Fix Flash in Darkness and `FadeInPalettes`

### DIFF
--- a/data/events/special_pointers.asm
+++ b/data/events/special_pointers.asm
@@ -172,3 +172,4 @@ SpecialsPointers::
 	add_special ShowKeyItemIcon
 	add_special ShowTMHMIcon
 	add_special FixPlayerEVsAndStats
+	add_special FadeInPalettes_EnableDynNoApply

--- a/engine/events/field_moves.asm
+++ b/engine/events/field_moves.asm
@@ -7,7 +7,7 @@ BlindingFlash::
 	ld a, CGB_MAPPALS
 	call GetCGBLayout
 	farcall LoadBlindingFlashPalette
-	jmp FadeInPalettes
+	jmp FadeInPalettes_EnableDynNoApply
 
 ShakeHeadbuttTree:
 	farcall CopyBGGreenToOBPal7

--- a/engine/events/sacred_ash.asm
+++ b/engine/events/sacred_ash.asm
@@ -53,7 +53,7 @@ SacredAshScript:
 rept 3
 	special FadeOutPalettes
 	special LoadMapPalettes
-	special FadeInPalettes
+	special FadeInPalettes_EnableDynNoApply
 endr
 	waitsfx
 	opentext

--- a/engine/tilesets/timeofday_pals.asm
+++ b/engine/tilesets/timeofday_pals.asm
@@ -107,6 +107,9 @@ _UpdateTimePals::
 	call GetTimePalFade
 	jmp DmgToCgbTimePals
 
+FadeInPalettes_EnableDynNoApply:
+	farcall EnableDynPalUpdatesNoApply
+	; fallthrough
 FadeInPalettes::
 	ld c, 10
 	jmp FadePalettes

--- a/home/sprite_updates.asm
+++ b/home/sprite_updates.asm
@@ -35,8 +35,7 @@ FinishExitMenu::
 	call GetCGBLayout
 	farcall LoadBlindingFlashPalette
 	call ApplyAttrAndTilemapInVBlank
-	farcall FadeInPalettes
-	farcall EnableDynPalUpdates
+	farcall FadeInPalettes_EnableDynNoApply
 	; fallthrough
 EnableSpriteUpdates::
 	ld a, $1

--- a/maps/BluesHouse1F.asm
+++ b/maps/BluesHouse1F.asm
@@ -56,7 +56,7 @@ DaisyScript:
 	special SaveMusic
 	playmusic MUSIC_HEAL
 	pause 60
-	special FadeInPalettes
+	special FadeInPalettes_EnableDynNoApply
 	special RestoreMusic
 	opentext
 	writetext .LooksContentText

--- a/maps/CianwoodCityPhotoStudio.asm
+++ b/maps/CianwoodCityPhotoStudio.asm
@@ -38,7 +38,7 @@ CianwoodPhotoStudioFishingGuruScript:
 	playsound SFX_DOUBLE_SLAP
 	waitsfx
 	pause 10
-	special FadeInPalettes
+	special FadeInPalettes_EnableDynNoApply
 	readmem wCurPartySpecies
 	pokepic 0
 	cry 0

--- a/maps/CinnabarLab.asm
+++ b/maps/CinnabarLab.asm
@@ -175,7 +175,7 @@ CinnabarLabCelebiEventScript:
 	disappear CINNABARLAB_ARMORED_MEWTWO
 	appear CINNABARLAB_MEWTWO
 	waitsfx
-	special FadeInPalettes
+	special FadeInPalettes_EnableDynNoApply
 	opentext
 	writetext CinnabarLabMewtwoText
 	cry MEWTWO
@@ -186,7 +186,7 @@ CinnabarLabCelebiEventScript:
 	special LoadMapPalettes
 	pause 30
 	appear CINNABARLAB_CELEBI
-	special FadeInPalettes
+	special FadeInPalettes_EnableDynNoApply
 	waitsfx
 	opentext
 	writetext CinnabarLabCelebiText

--- a/maps/GiovannisCave.asm
+++ b/maps/GiovannisCave.asm
@@ -73,7 +73,7 @@ GiovannisCaveCelebiEventScript:
 	special FadeOutPalettes
 	special LoadMapPalettes
 	pause 30
-	special FadeInPalettes
+	special FadeInPalettes_EnableDynNoApply
 	waitsfx
 	showemote EMOTE_SHOCK, PLAYER, 15
 	applymovement PLAYER, GiovannisCave_PlayerStepsAsideMovementData

--- a/maps/IlexForest.asm
+++ b/maps/IlexForest.asm
@@ -499,7 +499,7 @@ MapIlexForestSignpost4Script:
 	special LoadMapPalettes
 	turnobject ILEXFOREST_CELEBI, DOWN
 	pause 30
-	special FadeInPalettes
+	special FadeInPalettes_EnableDynNoApply
 	waitsfx
 	showemote EMOTE_SHOCK, PLAYER, 15
 	turnobject PLAYER, UP

--- a/maps/OlivineLighthouse6F.asm
+++ b/maps/OlivineLighthouse6F.asm
@@ -57,7 +57,7 @@ OlivineLighthouseJasmine:
 	special FadeOutPalettes
 	special LoadMapPalettes
 	pause 10
-	special FadeInPalettes
+	special FadeInPalettes_EnableDynNoApply
 	showtext AmphyPaluPaluluText
 	showemote EMOTE_BOLT, OLIVINELIGHTHOUSE6F_AMPHAROS, 15
 	showtextfaceplayer JasmineThankYouText
@@ -103,10 +103,10 @@ OlivineLighthouseAmphy:
 	showcrytext AmphyPaluPaluluText, AMPHAROS
 	special FadeOutPalettes
 	special LoadMapPalettes
-	special FadeInPalettes
+	special FadeInPalettes_EnableDynNoApply
 	special FadeOutPalettes
 	special LoadMapPalettes
-	special FadeInPalettes
+	special FadeInPalettes_EnableDynNoApply
 	end
 
 OlivineLighthouseJasmineLeavesUpMovement:

--- a/maps/Route22Past.asm
+++ b/maps/Route22Past.asm
@@ -81,7 +81,7 @@ Route22PastCelebiEventScript:
 	special FadeOutPalettes
 	special LoadMapPalettes
 	pause 30
-	special FadeInPalettes
+	special FadeInPalettes_EnableDynNoApply
 	waitsfx
 	showemote EMOTE_SHOCK, PLAYER, 15
 	applymovement ROUTE22PAST_LYRA, Route22Past_LyraLooksAroundAgainMovementData

--- a/maps/TeamRocketBaseB1F.asm
+++ b/maps/TeamRocketBaseB1F.asm
@@ -511,7 +511,7 @@ VoltorbExplodingTrap:
 	special FadeOutPalettes
 	special LoadMapPalettes
 	cry VOLTORB
-	special FadeInPalettes
+	special FadeInPalettes_EnableDynNoApply
 	setlasttalked -1
 	loadvar VAR_BATTLETYPE, BATTLETYPE_TRAP
 	loadwildmon VOLTORB, 30
@@ -522,7 +522,7 @@ GeodudeExplodingTrap:
 	special FadeOutPalettes
 	special LoadMapPalettes
 	cry GEODUDE
-	special FadeInPalettes
+	special FadeInPalettes_EnableDynNoApply
 	setlasttalked -1
 	loadvar VAR_BATTLETYPE, BATTLETYPE_TRAP
 	loadwildmon GEODUDE, 28
@@ -533,7 +533,7 @@ KoffingExplodingTrap:
 	special FadeOutPalettes
 	special LoadMapPalettes
 	cry KOFFING
-	special FadeInPalettes
+	special FadeInPalettes_EnableDynNoApply
 	setlasttalked -1
 	loadvar VAR_BATTLETYPE, BATTLETYPE_TRAP
 	loadwildmon KOFFING, 28

--- a/maps/TeamRocketBaseB2F.asm
+++ b/maps/TeamRocketBaseB2F.asm
@@ -176,7 +176,7 @@ LanceHealsScript:
 	special LoadMapPalettes
 	playsound SFX_FULL_HEAL
 	special HealParty
-	special FadeInPalettes
+	special FadeInPalettes_EnableDynNoApply
 	showtext LanceHealsText2
 	setscene $1
 	setevent EVENT_LANCE_HEALED_YOU_IN_TEAM_ROCKET_BASE

--- a/maps/WarehouseEntrance.asm
+++ b/maps/WarehouseEntrance.asm
@@ -264,7 +264,7 @@ OlderHaircutBrotherScript:
 	special LoadMapPalettes
 	playmusic MUSIC_HEAL
 	pause 60
-	special FadeInPalettes
+	special FadeInPalettes_EnableDynNoApply
 	special RestartMapMusic
 	opentext
 	writetext GoldenrodUndergroundOlderHaircutBrotherAllDoneText
@@ -337,7 +337,7 @@ YoungerHaircutBrotherScript:
 	special LoadMapPalettes
 	playmusic MUSIC_HEAL
 	pause 60
-	special FadeInPalettes
+	special FadeInPalettes_EnableDynNoApply
 	special RestartMapMusic
 	opentext
 	writetext GoldenrodUndergroundYoungerHaircutBrotherAllDoneText


### PR DESCRIPTION
Fixes objects going white when using FLASH in darkness. This also fixes `FadeInPalettes` when used in various map scripts.