### PR TITLE
Sound engine optimization

### DIFF
--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -1570,25 +1570,23 @@ Music_ToggleNoise:
 	ld hl, wChannel1Flags - wChannel1
 	add hl, bc
 	bit SOUND_NOISE, [hl]
-	jr z, .on
 	; turn noise sampling off
 	res SOUND_NOISE, [hl]
-	ret
-
-.on
-	; turn noise sampling on
+	ret nz
+	; was off, turn noise sampling on instead
 	set SOUND_NOISE, [hl]
-	ld a, [wCurChannel]
-	cp CHAN5
-	jr c, Music_ChangeNoiseSampleSet
-; Channel 8 uses sfx sample set
-	call GetMusicByte
-	ld [wSFXNoiseSampleSet], a
-	ret
+; fallthrough
 
 Music_ChangeNoiseSampleSet:
+	ld a, [wCurChannel]
+	cp CHAN5
+	ld hl, wMusicNoiseSampleSet
+	jr c, .music
+; Channel 8 uses sfx sample set
+	inc hl ; wSFXNoiseSampleSet
+.music
 	call GetMusicByte
-	ld [wMusicNoiseSampleSet], a
+	ld [hl], a
 	ret
 
 Music_NoteType:

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -426,27 +426,6 @@ UpdateChannels:
 	ldh [rNR44], a
 	ret
 
-_CheckSFX:
-; return carry if any sfx channels are active
-	ld hl, wChannel5Flags
-	bit SOUND_CHANNEL_ON, [hl]
-	jr nz, .sfxon
-	ld hl, wChannel6Flags
-	bit SOUND_CHANNEL_ON, [hl]
-	jr nz, .sfxon
-	ld hl, wChannel7Flags
-	bit SOUND_CHANNEL_ON, [hl]
-	jr nz, .sfxon
-	ld hl, wChannel8Flags
-	bit SOUND_CHANNEL_ON, [hl]
-	jr nz, .sfxon
-	and a
-	ret
-
-.sfxon
-	scf
-	ret
-
 PlayDanger:
 	ld a, [wLowHealthAlarm]
 	bit 7, a
@@ -454,7 +433,7 @@ PlayDanger:
 	cp 255
 	ret z
 	ld d, a
-	call _CheckSFX
+	call CheckSFX
 	jr c, .increment
 	ld a, d
 	and $1f

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -668,7 +668,7 @@ LoadNote:
 	add hl, bc
 	sub [hl]
 	jr nc, .greater_than
-	ld hl, wChannel1Flags3 - wChannel1
+	ld hl, wChannel1Flags2 - wChannel1
 	add hl, bc
 	set SOUND_PITCH_SLIDE_DIR, [hl]
 	; get frequency
@@ -694,7 +694,7 @@ LoadNote:
 	jr .resume
 
 .greater_than
-	ld hl, wChannel1Flags3 - wChannel1
+	ld hl, wChannel1Flags2 - wChannel1
 	add hl, bc
 	res SOUND_PITCH_SLIDE_DIR, [hl]
 	; get frequency
@@ -830,7 +830,7 @@ HandleTrackVibrato:
 	ld a, [wCurTrackFrequency]
 	ld e, a
 	; toggle vibrato up/down
-	ld hl, wChannel1Flags3 - wChannel1
+	ld hl, wChannel1Flags2 - wChannel1
 	add hl, bc
 	bit SOUND_VIBRATO_DIR, [hl] ; vibrato up/down
 	jr z, .down
@@ -880,7 +880,7 @@ ApplyPitchWheel:
 	ld d, [hl]
 	ld e, a
 	; check whether pitch wheel is going up or down
-	ld hl, wChannel1Flags3 - wChannel1
+	ld hl, wChannel1Flags2 - wChannel1
 	add hl, bc
 	bit SOUND_PITCH_SLIDE_DIR, [hl]
 	jr z, .decreasing
@@ -959,8 +959,6 @@ ApplyPitchWheel:
 	ld hl, wChannel1Flags2 - wChannel1
 	add hl, bc
 	res SOUND_PITCH_SLIDE, [hl]
-	ld hl, wChannel1Flags3 - wChannel1
-	add hl, bc
 	res SOUND_PITCH_SLIDE_DIR, [hl]
 	ret
 
@@ -1516,8 +1514,6 @@ Music_Vibrato:
 	add hl, bc
 	set SOUND_VIBRATO, [hl]
 	; start at lower frequency (extent is positive)
-	ld hl, wChannel1Flags3 - wChannel1
-	add hl, bc
 	res SOUND_VIBRATO_DIR, [hl]
 	; get delay
 	call GetMusicByte
@@ -2440,17 +2436,6 @@ PlayStereoSFX::
 	ld hl, wChannel1Tracks - wChannel1
 	add hl, bc
 	ld [hl], a
-
-	ld a, [wCryTracks]
-	cp 2 ; ch 1-2
-	jr c, .skip
-
-; ch3-4
-	ld hl, wChannel1Flags2 - wChannel1
-	add hl, bc
-	set SOUND_UNKN_0F, [hl]
-
-.skip
 	pop de
 
 ; turn channel on

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -1328,14 +1328,13 @@ Music_EndChannel:
 	add hl, bc
 	res SOUND_SUBROUTINE, [hl]
 	; copy LastMusicAddress to MusicAddress
-	ld hl, wChannel1LastMusicAddress - wChannel1
+	ld hl, wChannel1LastMusicAddress + 1 - wChannel1
 	add hl, bc
-	ld a, [hli]
-	ld d, [hl]
-	ld hl, wChannel1MusicAddress - wChannel1
-	add hl, bc
-	ld [hli], a
-	ld [hl], d
+	ld a, [hld]
+	ld e, [hl]
+	dec hl ; no-optimize b|c|d|e = *hl++|*hl--
+	ld [hld], a
+	ld [hl], e
 	ret
 
 Music_CallChannel:
@@ -1349,10 +1348,7 @@ Music_CallChannel:
 	add hl, bc
 	ld a, [hli]
 	ld d, [hl]
-	ld e, a
-	ld hl, wChannel1LastMusicAddress - wChannel1
-	add hl, bc
-	ld a, e
+	inc hl ; no-optimize b|c|d|e = *hl++|*hl--
 	ld [hli], a
 	ld [hl], d
 	; load pointer into MusicAddress
@@ -1824,11 +1820,9 @@ Music_RestartChannel:
 	add hl, bc
 	ld a, [hli]
 	ld [wMusicIDLo], a
-	ld a, [hl]
+	ld a, [hli]
 	ld [wMusicIDHi], a
 	; update music bank
-	ld hl, wChannel1MusicBank - wChannel1
-	add hl, bc
 	ld a, [hl]
 	ld [wMusicBank], a
 	; get pointer to new channel header
@@ -1861,23 +1855,20 @@ GetMusicByte:
 	push hl
 	push de
 	; load address into de
-	ld hl, wChannel1MusicAddress - wChannel1
+	ld hl, wChannel1MusicAddress + 1 - wChannel1
 	add hl, bc
-	ld a, [hli]
+	ld a, [hld]
+	ld d, a
+	ld a, [hld]
 	ld e, a
-	ld d, [hl]
 	; load bank into a
-	ld hl, wChannel1MusicBank - wChannel1
-	add hl, bc
-	ld a, [hl]
+	ld a, [hli]
 	; get byte
 	call _LoadMusicByte ; load data into wCurMusicByte
 	inc de ; advance to next byte for next time this is called
 	; update channeldata address
-	ld hl, wChannel1MusicAddress - wChannel1
-	add hl, bc
 	ld [hl], e
-	inc hl
+	inc hl ; no-optimize *hl++|*hl-- = b|c|d|e
 	ld [hl], d
 	; cleanup
 	pop de
@@ -1890,14 +1881,13 @@ GetMusicWord:
 ; input: bc = start of current channel
 	push hl
 	; load address into de
-	ld hl, wChannel1MusicAddress - wChannel1
+	ld hl, wChannel1MusicAddress + 1 - wChannel1
 	add hl, bc
-	ld a, [hli]
+	ld a, [hld]
+	ld d, a
+	ld a, [hld]
 	ld e, a
-	ld d, [hl]
 	; load bank into a
-	ld hl, wChannel1MusicBank - wChannel1
-	add hl, bc
 	ld a, [hl]
 	; get byte
 	call _LoadMusicWord ; load data into hl
@@ -2478,10 +2468,8 @@ LoadChannel:
 	ld a, [wMusicIDLo]
 	ld [hli], a
 	ld a, [wMusicIDHi]
-	ld [hl], a
+	ld [hli], a
 	; load music bank
-	ld hl, wChannel1MusicBank - wChannel1
-	add hl, bc
 	ld a, [wMusicBank]
 	ld [hl], a
 	ret

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -142,18 +142,8 @@ _UpdateSound::
 	jr nc, .next
 	; are any sfx channels active?
 	; if so, mute
-	ld hl, wChannel5Flags
-	bit SOUND_CHANNEL_ON, [hl]
-	jr nz, .restnote
-	ld hl, wChannel6Flags
-	bit SOUND_CHANNEL_ON, [hl]
-	jr nz, .restnote
-	ld hl, wChannel7Flags
-	bit SOUND_CHANNEL_ON, [hl]
-	jr nz, .restnote
-	ld hl, wChannel8Flags
-	bit SOUND_CHANNEL_ON, [hl]
-	jr z, .next
+	call CheckSFX
+	jr nc, .next
 .restnote
 	ld hl, wChannel1NoteFlags - wChannel1
 	add hl, bc

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -138,7 +138,7 @@ _UpdateSound::
 	jr z, .next
 	; are we in a sfx channel right now?
 	ld a, [wCurChannel]
-	cp $4
+	cp CHAN5
 	jr nc, .next
 	; are any sfx channels active?
 	; if so, mute
@@ -161,7 +161,7 @@ _UpdateSound::
 .next
 	; are we in a sfx channel right now?
 	ld a, [wCurChannel]
-	cp $4 ; sfx
+	cp CHAN5 ; sfx
 	jr nc, .sfx_channel
 	ld hl, wChannel5Flags - wChannel1
 	add hl, bc
@@ -939,7 +939,7 @@ HandleNoise:
 	ret z
 	; are we in a sfx channel?
 	ld a, [wCurChannel]
-	bit 2, a ; sfx
+	bit NOISE_CHAN_F, a ; sfx
 	jr nz, .next
 	; is ch8 on? (noise)
 	ld hl, wChannel8Flags
@@ -1093,7 +1093,7 @@ ParseMusic:
 	bit SOUND_SUBROUTINE, [hl] ; in a subroutine?
 	jr nz, .readcommand ; execute
 	ld a, [wCurChannel]
-	cp $4 ; channels 0-3?
+	cp CHAN5 ; channels 0-3?
 	jr nc, .chan_5to8
 	; ????
 	ld hl, wChannel5Flags - wChannel1
@@ -1107,7 +1107,7 @@ ParseMusic:
 	call nz, RestoreVolume
 	; end music
 	ld a, [wCurChannel]
-	cp $4 ; channel 5?
+	cp CHAN5 ; channel 5?
 	jr nz, .ok
 	; ????
 	xor a
@@ -1141,7 +1141,7 @@ ParseMusic:
 RestoreVolume:
 	; ch5 only
 	ld a, [wCurChannel]
-	cp $4
+	cp CHAN5
 	ret nz
 	xor a
 	ld hl, wChannel6CryPitch
@@ -1201,7 +1201,7 @@ GetNoiseSample:
 	call SetNoteDuration
 	; check current channel
 	ld a, [wCurChannel]
-	bit 2, a ; are we in a sfx channel?
+	bit NOISE_CHAN_F, a ; are we in a sfx channel?
 	ld a, [wSFXNoiseSampleSet]
 	jr nz, .next
 	; check wChannelSelectorSwitches

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -964,18 +964,17 @@ ReadNoiseSample:
 ;	zz: intensity
 ;       yy: frequency
 
-	; de = [wNoiseSampleAddress]
+	; hl = [wNoiseSampleAddress]
 	ld hl, wNoiseSampleAddress
 	ld a, [hli]
-	ld d, [hl]
-	ld e, a
+	ld h, [hl]
+	ld l, a
 
 	; is it empty?
-	or d
+	or h
 	ret z
 
-	ld a, [de]
-	inc de
+	ld a, [hli]
 
 	cp $ff
 	ret z
@@ -983,17 +982,16 @@ ReadNoiseSample:
 	and $f
 	inc a
 	ld [wNoiseSampleDelay], a
-	ld a, [de]
-	inc de
+	ld a, [hli]
 	ld [wCurTrackIntensity], a
-	ld a, [de]
-	inc de
+	ld a, [hli]
 	ld [wCurTrackFrequency], a
 	xor a
 	ld [wCurTrackFrequency + 1], a
 
+	ld d, h
+	ld a, l
 	ld hl, wNoiseSampleAddress
-	ld a, e
 	ld [hli], a
 	ld [hl], d
 

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -143,7 +143,7 @@ _UpdateSound::
 	; are any sfx channels active?
 	; if so, mute
 	call CheckSFX
-	jr nc, .next
+	jr z, .next
 .restnote
 	ld hl, wChannel1NoteFlags - wChannel1
 	add hl, bc
@@ -420,7 +420,7 @@ PlayDanger:
 	ret z
 	ld d, a
 	call CheckSFX
-	jr c, .increment
+	jr nz, .increment
 	ld a, d
 	and $1f
 	jr z, .begin

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -1518,9 +1518,8 @@ Music_SlidePitchTo:
 	call GetFrequency
 	ld hl, wChannel1PitchWheelTarget - wChannel1
 	add hl, bc
-	ld [hl], e
-	ld hl, wChannel1PitchWheelTarget + 1 - wChannel1
-	add hl, bc
+	ld a, e
+	ld [hli], a
 	ld [hl], d
 	ld hl, wChannel1Flags2 - wChannel1
 	add hl, bc
@@ -1566,13 +1565,9 @@ Music_ToggleSFX:
 ; params: none
 	ld hl, wChannel1Flags - wChannel1
 	add hl, bc
-	bit SOUND_SFX, [hl]
-	jr z, .on
-	res SOUND_SFX, [hl]
-	ret
-
-.on
-	set SOUND_SFX, [hl]
+	ld a, 1 << SOUND_SFX
+	xor [hl]
+	ld [hl], a
 	ret
 
 Music_ToggleNoise:

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -2169,10 +2169,6 @@ _PlayMusic::
 	dec a
 	jr nz, .loop
 	xor a
-	ld [wChannel1JumpCondition], a
-	ld [wChannel2JumpCondition], a
-	ld [wChannel3JumpCondition], a
-	ld [wChannel4JumpCondition], a
 	ld [wNoiseSampleAddressLo], a
 	ld [wNoiseSampleAddressHi], a
 	ld [wNoiseSampleDelay], a
@@ -2450,25 +2446,11 @@ PlayStereoSFX::
 	add hl, bc
 	ld [hl], a
 
-	ld hl, wChannel1Field0x30 - wChannel1 ; $c131 - Channel1
-	add hl, bc
-	ld [hl], a
-
 	ld a, [wCryTracks]
 	cp 2 ; ch 1-2
 	jr c, .skip
 
 ; ch3-4
-	ld a, [wSFXDuration]
-
-	ld hl, wChannel1Field0x2e - wChannel1 ; $c12f - Channel1
-	add hl, bc
-	ld [hl], a
-
-	ld hl, wChannel1Field0x2f - wChannel1 ; $c130 - Channel1
-	add hl, bc
-	ld [hl], a
-
 	ld hl, wChannel1Flags2 - wChannel1
 	add hl, bc
 	set SOUND_UNKN_0F, [hl]

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -1594,10 +1594,10 @@ Music_Tone:
 	ld hl, wChannel1Flags2 - wChannel1
 	add hl, bc
 	set SOUND_PITCH_OFFSET, [hl]
-	ld hl, wChannel1CryPitch + 1 - wChannel1
+	ld hl, wChannel1CryPitch - wChannel1
 	add hl, bc
 	call GetMusicByte
-	ld [hld], a
+	ld [hli], a
 	call GetMusicByte
 	ld [hl], a
 	ret
@@ -1723,9 +1723,9 @@ Music_Tempo:
 ; params: 2
 ;	de: tempo
 	call GetMusicByte
-	ld d, a
-	call GetMusicByte
 	ld e, a
+	call GetMusicByte
+	ld d, a
 	ld a, [wCurChannel]
 	cp CHAN5
 	jmp nc, SetGlobalTempo

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -1891,14 +1891,12 @@ GetMusicByte:
 	; update channeldata address
 	ld hl, wChannel1MusicAddress - wChannel1
 	add hl, bc
-	ld a, e
-	ld [hli], a
+	ld [hl], e
+	inc hl
 	ld [hl], d
 	; cleanup
 	pop de
 	pop hl
-	; store channeldata in a
-	ld a, [wCurMusicByte]
 	ret
 
 GetFrequency:
@@ -2502,16 +2500,6 @@ ChannelInit:
 	add hl, bc
 	ld [hl], a
 	pop de
-	ret
-
-LoadMusicByte::
-; input:
-;   de = current music address
-; output:
-;   a = wCurMusicByte
-	ld a, [wMusicBank]
-	call _LoadMusicByte
-	ld a, [wCurMusicByte]
 	ret
 
 ReloadWaveform::

--- a/audio/music/swsh/gymleaderbattle.asm
+++ b/audio/music/swsh/gymleaderbattle.asm
@@ -500,11 +500,11 @@ Music_GymLeaderBattleSwSh_Ch2_EnterLastPokemonPhase:
 	vibrato 0, 0, 0
 	octave 3
 	stereo_panning TRUE, FALSE
-	;slidepitchto 1, 5, G_
+	;pitch_slide 1, 5, G_
 	rest 16
-	;slidepitchto 1, 4, C_
+	;pitch_slide 1, 4, C_
 	rest 16
-	;slidepitchto 1, 4, F#
+	;pitch_slide 1, 4, F#
 	octave 4
 	rest 16
 	rest 8
@@ -565,11 +565,11 @@ Music_GymLeaderBattleSwSh_Ch1_EnterLastPokemonPhase:
 	vibrato 0, 0, 0
 	octave 2
 	stereo_panning FALSE, TRUE
-	;slidepitchto 1, 5, G_
+	;pitch_slide 1, 5, G_
 	rest 16
-	;slidepitchto 1, 4, C_
+	;pitch_slide 1, 4, C_
 	rest 16
-	;slidepitchto 1, 4, F#
+	;pitch_slide 1, 4, F#
 	octave 3
 	rest 16
 	rest 8

--- a/constants/audio_constants.asm
+++ b/constants/audio_constants.asm
@@ -94,16 +94,10 @@ DEF NOISE_CHAN_F EQU 2 ; bit set in CHAN5-CHAN7
 	const SOUND_VIBRATO      ; 0
 	const SOUND_PITCH_SLIDE  ; 1
 	const SOUND_DUTY_LOOP    ; 2
-	const SOUND_UNKN_0B      ; 3
+	const_skip               ; 3
 	const SOUND_PITCH_OFFSET ; 4
-	const SOUND_UNKN_0D      ; 5
-	const SOUND_UNKN_0E      ; 6
-	const SOUND_UNKN_0F      ; 7
-
-; Flags3
-	const_def
-	const SOUND_VIBRATO_DIR     ; 0
-	const SOUND_PITCH_SLIDE_DIR ; 1
+	const SOUND_VIBRATO_DIR     ; 5
+	const SOUND_PITCH_SLIDE_DIR ; 6
 
 ; NoteFlags
 	const_def

--- a/constants/audio_constants.asm
+++ b/constants/audio_constants.asm
@@ -37,12 +37,10 @@ DEF NUM_CHANNELS EQU const_value
 rsreset
 DEF CHANNEL_MUSIC_ID                    rw
 DEF CHANNEL_MUSIC_BANK                  rb
-DEF CHANNEL_FLAGS1                      rb
-DEF CHANNEL_FLAGS2                      rb
-DEF CHANNEL_FLAGS3                      rb
 DEF CHANNEL_MUSIC_ADDRESS               rw
 DEF CHANNEL_LAST_MUSIC_ADDRESS          rw
-                                        rb_skip 2
+DEF CHANNEL_FLAGS1                      rb
+DEF CHANNEL_FLAGS2                      rb
 DEF CHANNEL_NOTE_FLAGS                  rb
 DEF CHANNEL_CONDITION                   rb
 DEF CHANNEL_DUTY_CYCLE                  rb
@@ -53,29 +51,20 @@ DEF CHANNEL_OCTAVE                      rb
 DEF CHANNEL_TRANSPOSITION               rb
 DEF CHANNEL_NOTE_DURATION               rb
 DEF CHANNEL_FIELD16                     rb
-                                        rb_skip
 DEF CHANNEL_LOOP_COUNT                  rb
 DEF CHANNEL_TEMPO                       rw
 DEF CHANNEL_TRACKS                      rb
 DEF CHANNEL_DUTY_CYCLE_PATTERN          rb
-DEF CHANNEL_VIBRATO_DELAY_COUNT         rb
 DEF CHANNEL_VIBRATO_DELAY               rb
+DEF CHANNEL_VIBRATO_DELAY_COUNT         rb
 DEF CHANNEL_VIBRATO_EXTENT              rb
 DEF CHANNEL_VIBRATO_RATE                rb
 DEF CHANNEL_PITCH_SLIDE_TARGET          rw
 DEF CHANNEL_PITCH_SLIDE_AMOUNT          rb
 DEF CHANNEL_PITCH_SLIDE_AMOUNT_FRACTION rb
 DEF CHANNEL_FIELD25                     rb
-                                        rb_skip
 DEF CHANNEL_PITCH_OFFSET                rw
-DEF CHANNEL_FIELD29                     rb
-DEF CHANNEL_FIELD2A                     rw
-DEF CHANNEL_FIELD2C                     rb
 DEF CHANNEL_NOTE_LENGTH                 rb
-DEF CHANNEL_FIELD2E                     rb
-DEF CHANNEL_FIELD2F                     rb
-DEF CHANNEL_FIELD30                     rb
-                                        rb_skip
 DEF CHANNEL_STRUCT_LENGTH EQU _RS
 
 DEF NOISE_CHAN_F EQU 2 ; bit set in CHAN5-CHAN7

--- a/engine/overworld/player_movement.asm
+++ b/engine/overworld/player_movement.asm
@@ -881,7 +881,7 @@ endc
 	ret nz
 
 	call CheckSFX
-	ret c
+	ret nz
 	ld de, SFX_BUMP
 	jmp PlaySFX
 

--- a/home/audio.asm
+++ b/home/audio.asm
@@ -55,6 +55,19 @@ _LoadMusicByte::
 	ld a, [wCurMusicByte]
 	ret
 
+_LoadMusicWord::
+	rst Bankswitch
+	ld a, [de]
+	ld l, a
+	inc de
+	ld a, [de]
+	ld h, a
+	inc de
+	ld [wCurMusicByte], a
+	ld a, BANK(GetMusicByte)
+	rst Bankswitch
+	ret
+
 CheckSpecialMapMusic:
 ; Returns z if the current map has a special music handler.
 

--- a/home/audio.asm
+++ b/home/audio.asm
@@ -252,18 +252,8 @@ WaitSFX::
 .wait
 	call DelayFrame
 .handleLoop
-	ld hl, wChannel5Flags
-	bit 0, [hl]
-	jr nz, .wait
-	ld hl, wChannel6Flags
-	bit 0, [hl]
-	jr nz, .wait
-	ld hl, wChannel7Flags
-	bit 0, [hl]
-	jr nz, .wait
-	ld hl, wChannel8Flags
-	bit 0, [hl]
-	jr nz, .wait
+	call CheckSFX
+	jr c, .wait
 
 	pop hl
 	ret
@@ -421,21 +411,22 @@ GetPlayerStateMusic:
 
 CheckSFX::
 ; Return carry if any SFX channels are active.
-	ld a, [wChannel5Flags]
-	bit 0, a
-	jr nz, .playing
-	ld a, [wChannel6Flags]
-	bit 0, a
-	jr nz, .playing
-	ld a, [wChannel7Flags]
-	bit 0, a
-	jr nz, .playing
-	ld a, [wChannel8Flags]
-	bit 0, a
-	jr nz, .playing
+	ld hl, wChannel5Flags
+	bit SOUND_CHANNEL_ON, [hl]
+	jr nz, .sfxon
+	ld hl, wChannel6Flags
+	bit SOUND_CHANNEL_ON, [hl]
+	jr nz, .sfxon
+	ld hl, wChannel7Flags
+	bit SOUND_CHANNEL_ON, [hl]
+	jr nz, .sfxon
+	ld hl, wChannel8Flags
+	bit SOUND_CHANNEL_ON, [hl]
+	jr nz, .sfxon
 	and a
 	ret
-.playing
+
+.sfxon
 	scf
 	ret
 

--- a/home/audio.asm
+++ b/home/audio.asm
@@ -432,17 +432,16 @@ GetPlayerStateMusic:
 
 CheckSFX::
 ; Return carry if any SFX channels are active.
+	xor a
 	ld hl, wChannel5Flags
-	bit SOUND_CHANNEL_ON, [hl]
-	jr nz, .sfxon
+	or [hl]
 	ld hl, wChannel6Flags
-	bit SOUND_CHANNEL_ON, [hl]
-	jr nz, .sfxon
+	or [hl]
 	ld hl, wChannel7Flags
-	bit SOUND_CHANNEL_ON, [hl]
-	jr nz, .sfxon
+	or [hl]
 	ld hl, wChannel8Flags
-	bit SOUND_CHANNEL_ON, [hl]
+	or [hl]
+	bit SOUND_CHANNEL_ON, a
 	jr nz, .sfxon
 	and a
 	ret

--- a/home/audio.asm
+++ b/home/audio.asm
@@ -38,13 +38,21 @@ UpdateSound::
 
 	jmp PopAFBCDEHL
 
+LoadMusicByte::
+; input:
+;   de = current music address
+; output:
+;   a = wCurMusicByte
+	ld a, [wMusicBank]
+; fallthrough
 _LoadMusicByte::
 ; wCurMusicByte = [a:de]
 	rst Bankswitch
 	ld a, [de]
 	ld [wCurMusicByte], a
-	ld a, BANK(LoadMusicByte)
+	ld a, BANK(GetMusicByte)
 	rst Bankswitch
+	ld a, [wCurMusicByte]
 	ret
 
 CheckSpecialMapMusic:

--- a/home/audio.asm
+++ b/home/audio.asm
@@ -238,7 +238,7 @@ PlaySFX::
 
 	; Is something already playing?
 	call CheckSFX
-	jr nc, .play
+	jr z, .play
 
 	; Does it have priority?
 	ld a, [wCurSFX]
@@ -274,7 +274,7 @@ WaitSFX::
 	call DelayFrame
 .handleLoop
 	call CheckSFX
-	jr c, .wait
+	jr nz, .wait
 
 	pop hl
 	ret
@@ -431,7 +431,7 @@ GetPlayerStateMusic:
 	ret
 
 CheckSFX::
-; Return carry if any SFX channels are active.
+; Return nz if any SFX channels are active.
 	xor a
 	ld hl, wChannel5Flags
 	or [hl]
@@ -442,12 +442,6 @@ CheckSFX::
 	ld hl, wChannel8Flags
 	or [hl]
 	bit SOUND_CHANNEL_ON, a
-	jr nz, .sfxon
-	and a
-	ret
-
-.sfxon
-	scf
 	ret
 
 TerminateExpBarSound::

--- a/macros/ram.asm
+++ b/macros/ram.asm
@@ -179,7 +179,6 @@ MACRO channel_struct
 \1PitchOffset::       db ; raises existing octaves (to repeat phrases)
 \1NoteDuration::      db ; frames remaining for the current note
 \1Field0x16::         db
-                      ds 1
 \1LoopCount::         db
 \1Tempo::             dw
 \1Tracks::            db ; hi:left lo:right
@@ -192,14 +191,8 @@ MACRO channel_struct
 \1PitchWheelAmount::  db
 \1PitchWheelAmountFraction:: db
 \1Field0x25::         db
-                      ds 1
 \1CryPitch::          dw
-                      ds 4
 \1NoteLength::        db ; frames per 16th note
-\1Field0x2e::         db
-\1Field0x2f::         db
-\1Field0x30::         db
-                      ds 1
 ENDM
 
 MACRO mailmsg

--- a/macros/ram.asm
+++ b/macros/ram.asm
@@ -165,7 +165,6 @@ MACRO channel_struct
 \1Flags2::            db ; 0:vibrato on/off 2:duty 4:cry pitch 5:vibrato up/down
 \1MusicAddress::      dw
 \1LastMusicAddress::  dw
-                      dw
 \1NoteFlags::         db ; 5:rest
 \1Condition::         db ; conditional jumps
 \1DutyCycle::         db ; bits 6-7 (0:12.5% 1:25% 2:50% 3:75%)

--- a/macros/ram.asm
+++ b/macros/ram.asm
@@ -181,8 +181,8 @@ MACRO channel_struct
 \1Tempo::             dw
 \1Tracks::            db ; hi:left lo:right
 \1SFXDutyLoop::       db
-\1VibratoDelayCount:: db ; initialized by \1VibratoDelay
 \1VibratoDelay::      db ; number of frames a note plays until vibrato starts
+\1VibratoDelayCount:: db ; initialized by \1VibratoDelay
 \1VibratoExtent::     db
 \1VibratoRate::       db ; hi:frames for each alt lo:frames to the next alt
 \1PitchWheelTarget::  dw ; frequency endpoint for pitch wheel

--- a/macros/ram.asm
+++ b/macros/ram.asm
@@ -162,8 +162,7 @@ MACRO channel_struct
 \1MusicID::           dw
 \1MusicBank::         db
 \1Flags::             db ; 0:on/off 1:subroutine 3:sfx 4:noise 5:rest
-\1Flags2::            db ; 0:vibrato on/off 2:duty 4:cry pitch
-\1Flags3::            db ; 0:vibrato up/down
+\1Flags2::            db ; 0:vibrato on/off 2:duty 4:cry pitch 5:vibrato up/down
 \1MusicAddress::      dw
 \1LastMusicAddress::  dw
                       dw

--- a/macros/ram.asm
+++ b/macros/ram.asm
@@ -178,7 +178,8 @@ MACRO channel_struct
 \1Octave::            db ; 7-0 (0 is highest)
 \1PitchOffset::       db ; raises existing octaves (to repeat phrases)
 \1NoteDuration::      db ; frames remaining for the current note
-\1Field0x16::         dw
+\1Field0x16::         db
+                      ds 1
 \1LoopCount::         db
 \1Tempo::             dw
 \1Tracks::            db ; hi:left lo:right
@@ -190,15 +191,15 @@ MACRO channel_struct
 \1PitchWheelTarget::  dw ; frequency endpoint for pitch wheel
 \1PitchWheelAmount::  db
 \1PitchWheelAmountFraction:: db
-\1Field0x25::         dw
+\1Field0x25::         db
+                      ds 1
 \1CryPitch::          dw
-\1Field0x29::         db
-\1Field0x2a::         dw
-\1Field0x2c::         db
+                      ds 4
 \1NoteLength::        db ; frames per 16th note
 \1Field0x2e::         db
 \1Field0x2f::         db
-\1Field0x30::         dw
+\1Field0x30::         db
+                      ds 1
 ENDM
 
 MACRO mailmsg

--- a/macros/ram.asm
+++ b/macros/ram.asm
@@ -161,10 +161,10 @@ ENDM
 MACRO channel_struct
 \1MusicID::           dw
 \1MusicBank::         db
-\1Flags::             db ; 0:on/off 1:subroutine 3:sfx 4:noise 5:rest
-\1Flags2::            db ; 0:vibrato on/off 2:duty 4:cry pitch 5:vibrato up/down
 \1MusicAddress::      dw
 \1LastMusicAddress::  dw
+\1Flags::             db ; 0:on/off 1:subroutine 3:sfx 4:noise 5:rest
+\1Flags2::            db ; 0:vibrato on/off 2:duty 4:cry pitch 5:vibrato up/down
 \1NoteFlags::         db ; 5:rest
 \1Condition::         db ; conditional jumps
 \1DutyCycle::         db ; bits 6-7 (0:12.5% 1:25% 2:50% 3:75%)

--- a/macros/scripts/audio.asm
+++ b/macros/scripts/audio.asm
@@ -93,7 +93,7 @@ ENDM
 	const tempo_cmd ; $de
 MACRO tempo
 	db tempo_cmd
-	bigdw \1 ; tempo
+	dw \1 ; tempo
 ENDM
 
 	const volume_envelope_cmd ; $df
@@ -170,13 +170,13 @@ ENDM
 	const pitch_offset_cmd ; $e7
 MACRO pitch_offset
 	db pitch_offset_cmd
-	bigdw \1 ; pitch offset
+	dw \1 ; pitch offset
 ENDM
 
 	const tempo_relative_cmd ; $e8
 MACRO tempo_relative
 	db tempo_relative_cmd
-	bigdw \1 ; tempo adjustment
+	db \1 ; tempo adjustment
 ENDM
 
 	const restart_channel_cmd ; $e9
@@ -188,7 +188,7 @@ ENDM
 	const new_song_cmd ; $ea
 MACRO new_song
 	db new_song_cmd
-	bigdw \1 ; id
+	dw \1 ; id
 ENDM
 
 	const sfx_priority_on_cmd ; $eb

--- a/ram/wram0.asm
+++ b/ram/wram0.asm
@@ -62,7 +62,6 @@ wNoiseSampleAddress::
 wNoiseSampleAddressLo:: db
 wNoiseSampleAddressHi:: db
 wNoiseSampleDelay:: db ; noise delay?
-	ds 1
 wMusicNoiseSampleSet:: db
 wSFXNoiseSampleSet:: db
 wLowHealthAlarm::
@@ -80,17 +79,10 @@ wMusicFadeCount:: db
 wMusicFadeID::
 wMusicFadeIDLo:: db
 wMusicFadeIDHi:: db
-	ds 5
 wCryPitch:: dw
 wCryLength:: dw
 wLastVolume:: db
-	ds 1
 wSFXPriority:: db ; if nonzero, turn off music when playing sfx
-	ds 1
-wChannel1JumpCondition:: db
-wChannel2JumpCondition:: db
-wChannel3JumpCondition:: db
-wChannel4JumpCondition:: db
 wStereoPanningMask:: db
 wCryTracks::
 ; plays only in left or right track depending on what side the monster is on


### PR DESCRIPTION
Removes dead code, unused variables, and elides many hl loads

Commands like new_song and restart_channel are currently unused and were not tested as a result. it may make sense to remove them

238 fewer rom bytes and 116 less wram0