### PR TITLE
Compacting music commands

### DIFF
--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -1318,7 +1318,6 @@ MusicCommands:
 	dw Music_SlidePitchTo ; pitch wheel
 	dw Music_Vibrato ; vibrato
 	dw Music_ToggleNoise ; music noise sampling
-	dw Music_Panning ; force panning
 	dw Music_Volume ; volume
 	dw Music_Tone ; tone
 	dw Music_TempoRelative ; global tempo
@@ -1328,6 +1327,7 @@ MusicCommands:
 	dw Music_SFXPriorityOff ; sfx priority off
 	dw Music_StereoPanning ; stereo panning
 	dw Music_SFXToggleNoise ; sfx noise sampling
+	dw DoNothing ; $EF
 	dw DoNothing ; $F0
 	dw DoNothing ; $F1
 	dw DoNothing ; $F2
@@ -1796,11 +1796,6 @@ Music_StereoPanning:
 	bit STEREO, a
 	; skip param
 	jr z, GetMusicByte
-	; fallthrough
-
-Music_Panning:
-; force panning
-; params: 1
 	call SetLRTracks
 	call GetMusicByte
 	ld hl, wChannel1Tracks - wChannel1

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -1429,7 +1429,7 @@ Music_LoopChannel:
 	bit SOUND_LOOPING, [hl] ; has the loop been initiated?
 	jr nz, .checkloop
 	and a ; loop counter 0 = infinite
-	jr z, .loop
+	jr z, Music_JumpChannel
 	; initiate loop
 	dec a
 	set SOUND_LOOPING, [hl] ; set loop flag
@@ -1443,7 +1443,6 @@ Music_LoopChannel:
 	and a ; are we done?
 	jr z, .endloop
 	dec [hl]
-.loop
 	jr Music_JumpChannel
 
 .endloop

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -1326,9 +1326,9 @@ MusicCommands:
 	dw Music_NewSong ; new song
 	dw Music_SFXPriorityOn ; sfx priority on
 	dw Music_SFXPriorityOff ; sfx priority off
-	dw DoNothing ; $EE
 	dw Music_StereoPanning ; stereo panning
 	dw Music_SFXToggleNoise ; sfx noise sampling
+	dw DoNothing ; $F0
 	dw DoNothing ; $F1
 	dw DoNothing ; $F2
 	dw DoNothing ; $F3

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -1326,7 +1326,7 @@ MusicCommands:
 	dw Music_SFXPriorityOn ; sfx priority on
 	dw Music_SFXPriorityOff ; sfx priority off
 	dw Music_StereoPanning ; stereo panning
-	dw Music_SFXToggleNoise ; sfx noise sampling
+	dw DoNothing ; $EE
 	dw DoNothing ; $EF
 	dw DoNothing ; $F0
 	dw DoNothing ; $F1
@@ -1660,30 +1660,17 @@ Music_ToggleNoise:
 .on
 	; turn noise sampling on
 	set SOUND_NOISE, [hl]
+	ld a, [wCurChannel]
+	bit 3, a
+	jr z, Music_ChangeNoiseSampleSet
+; Channel 8 uses sfx sample set
+	call GetMusicByte
+	ld [wSFXNoiseSampleSet], a
+	ret
+
 Music_ChangeNoiseSampleSet:
 	call GetMusicByte
 	ld [wMusicNoiseSampleSet], a
-	ret
-
-Music_SFXToggleNoise:
-; toggle sfx noise sampling
-; params:
-;	on: 1
-; 	off: 0
-	; check if noise sampling is on
-	ld hl, wChannel1Flags - wChannel1
-	add hl, bc
-	bit SOUND_NOISE, [hl]
-	jr z, .on
-	; turn noise sampling off
-	res SOUND_NOISE, [hl]
-	ret
-
-.on
-	; turn noise sampling on
-	set SOUND_NOISE, [hl]
-	call GetMusicByte
-	ld [wSFXNoiseSampleSet], a
 	ret
 
 Music_NoteType:

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -1304,23 +1304,23 @@ MusicCommands:
 	dw Music_Octave3 ; octave 3
 	dw Music_Octave2 ; octave 2
 	dw Music_Octave1 ; octave 1
+	dw Music_DutyCycle0 ; duty cycle 0
+	dw Music_DutyCycle1 ; duty cycle 1
+	dw Music_DutyCycle2 ; duty cycle 2
+	dw Music_DutyCycle3 ; duty cycle 3
 	dw Music_NoteType ; note length + intensity
 	dw Music_ForceOctave ; set starting octave
 	dw Music_Tempo ; tempo
-	dw Music_DutyCycle ; duty cycle
 	dw Music_Intensity ; intensity
 	dw Music_SoundStatus ; update sound status
 	dw Music_SoundDuty ; sfx duty
 	dw Music_ToggleSFX ; sound on/off
 	dw Music_SlidePitchTo ; pitch wheel
 	dw Music_Vibrato ; vibrato
-	dw DoNothing ; $E2
 	dw Music_ToggleNoise ; music noise sampling
 	dw Music_Panning ; force panning
 	dw Music_Volume ; volume
 	dw Music_Tone ; tone
-	dw DoNothing ; $E7
-	dw DoNothing ; $E8
 	dw Music_TempoRelative ; global tempo
 	dw Music_RestartChannel ; restart current channel from header
 	dw Music_NewSong ; new song
@@ -1723,10 +1723,12 @@ Music_SoundStatus:
 	set NOTE_PITCH_SWEEP, [hl]
 	ret
 
-Music_DutyCycle:
+Music_DutyCycle0:
+Music_DutyCycle1:
+Music_DutyCycle2:
+Music_DutyCycle3:
 ; duty cycle
-; params: 1
-	call GetMusicByte
+	ld a, [wCurMusicByte]
 	rrca
 	rrca
 	and $c0

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -1052,7 +1052,7 @@ ParseMusic:
 	call GetMusicByte ; store next byte in a
 	cp $ff ; is the song over?
 	jr z, .endchannel
-	cp $d0 ; is it a note?
+	cp FIRST_MUSIC_CMD ; is it a note?
 	jr c, .readnote
 	; then it's a command
 .readcommand
@@ -1289,7 +1289,7 @@ ParseMusicCommand:
 	; reload command
 	ld a, [wCurMusicByte]
 	; get command #
-	sub $d0 ; first command
+	sub FIRST_MUSIC_CMD
 	; jump to the new command pointer
 	call StackJumpTable
 

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -1325,9 +1325,9 @@ MusicCommands:
 	dw Music_NewSong ; new song
 	dw Music_SFXPriorityOn ; sfx priority on
 	dw Music_SFXPriorityOff ; sfx priority off
-	dw Music_StereoPanning ; stereo panning
-	dw DoNothing ; $EE
-	dw DoNothing ; $EF
+	dw Music_PanLeft ; stereo panning
+	dw Music_PanRight
+	dw Music_PanCentre
 	dw DoNothing ; $F0
 	dw DoNothing ; $F1
 	dw DoNothing ; $F2
@@ -1775,16 +1775,27 @@ Music_ForceOctave:
 	ld [hl], a
 	ret
 
-Music_StereoPanning:
 ; stereo panning
-; params: 1
+Music_PanLeft:
+	ld a, $F0
+	jr _stereo_pan
+
+Music_PanRight:
+	ld a, $0F
+	jr _stereo_pan
+
+Music_PanCentre:
+	ld a, $FF
+	; fallthrough
+_stereo_pan:
 	; stereo on?
-	ld a, [wOptions1]
-	bit STEREO, a
-	; skip param
-	jr z, GetMusicByte
+	ld hl, wOptions1
+	bit STEREO, [hl]
+	ret z
+
+	ld d, a
 	call SetLRTracks
-	call GetMusicByte
+	ld a, d
 	ld hl, wChannel1Tracks - wChannel1
 	add hl, bc
 	and [hl]

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -1314,29 +1314,29 @@ MusicCommands:
 	dw Music_ToggleSFX ; sound on/off
 	dw Music_SlidePitchTo ; pitch wheel
 	dw Music_Vibrato ; vibrato
-	dw MusicE2 ; unused
+	dw DoNothing ; $E2
 	dw Music_ToggleNoise ; music noise sampling
 	dw Music_Panning ; force panning
 	dw Music_Volume ; volume
 	dw Music_Tone ; tone
-	dw MusicE7 ; unused
-	dw MusicE8 ; unused
+	dw DoNothing ; $E7
+	dw DoNothing ; $E8
 	dw Music_TempoRelative ; global tempo
 	dw Music_RestartChannel ; restart current channel from header
 	dw Music_NewSong ; new song
 	dw Music_SFXPriorityOn ; sfx priority on
 	dw Music_SFXPriorityOff ; sfx priority off
-	dw MusicEE ; unused
+	dw DoNothing ; $EE
 	dw Music_StereoPanning ; stereo panning
 	dw Music_SFXToggleNoise ; sfx noise sampling
-	dw MusicF1 ; nothing
-	dw MusicF2 ; nothing
-	dw MusicF3 ; nothing
-	dw MusicF4 ; nothing
-	dw MusicF5 ; nothing
-	dw MusicF6 ; nothing
-	dw MusicF7 ; nothing
-	dw MusicF8 ; nothing
+	dw DoNothing ; $F1
+	dw DoNothing ; $F2
+	dw DoNothing ; $F3
+	dw DoNothing ; $F4
+	dw DoNothing ; $F5
+	dw DoNothing ; $F6
+	dw DoNothing ; $F7
+	dw DoNothing ; $F8
 	dw Music_ChangeNoiseSampleSet ; noisesampleset
 	dw Music_SetCondition ; setcondition
 	dw Music_JumpIf ; jumpif
@@ -1346,20 +1346,6 @@ MusicCommands:
 	dw Music_EndChannel ; return
 	assert_table_length $100 - FIRST_MUSIC_CMD
 
-MusicE2:
-MusicE7:
-MusicE8:
-MusicEE:
-MusicF1:
-MusicF2:
-MusicF3:
-MusicF4:
-MusicF5:
-MusicF6:
-MusicF7:
-MusicF8:
-MusicF9:
-	ret ; no-optimize stub function
 
 Music_EndChannel:
 ; called when $ff is encountered w/ subroutine flag set

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -1327,7 +1327,7 @@ MusicCommands:
 	dw Music_SFXPriorityOff ; sfx priority off
 	dw Music_PanLeft ; stereo panning
 	dw Music_PanRight
-	dw Music_Pancenter
+	dw Music_PanCenter
 	dw DoNothing ; $F0
 	dw DoNothing ; $F1
 	dw DoNothing ; $F2
@@ -1783,7 +1783,7 @@ Music_PanRight:
 	ld a, $0F
 	jr _ForcePanning
 
-Music_Pancenter:
+Music_PanCenter:
 	ld a, $FF
 	; fallthrough
 _ForcePanning:

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -1327,7 +1327,7 @@ MusicCommands:
 	dw Music_SFXPriorityOff ; sfx priority off
 	dw Music_PanLeft ; stereo panning
 	dw Music_PanRight
-	dw Music_PanCentre
+	dw Music_Pancenter
 	dw DoNothing ; $F0
 	dw DoNothing ; $F1
 	dw DoNothing ; $F2
@@ -1777,16 +1777,16 @@ Music_ForceOctave:
 ; stereo panning
 Music_PanLeft:
 	ld a, $F0
-	jr _stereo_pan
+	jr _ForcePanning
 
 Music_PanRight:
 	ld a, $0F
-	jr _stereo_pan
+	jr _ForcePanning
 
-Music_PanCentre:
+Music_Pancenter:
 	ld a, $FF
 	; fallthrough
-_stereo_pan:
+_ForcePanning:
 	; stereo on?
 	ld hl, wOptions1
 	bit STEREO, [hl]

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -1458,18 +1458,7 @@ Music_LoopChannel:
 	jr z, .endloop
 	dec [hl]
 .loop
-	; get pointer
-	call GetMusicByte
-	ld e, a
-	call GetMusicByte
-	ld d, a
-	; load new pointer into MusicAddress
-	ld hl, wChannel1MusicAddress - wChannel1
-	add hl, bc
-	ld a, e
-	ld [hli], a
-	ld [hl], d
-	ret
+	jr Music_JumpChannel
 
 .endloop
 	; reset loop flag
@@ -1516,7 +1505,7 @@ Music_JumpIf:
 	ld hl, wChannel1Condition - wChannel1
 	add hl, bc
 	cp [hl]
-	jr z, .jump
+	jr z, Music_JumpChannel
 ; skip to next command
 	; get address
 	ld hl, wChannel1MusicAddress - wChannel1
@@ -1531,21 +1520,6 @@ Music_JumpIf:
 	ld a, d
 	ld [hld], a
 	ld [hl], e
-	ret
-
-.jump
-; jump to the new address
-	; get pointer
-	call GetMusicByte
-	ld e, a
-	call GetMusicByte
-	ld d, a
-	; update pointer in MusicAddress
-	ld hl, wChannel1MusicAddress - wChannel1
-	add hl, bc
-	ld a, e
-	ld [hli], a
-	ld [hl], d
 	ret
 
 Music_Vibrato:

--- a/macros/scripts/audio.asm
+++ b/macros/scripts/audio.asm
@@ -49,20 +49,20 @@ ENDM
 DEF FIRST_MUSIC_CMD EQU const_value
 
 	const octave_cmd
+	assert octave_cmd & %111 == 0, "octave_cmd must be 3-bit aligned"
 MACRO octave
 	assert 1 <= (\1) && (\1) <= 8, "octave must be 1-8"
 	db octave_cmd + 8 - (\1) ; octave
 ENDM
-assert octave_cmd & $7 == 0, "octave_cmd must be 3 bit aligned"
 
 	const_skip 7 ; all octave values
 
 	const duty_cycle_cmd
+	assert duty_cycle_cmd & %11 == 0, "duty_cycle_cmd must be 2-bit aligned"
 MACRO duty_cycle
 	assert 0 <= (\1) && (\1) <= 6, "duty cycle must be 0-6"
 	db duty_cycle_cmd | (\1 & 3) ; values 4-6 fold into 0-2
 ENDM
-assert duty_cycle_cmd & $3 == 0, "duty_cycle_cmd must be 2 bit aligned"
 
 	const_skip 3 ; all duty cycle values
 
@@ -260,7 +260,7 @@ MACRO sound_call
 ENDM
 
 	const sound_ret_cmd
+	assert sound_ret_cmd == $ff, "sound_ret_cmd must be $ff"
 MACRO sound_ret
 	db sound_ret_cmd
 ENDM
-assert sound_ret_cmd == $ff, "sound_ret must be $ff"

--- a/macros/scripts/audio.asm
+++ b/macros/scripts/audio.asm
@@ -53,6 +53,7 @@ MACRO octave
 	assert 1 <= (\1) && (\1) <= 8, "octave must be 1-8"
 	db octave_cmd + 8 - (\1) ; octave
 ENDM
+assert octave_cmd & $7 == 0, "octave_cmd must be 3 bit aligned"
 
 	const_skip 7 ; all octave values
 
@@ -61,6 +62,7 @@ MACRO duty_cycle
 	assert 0 <= (\1) && (\1) <= 6, "duty cycle must be 0-6"
 	db duty_cycle_cmd | (\1 & 3) ; values 4-6 fold into 0-2
 ENDM
+assert duty_cycle_cmd & $3 == 0, "duty_cycle_cmd must be 2 bit aligned"
 
 	const_skip 3 ; all duty cycle values
 
@@ -261,3 +263,4 @@ ENDM
 MACRO sound_ret
 	db sound_ret_cmd
 ENDM
+assert sound_ret_cmd == $ff, "sound_ret must be $ff"

--- a/macros/scripts/audio.asm
+++ b/macros/scripts/audio.asm
@@ -199,13 +199,23 @@ MACRO sfx_priority_off
 	db sfx_priority_off_cmd
 ENDM
 
-	const stereo_panning_cmd
+	const stereo_left_cmd
+	const stereo_right_cmd
+	const stereo_centre_cmd
+
 MACRO stereo_panning
-	db stereo_panning_cmd
-	dn %1111 * (1 && \1), %1111 * (1 && \2) ; left enable, right enable
+	if (\1) && !(\2)
+		db stereo_left_cmd
+	elif !(\1) && (\2)
+		db stereo_right_cmd
+	elif (\1) && (\2)
+		db stereo_centre_cmd
+	else
+		fail "Cannot mute with stereo_panning"
+	endc
 ENDM
 
-	const_skip 11
+	const_skip 9
 
 	const noisesampleset_cmd
 MACRO noisesampleset

--- a/macros/scripts/audio.asm
+++ b/macros/scripts/audio.asm
@@ -48,7 +48,7 @@ ENDM
 	const_def $d0
 DEF FIRST_MUSIC_CMD EQU const_value
 
-	const octave_cmd
+	const octave_cmd ; $d0
 	assert octave_cmd & %111 == 0, "octave_cmd must be 3-bit aligned"
 MACRO octave
 	assert 1 <= (\1) && (\1) <= 8, "octave must be 1-8"
@@ -57,7 +57,7 @@ ENDM
 
 	const_skip 7 ; all octave values
 
-	const duty_cycle_cmd
+	const duty_cycle_cmd ; $d8
 	assert duty_cycle_cmd & %11 == 0, "duty_cycle_cmd must be 2-bit aligned"
 MACRO duty_cycle
 	assert 0 <= (\1) && (\1) <= 6, "duty cycle must be 0-6"
@@ -66,7 +66,7 @@ ENDM
 
 	const_skip 3 ; all duty cycle values
 
-	const note_type_cmd
+	const note_type_cmd ; $dc
 MACRO note_type
 	db note_type_cmd
 	db \1 ; note length
@@ -84,19 +84,19 @@ MACRO drum_speed
 	note_type \1 ; note length
 ENDM
 
-	const transpose_cmd
+	const transpose_cmd ; $dd
 MACRO transpose
 	db transpose_cmd
 	dn \1, \2 ; num octaves, num pitches
 ENDM
 
-	const tempo_cmd
+	const tempo_cmd ; $de
 MACRO tempo
 	db tempo_cmd
 	bigdw \1 ; tempo
 ENDM
 
-	const volume_envelope_cmd
+	const volume_envelope_cmd ; $df
 MACRO volume_envelope
 	db volume_envelope_cmd
 	if \2 < 0
@@ -106,7 +106,7 @@ MACRO volume_envelope
 	endc
 ENDM
 
-	const pitch_sweep_cmd
+	const pitch_sweep_cmd ; $e0
 MACRO pitch_sweep
 	db pitch_sweep_cmd
 	if \2 < 0
@@ -116,25 +116,25 @@ MACRO pitch_sweep
 	endc
 ENDM
 
-	const duty_cycle_pattern_cmd
+	const duty_cycle_pattern_cmd ; $e1
 MACRO duty_cycle_pattern
 	db duty_cycle_pattern_cmd
 	db (\1 << 6) | (\2 << 4) | (\3 << 2) | (\4 << 0) ; duty cycle pattern
 ENDM
 
-	const toggle_sfx_cmd
+	const toggle_sfx_cmd ; $e2
 MACRO toggle_sfx
 	db toggle_sfx_cmd
 ENDM
 
-	const pitch_slide_cmd
+	const pitch_slide_cmd ; $e3
 MACRO pitch_slide
 	db pitch_slide_cmd
 	db \1 - 1 ; duration
 	dn 8 - \2, \3 % 12 ; octave, pitch
 ENDM
 
-	const vibrato_cmd
+	const vibrato_cmd ; $e4
 MACRO vibrato
 	db vibrato_cmd
 	db \1 ; delay
@@ -145,7 +145,7 @@ MACRO vibrato
 	endc
 ENDM
 
-	const toggle_noise_cmd
+	const toggle_noise_cmd ; $e5
 MACRO toggle_noise
 	db toggle_noise_cmd
 	if _NARG > 0
@@ -157,7 +157,7 @@ MACRO sfx_toggle_noise
 	toggle_noise \#
 ENDM
 
-	const volume_cmd
+	const volume_cmd ; $e6
 MACRO volume
 	db volume_cmd
 	if _NARG > 1
@@ -167,44 +167,43 @@ MACRO volume
 	endc
 ENDM
 
-	const pitch_offset_cmd
+	const pitch_offset_cmd ; $e7
 MACRO pitch_offset
 	db pitch_offset_cmd
 	bigdw \1 ; pitch offset
 ENDM
 
-	const tempo_relative_cmd
+	const tempo_relative_cmd ; $e8
 MACRO tempo_relative
 	db tempo_relative_cmd
 	bigdw \1 ; tempo adjustment
 ENDM
 
-	const restart_channel_cmd
+	const restart_channel_cmd ; $e9
 MACRO restart_channel
 	db restart_channel_cmd
 	dw \1 ; address
 ENDM
 
-	const new_song_cmd
+	const new_song_cmd ; $ea
 MACRO new_song
 	db new_song_cmd
 	bigdw \1 ; id
 ENDM
 
-	const sfx_priority_on_cmd
+	const sfx_priority_on_cmd ; $eb
 MACRO sfx_priority_on
 	db sfx_priority_on_cmd
 ENDM
 
-	const sfx_priority_off_cmd
+	const sfx_priority_off_cmd ; $ec
 MACRO sfx_priority_off
 	db sfx_priority_off_cmd
 ENDM
 
-	const stereo_left_cmd
-	const stereo_right_cmd
-	const stereo_center_cmd
-
+	const stereo_left_cmd ; $ed
+	const stereo_right_cmd ; $ee
+	const stereo_center_cmd ; $ef
 MACRO stereo_panning
 	if (\1) && !(\2)
 		db stereo_left_cmd
@@ -219,32 +218,32 @@ ENDM
 
 	const_skip 9
 
-	const noisesampleset_cmd
+	const noisesampleset_cmd ; $f9
 MACRO noisesampleset
 	db noisesampleset_cmd
 	db \1 ; noise
 ENDM
 
-	const set_condition_cmd
+	const set_condition_cmd ; $fa
 MACRO set_condition
 	db set_condition_cmd
 	db \1 ; condition
 ENDM
 
-	const sound_jump_if_cmd
+	const sound_jump_if_cmd ; $fb
 MACRO sound_jump_if
 	db sound_jump_if_cmd
 	db \1 ; condition
 	dw \2 ; address
 ENDM
 
-	const sound_jump_cmd
+	const sound_jump_cmd ; $fc
 MACRO sound_jump
 	db sound_jump_cmd
 	dw \1 ; address
 ENDM
 
-	const sound_loop_cmd
+	const sound_loop_cmd ; $fd
 MACRO sound_loop
 	db sound_loop_cmd
 	assert (\1) != 0, "'sound_loop 0' can be 'sound_jump'"
@@ -253,13 +252,13 @@ MACRO sound_loop
 	dw \2 ; address
 ENDM
 
-	const sound_call_cmd
+	const sound_call_cmd ; $fe
 MACRO sound_call
 	db sound_call_cmd
 	dw \1 ; address
 ENDM
 
-	const sound_ret_cmd
+	const sound_ret_cmd ; $ff
 	assert sound_ret_cmd == $ff, "sound_ret_cmd must be $ff"
 MACRO sound_ret
 	db sound_ret_cmd

--- a/macros/scripts/audio.asm
+++ b/macros/scripts/audio.asm
@@ -201,8 +201,6 @@ MACRO sfx_priority_off
 	db sfx_priority_off_cmd
 ENDM
 
-	const_skip
-
 	const stereo_panning_cmd
 MACRO stereo_panning
 	db stereo_panning_cmd
@@ -217,7 +215,7 @@ MACRO sfx_toggle_noise
 	endc
 ENDM
 
-	const_skip 8
+	const_skip 9
 
 	const noisesampleset_cmd
 MACRO noisesampleset

--- a/macros/scripts/audio.asm
+++ b/macros/scripts/audio.asm
@@ -151,12 +151,6 @@ MACRO toggle_noise
 	endc
 ENDM
 
-	const force_stereo_panning_cmd
-MACRO force_stereo_panning
-	db force_stereo_panning_cmd
-	dn %1111 * (1 && \1), %1111 * (1 && \2) ; left enable, right enable
-ENDM
-
 	const volume_cmd
 MACRO volume
 	db volume_cmd
@@ -215,7 +209,7 @@ MACRO sfx_toggle_noise
 	endc
 ENDM
 
-	const_skip 9
+	const_skip 10
 
 	const noisesampleset_cmd
 MACRO noisesampleset

--- a/macros/scripts/audio.asm
+++ b/macros/scripts/audio.asm
@@ -141,11 +141,7 @@ MACRO vibrato
 	endc
 ENDM
 
-	const unknownmusic0xe2_cmd ; $e2
-MACRO unknownmusic0xe2
-	db unknownmusic0xe2_cmd
-	db \1 ; unknown
-ENDM
+	const_skip ; $e2
 
 	const toggle_noise_cmd ; $e3
 MACRO toggle_noise
@@ -177,17 +173,8 @@ MACRO pitch_offset
 	bigdw \1 ; pitch offset
 ENDM
 
-	const unknownmusic0xe7_cmd ; $e7
-MACRO unknownmusic0xe7
-	db unknownmusic0xe7_cmd
-	db \1 ; unknown
-ENDM
-
-	const unknownmusic0xe8_cmd ; $e8
-MACRO unknownmusic0xe8
-	db unknownmusic0xe8_cmd
-	db \1 ; unknown
-ENDM
+	const_skip ; $e7
+	const_skip ; $e8
 
 	const tempo_relative_cmd ; $e9
 MACRO tempo_relative
@@ -217,11 +204,7 @@ MACRO sfx_priority_off
 	db sfx_priority_off_cmd
 ENDM
 
-	const unknownmusic0xee_cmd ; $ee
-MACRO unknownmusic0xee
-	db unknownmusic0xee_cmd
-	dw \1 ; address
-ENDM
+	const_skip ; $ee
 
 	const stereo_panning_cmd ; $ef
 MACRO stereo_panning
@@ -237,45 +220,14 @@ MACRO sfx_toggle_noise
 	endc
 ENDM
 
-	const music0xf1_cmd ; $f1
-MACRO music0xf1
-	db music0xf1_cmd
-ENDM
-
-	const music0xf2_cmd ; $f2
-MACRO music0xf2
-	db music0xf2_cmd
-ENDM
-
-	const music0xf3_cmd ; $f3
-MACRO music0xf3
-	db music0xf3_cmd
-ENDM
-
-	const music0xf4_cmd ; $f4
-MACRO music0xf4
-	db music0xf4_cmd
-ENDM
-
-	const music0xf5_cmd ; $f5
-MACRO music0xf5
-	db music0xf5_cmd
-ENDM
-
-	const music0xf6_cmd ; $f6
-MACRO music0xf6
-	db music0xf6_cmd
-ENDM
-
-	const music0xf7_cmd ; $f7
-MACRO music0xf7
-	db music0xf7_cmd
-ENDM
-
-	const music0xf8_cmd ; $f8
-MACRO music0xf8
-	db music0xf8_cmd
-ENDM
+	const_skip ; $f1
+	const_skip ; $f2
+	const_skip ; $f3
+	const_skip ; $f4
+	const_skip ; $f5
+	const_skip ; $f6
+	const_skip ; $f7
+	const_skip ; $f8
 
 	const noisesampleset_cmd
 MACRO noisesampleset

--- a/macros/scripts/audio.asm
+++ b/macros/scripts/audio.asm
@@ -48,7 +48,7 @@ ENDM
 	const_def $d0
 DEF FIRST_MUSIC_CMD EQU const_value
 
-	const octave_cmd ; $d0
+	const octave_cmd
 MACRO octave
 	assert 1 <= (\1) && (\1) <= 8, "octave must be 1-8"
 	db octave_cmd + 8 - (\1) ; octave
@@ -56,7 +56,7 @@ ENDM
 
 	const_skip 7 ; all octave values
 
-	const note_type_cmd ; $d8
+	const note_type_cmd
 MACRO note_type
 	db note_type_cmd
 	db \1 ; note length
@@ -74,25 +74,25 @@ MACRO drum_speed
 	note_type \1 ; note length
 ENDM
 
-	const transpose_cmd ; $d9
+	const transpose_cmd
 MACRO transpose
 	db transpose_cmd
 	dn \1, \2 ; num octaves, num pitches
 ENDM
 
-	const tempo_cmd ; $da
+	const tempo_cmd
 MACRO tempo
 	db tempo_cmd
 	bigdw \1 ; tempo
 ENDM
 
-	const duty_cycle_cmd ; $db
+	const duty_cycle_cmd
 MACRO duty_cycle
 	db duty_cycle_cmd
 	db \1 ; duty cycle
 ENDM
 
-	const volume_envelope_cmd ; $dc
+	const volume_envelope_cmd
 MACRO volume_envelope
 	db volume_envelope_cmd
 	if \2 < 0
@@ -102,7 +102,7 @@ MACRO volume_envelope
 	endc
 ENDM
 
-	const pitch_sweep_cmd ; $dd
+	const pitch_sweep_cmd
 MACRO pitch_sweep
 	db pitch_sweep_cmd
 	if \2 < 0
@@ -112,25 +112,25 @@ MACRO pitch_sweep
 	endc
 ENDM
 
-	const duty_cycle_pattern_cmd ; $de
+	const duty_cycle_pattern_cmd
 MACRO duty_cycle_pattern
 	db duty_cycle_pattern_cmd
 	db (\1 << 6) | (\2 << 4) | (\3 << 2) | (\4 << 0) ; duty cycle pattern
 ENDM
 
-	const toggle_sfx_cmd ; $df
+	const toggle_sfx_cmd
 MACRO toggle_sfx
 	db toggle_sfx_cmd
 ENDM
 
-	const pitch_slide_cmd ; $e0
+	const pitch_slide_cmd
 MACRO pitch_slide
 	db pitch_slide_cmd
 	db \1 - 1 ; duration
 	dn 8 - \2, \3 % 12 ; octave, pitch
 ENDM
 
-	const vibrato_cmd ; $e1
+	const vibrato_cmd
 MACRO vibrato
 	db vibrato_cmd
 	db \1 ; delay
@@ -141,9 +141,9 @@ MACRO vibrato
 	endc
 ENDM
 
-	const_skip ; $e2
+	const_skip
 
-	const toggle_noise_cmd ; $e3
+	const toggle_noise_cmd
 MACRO toggle_noise
 	db toggle_noise_cmd
 	if _NARG > 0
@@ -151,13 +151,13 @@ MACRO toggle_noise
 	endc
 ENDM
 
-	const force_stereo_panning_cmd ; $e4
+	const force_stereo_panning_cmd
 MACRO force_stereo_panning
 	db force_stereo_panning_cmd
 	dn %1111 * (1 && \1), %1111 * (1 && \2) ; left enable, right enable
 ENDM
 
-	const volume_cmd ; $e5
+	const volume_cmd
 MACRO volume
 	db volume_cmd
 	if _NARG > 1
@@ -167,52 +167,51 @@ MACRO volume
 	endc
 ENDM
 
-	const pitch_offset_cmd ; $e6
+	const pitch_offset_cmd
 MACRO pitch_offset
 	db pitch_offset_cmd
 	bigdw \1 ; pitch offset
 ENDM
 
-	const_skip ; $e7
-	const_skip ; $e8
+	const_skip 2
 
-	const tempo_relative_cmd ; $e9
+	const tempo_relative_cmd
 MACRO tempo_relative
 	db tempo_relative_cmd
 	bigdw \1 ; tempo adjustment
 ENDM
 
-	const restart_channel_cmd ; $ea
+	const restart_channel_cmd
 MACRO restart_channel
 	db restart_channel_cmd
 	dw \1 ; address
 ENDM
 
-	const new_song_cmd ; $eb
+	const new_song_cmd
 MACRO new_song
 	db new_song_cmd
 	bigdw \1 ; id
 ENDM
 
-	const sfx_priority_on_cmd ; $ec
+	const sfx_priority_on_cmd
 MACRO sfx_priority_on
 	db sfx_priority_on_cmd
 ENDM
 
-	const sfx_priority_off_cmd ; $ed
+	const sfx_priority_off_cmd
 MACRO sfx_priority_off
 	db sfx_priority_off_cmd
 ENDM
 
-	const_skip ; $ee
+	const_skip
 
-	const stereo_panning_cmd ; $ef
+	const stereo_panning_cmd
 MACRO stereo_panning
 	db stereo_panning_cmd
 	dn %1111 * (1 && \1), %1111 * (1 && \2) ; left enable, right enable
 ENDM
 
-	const sfx_toggle_noise_cmd ; $f0
+	const sfx_toggle_noise_cmd
 MACRO sfx_toggle_noise
 	db sfx_toggle_noise_cmd
 	if _NARG > 0
@@ -220,14 +219,7 @@ MACRO sfx_toggle_noise
 	endc
 ENDM
 
-	const_skip ; $f1
-	const_skip ; $f2
-	const_skip ; $f3
-	const_skip ; $f4
-	const_skip ; $f5
-	const_skip ; $f6
-	const_skip ; $f7
-	const_skip ; $f8
+	const_skip 8
 
 	const noisesampleset_cmd
 MACRO noisesampleset
@@ -235,26 +227,26 @@ MACRO noisesampleset
 	db \1 ; noise
 ENDM
 
-	const set_condition_cmd ; $fa
+	const set_condition_cmd
 MACRO set_condition
 	db set_condition_cmd
 	db \1 ; condition
 ENDM
 
-	const sound_jump_if_cmd ; $fb
+	const sound_jump_if_cmd
 MACRO sound_jump_if
 	db sound_jump_if_cmd
 	db \1 ; condition
 	dw \2 ; address
 ENDM
 
-	const sound_jump_cmd ; $fc
+	const sound_jump_cmd
 MACRO sound_jump
 	db sound_jump_cmd
 	dw \1 ; address
 ENDM
 
-	const sound_loop_cmd ; $fd
+	const sound_loop_cmd
 MACRO sound_loop
 	db sound_loop_cmd
 	assert (\1) != 0, "'sound_loop 0' can be 'sound_jump'"
@@ -263,13 +255,13 @@ MACRO sound_loop
 	dw \2 ; address
 ENDM
 
-	const sound_call_cmd ; $fe
+	const sound_call_cmd
 MACRO sound_call
 	db sound_call_cmd
 	dw \1 ; address
 ENDM
 
-	const sound_ret_cmd ; $ff
+	const sound_ret_cmd
 MACRO sound_ret
 	db sound_ret_cmd
 ENDM

--- a/macros/scripts/audio.asm
+++ b/macros/scripts/audio.asm
@@ -201,7 +201,7 @@ ENDM
 
 	const stereo_left_cmd
 	const stereo_right_cmd
-	const stereo_centre_cmd
+	const stereo_center_cmd
 
 MACRO stereo_panning
 	if (\1) && !(\2)
@@ -209,7 +209,7 @@ MACRO stereo_panning
 	elif !(\1) && (\2)
 		db stereo_right_cmd
 	elif (\1) && (\2)
-		db stereo_centre_cmd
+		db stereo_center_cmd
 	else
 		fail "Cannot mute with stereo_panning"
 	endc

--- a/macros/scripts/audio.asm
+++ b/macros/scripts/audio.asm
@@ -151,6 +151,10 @@ MACRO toggle_noise
 	endc
 ENDM
 
+MACRO sfx_toggle_noise
+	toggle_noise \#
+ENDM
+
 	const volume_cmd
 MACRO volume
 	db volume_cmd
@@ -201,15 +205,7 @@ MACRO stereo_panning
 	dn %1111 * (1 && \1), %1111 * (1 && \2) ; left enable, right enable
 ENDM
 
-	const sfx_toggle_noise_cmd
-MACRO sfx_toggle_noise
-	db sfx_toggle_noise_cmd
-	if _NARG > 0
-		db \1 ; drum kit
-	endc
-ENDM
-
-	const_skip 10
+	const_skip 11
 
 	const noisesampleset_cmd
 MACRO noisesampleset

--- a/macros/scripts/audio.asm
+++ b/macros/scripts/audio.asm
@@ -56,6 +56,14 @@ ENDM
 
 	const_skip 7 ; all octave values
 
+	const duty_cycle_cmd
+MACRO duty_cycle
+	assert 0 <= (\1) && (\1) <= 6, "duty cycle must be 0-6"
+	db duty_cycle_cmd | (\1 & 3) ; values 4-6 fold into 0-2
+ENDM
+
+	const_skip 3 ; all duty cycle values
+
 	const note_type_cmd
 MACRO note_type
 	db note_type_cmd
@@ -84,12 +92,6 @@ ENDM
 MACRO tempo
 	db tempo_cmd
 	bigdw \1 ; tempo
-ENDM
-
-	const duty_cycle_cmd
-MACRO duty_cycle
-	db duty_cycle_cmd
-	db \1 ; duty cycle
 ENDM
 
 	const volume_envelope_cmd
@@ -141,8 +143,6 @@ MACRO vibrato
 	endc
 ENDM
 
-	const_skip
-
 	const toggle_noise_cmd
 MACRO toggle_noise
 	db toggle_noise_cmd
@@ -172,8 +172,6 @@ MACRO pitch_offset
 	db pitch_offset_cmd
 	bigdw \1 ; pitch offset
 ENDM
-
-	const_skip 2
 
 	const tempo_relative_cmd
 MACRO tempo_relative


### PR DESCRIPTION
```
Before: ROMX: 2004054 bytes used / 11178 free in 123 banks
After:  ROMX: 2002147 bytes used / 13085 free in 123 banks
 +1907 bytes
```

Changes stereo panning and duty cycle to avoid an argument byte, and a few other things

Music source compatible, with the exception of `stereo_panning FALSE, FALSE` which is no longer valid