### PR TITLE
Move hRTC* to wram

### DIFF
--- a/engine/menus/main_menu.asm
+++ b/engine/menus/main_menu.asm
@@ -164,8 +164,8 @@ MainMenu_PrintCurrentTimeAndDay:
 if DEF(NO_RTC)
 	ld a, BANK(sPlayerData)
 	call GetSRAMBank
-	ld hl, sPlayerData + wNoRTC - wPlayerData
-	ld de, wNoRTC
+	ld hl, sPlayerData + wRTCDayHi - wPlayerData
+	ld de, wRTCDayHi
 	ld bc, 5
 	rst CopyBytes
 	call CloseSRAM

--- a/engine/rtc/rtc.asm
+++ b/engine/rtc/rtc.asm
@@ -86,7 +86,7 @@ else
 endc
 
 _FixDays:
-	ld hl, hRTCDayHi
+	ld hl, wRTCDayHi
 	bit 7, [hl]
 	jr nz, .set_bit_7
 	bit 6, [hl]
@@ -126,7 +126,7 @@ ClockContinue:
 _InitTime::
 	call GetClock
 	call FixDays
-	ld hl, hRTCSeconds
+	ld hl, wRTCSeconds
 	ld de, wStartSecond
 	ld bc, wStringBuffer2 + 3
 ; seconds

--- a/home/game_time.asm
+++ b/home/game_time.asm
@@ -136,7 +136,7 @@ UpdateNoRTC::
 	ld a, 60
 	ld b, a
 
-	ld hl, wNoRTCSeconds
+	ld hl, wRTCSeconds
 
 ; +1 second
 	inc [hl]

--- a/ram/hram.asm
+++ b/ram/hram.asm
@@ -6,11 +6,7 @@ hROMBank:: db
 hROMBankBackup:: db
 hTempBank:: db
 
-hRTCDayHi::   db
-hRTCDayLo::   db
-hRTCHours::   db
-hRTCMinutes:: db
-hRTCSeconds:: db
+	ds 5 ; unused
 
 hHours:: db
 hMinutes:: db

--- a/ram/wramx.asm
+++ b/ram/wramx.asm
@@ -892,18 +892,13 @@ wGameTimeFrames:: db
 
 wCurDay:: db
 
-; do not talk to the RTC hardware in the no-RTC patch
-if DEF(NO_RTC)
-wNoRTC::
-wNoRTCDayHi::   ds 1 ; copied to hRTCDayHi
-wNoRTCDayLo::   ds 1 ; copied to hRTCDayLo
-wNoRTCHours::   ds 1 ; copied to hRTCHours
-wNoRTCMinutes:: db ; copied to hRTCMinutes
-wNoRTCSeconds:: db ; copied to hRTCSeconds
-else
-; reserve equal space in RTC versions so that saved games remain compatible
-	ds 5
-endc
+; no-RTC patch needs to save/restore rtc state
+; builds with rtc will simply overwrite the saved value
+wRTCDayHi::   db
+wRTCDayLo::   db
+wRTCHours::   db
+wRTCMinutes:: db
+wRTCSeconds:: db
 
 wPlayerGoingUpStairs:: db
 


### PR DESCRIPTION
Ends up being pretty much equivalent, uses a few less rom0 bytes and 5 less hram bytes

Reduces the delta with the no-rtc build

UpdateTime already assumed rSVBK == 1 but only on no-RTC, so it's possible bugs in that build would be exposed to rtc-enabled builds