### PR TITLE
Wram housekeeping

### DIFF
--- a/engine/games/unown_puzzle.asm
+++ b/engine/games/unown_puzzle.asm
@@ -13,8 +13,8 @@ UnownPuzzle:
 	xor a
 	ldh [hBGMapMode], a
 	call DisableLCD
-	ld hl, wMisc
-	ld bc, wMiscEnd - wMisc
+	ld hl, wUnownPuzzle
+	ld bc, wUnownPuzzleEnd - wUnownPuzzle
 	xor a
 	rst ByteFill
 	ld hl, UnownPuzzleCursorGFX

--- a/home/sprite_anims.asm
+++ b/home/sprite_anims.asm
@@ -5,15 +5,10 @@ ReinitSpriteAnimFrame::
 	farjp _ReinitSpriteAnimFrame
 
 ClearSpriteAnims::
+	xor a
 	ld hl, wSpriteAnimDict
 	ld bc, wSpriteAnimsEnd - wSpriteAnimDict
-.loop
-	xor a
-	ld [hli], a
-	dec bc
-	ld a, c
-	or b
-	jr nz, .loop
+	rst ByteFill
 	ret
 
 ClearSpriteAnims2::

--- a/home/video.asm
+++ b/home/video.asm
@@ -70,6 +70,11 @@ UpdateBGMapBuffer::
 	ld bc, wBGMapPalBuffer
 	ld de, wBGMapBuffer
 
+; We increment the low byte of a pointer, so ensure these buffers
+; dont cross a 256 byte boundary
+assert HIGH(wBGMapBuffer) == HIGH(wBGMapBuffer + 47)
+assert HIGH(wBGMapPalBuffer) == HIGH(wBGMapPalBuffer + 47)
+
 .next
 ; Copy a pair of 16x8 blocks (one 16x16 block)
 

--- a/home/video.asm
+++ b/home/video.asm
@@ -72,8 +72,8 @@ UpdateBGMapBuffer::
 
 ; We increment the low byte of a pointer, so ensure these buffers
 ; dont cross a 256 byte boundary
-assert HIGH(wBGMapBuffer) == HIGH(wBGMapBuffer + 47)
-assert HIGH(wBGMapPalBuffer) == HIGH(wBGMapPalBuffer + 47)
+assert HIGH(wBGMapBuffer) == HIGH(wBGMapBufferEnd)
+assert HIGH(wBGMapPalBuffer) == HIGH(wBGMapPalBufferEnd)
 
 .next
 ; Copy a pair of 16x8 blocks (one 16x16 block)

--- a/layout.link
+++ b/layout.link
@@ -220,22 +220,10 @@ WRAM0
 	org $c000
 	"Stack"
 	align 8
-	"Audio RAM"
-	"WRAM 0"
-	org $c308
-	"Sprite Animations"
-	org $c400
-	align 8
 	"Sprites"
-	org $c4a0
 	"Tilemap and Attrmap"
-	org $c770
 	"Misc 480"
-	org $c950
 	"Misc 1326"
-	org $ce7e
-	"Video"
-	"More WRAM 0"
 	org $cff0
 	"Options"
 

--- a/ram/wram0.asm
+++ b/ram/wram0.asm
@@ -1045,6 +1045,9 @@ wBGMapBuffer:: ds 48
 wBGMapPalBuffer:: ds 48
 wBGMapBufferPtrs:: ds 48 ; 24 bg map addresses (16x8 tiles)
 
+wTileAnimBuffer:: ds 1 tiles
+wTileAnimationTimer:: db
+
 
 SECTION "More WRAM 0", WRAM0
 
@@ -1061,8 +1064,6 @@ wHPPals:: ds PARTY_LENGTH
 wCurHPPal:: db
 wHPPalIndex:: db
 ENDU
-
-wTileAnimBuffer:: ds 1 tiles
 
 ; link data
 UNION
@@ -1306,8 +1307,6 @@ wFXAnimIDHi:: db
 
 wPlaceBallsX:: db
 wPlaceBallsY:: db
-
-wTileAnimationTimer:: db
 
 ; palette backups?
 wBGP:: db

--- a/ram/wram0.asm
+++ b/ram/wram0.asm
@@ -1042,7 +1042,9 @@ wLinkReceivedMailEnd:: db
 SECTION "Video", WRAM0
 
 wBGMapBuffer:: ds 48
+wBGMapBufferEnd::
 wBGMapPalBuffer:: ds 48
+wBGMapPalBufferEnd::
 wBGMapBufferPtrs:: ds 48 ; 24 bg map addresses (16x8 tiles)
 
 wTileAnimBuffer:: ds 1 tiles

--- a/ram/wram0.asm
+++ b/ram/wram0.asm
@@ -10,8 +10,6 @@ wStackTop::
 
 SECTION "Audio RAM", WRAM0
 
-wEchoRAMTest:: db
-
 wMusic::
 wMusicPlaying:: db ; nonzero if playing
 
@@ -1164,6 +1162,7 @@ wNamingScreenLetterCase::
 wHallOfFameMonCounter::
 wTradeDialog::
 wRandomValue::
+wEchoRAMTest::
 	db
 wFrameCounter2:: db
 wUnusedTradeAnimPlayEvolutionMusic:: db

--- a/ram/wram0.asm
+++ b/ram/wram0.asm
@@ -196,8 +196,6 @@ wLinkOtherPlayerGender:: db
 
 wPalFlags:: db
 
-	ds 4
-
 
 SECTION "Sprite Animations", WRAM0
 
@@ -1052,8 +1050,6 @@ wBGMapBufferPtrs:: ds 48 ; 24 bg map addresses (16x8 tiles)
 
 SECTION "More WRAM 0", WRAM0
 
-	ds 82 ; unused
-
 wMemCGBLayout:: db
 
 UNION
@@ -1276,8 +1272,6 @@ w2DMenuDataEnd::
 
 wMonPicSize:: db
 wMonAnimationSize:: db
-
-	ds 1 ; unused
 
 wPendingOverworldGraphics:: db
 wTextDelayFrames:: db


### PR DESCRIPTION
Mostly removes unused constraints in layout.link

Misc 480/1326 are both 4 bit aligned, nothing seems to depend on that fact anymore (wMisc likely used to) but it cost nothing to preserve that

The only alignment sensitive code i found dealt with wBGMapBuffer, for which asserts are provided