### PR TITLE
Move music player ram to Misc 480

### DIFF
--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -92,7 +92,7 @@ _UpdateSound::
 	ld hl, wChannel1Flags - wChannel1
 	add hl, bc
 	bit SOUND_CHANNEL_ON, [hl]
-	jmp z, .nextchannel
+	jr z, .nextchannel
 	; check time left in the current note
 	ld hl, wChannel1NoteDuration - wChannel1
 	add hl, bc

--- a/audio/music_player.asm
+++ b/audio/music_player.asm
@@ -172,7 +172,6 @@ RenderMusicPlayer:
 	ldh [hOAMUpdate], a ; we will manually do it in LCD interrupt
 
 	ld hl, wChannelSelectorSwitches
-	ld a, NUM_MUSIC_CHANS - 1
 .ch_label_loop:
 	ld [wChannelSelector], a
 	ld a, [hli]
@@ -180,8 +179,8 @@ RenderMusicPlayer:
 	call DrawChannelLabel
 	pop hl
 	ld a, [wChannelSelector]
-	dec a
-	cp -1
+	inc a
+	cp NUM_MUSIC_CHANS
 	jr nz, .ch_label_loop
 
 	call DelayFrame

--- a/home/lcd.asm
+++ b/home/lcd.asm
@@ -37,13 +37,6 @@ LCDMusicPlayer::
 
 	ldh a, [hMPState]
 	inc a
-	add l
-	jr nc, .ok
-	sub SCREEN_HEIGHT_PX
-.ok
-
-	ldh a, [hMPState]
-	inc a
 	assert PIANO_ROLL_HEIGHT_PX + 1 < $80
 	add l
 	add a
@@ -58,7 +51,7 @@ LCDMusicPlayer::
 	ld [oamSprite00XCoord], a
 	ld a, [hli]
 	ld [oamSprite01XCoord], a
-	ld a, [hli]
+	ld a, [hl]
 	ld [oamSprite02XCoord], a
 	pop hl
 

--- a/layout.link
+++ b/layout.link
@@ -224,7 +224,6 @@ WRAM0
 	"WRAM 0"
 	org $c308
 	"Sprite Animations"
-	"Music Player RAM"
 	org $c400
 	align 8
 	"Sprites"

--- a/ram/wram0.asm
+++ b/ram/wram0.asm
@@ -96,6 +96,13 @@ wMapMusic:: db
 wDontPlayMapMusicOnReload:: db
 wMusicEnd::
 
+; Music player
+; audio engine input
+wChannelSelectorSwitches:: ds 4
+wPitchTransposition:: db
+wTempoAdjustment:: db
+; audio engine output
+wNoiseHit:: db
 
 SECTION "WRAM 0", WRAM0
 
@@ -230,7 +237,7 @@ wGlobalAnimXOffset:: db
 wSpriteAnimsEnd::
 
 
-SECTION "Music Player RAM", WRAM0
+SECTION UNION "Misc 480", WRAM0
 
 wMusicPlayerWRAM::
 wSongSelection:: dw
@@ -258,12 +265,6 @@ wSelectorCur:: db
 ; song editor
 wChannelSelector:: db
 wAdjustingTempo:: db
-; audio engine input
-wChannelSelectorSwitches:: ds 4
-wPitchTransposition:: db
-wTempoAdjustment:: db
-; audio engine output
-wNoiseHit:: db
 wMusicPlayerWRAMEnd::
 
 


### PR DESCRIPTION
Memory used by the audio engine moved into its section

As a side effect, settings are preserved when re-entering the
music player

+2 trivial patches