### PR TITLE
Audio engine fixes

### DIFF
--- a/audio/cries.asm
+++ b/audio/cries.asm
@@ -1480,7 +1480,7 @@ Cry_Seel_Ch8:
 	sound_ret
 
 Cry_Slowpoke_Ch5:
-	duty_cycle_pattern 0, 0, 0, 0
+	duty_cycle 0
 	square_note 8, 15, 5, 1152
 	square_note 2, 14, 1, 1504
 	square_note 8, 13, 1, 1500

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -267,9 +267,6 @@ UpdateChannels:
 	ret
 
 .ch1_rest
-	ldh a, [rNR52]
-	and %10001110 ; ch1 off
-	ldh [rNR52], a
 	ld hl, rNR10
 	jmp ClearChannel
 
@@ -319,9 +316,6 @@ UpdateChannels:
 	ret
 
 .ch2_rest
-	ldh a, [rNR52]
-	and %10001101 ; ch2 off
-	ldh [rNR52], a
 	ld hl, rNR20
 	jmp ClearChannel
 
@@ -355,9 +349,6 @@ UpdateChannels:
 	ret
 
 .ch3_rest
-	ldh a, [rNR52]
-	and %10001011 ; ch3 off
-	ldh [rNR52], a
 	ld hl, rNR30
 	jmp ClearChannel
 
@@ -395,9 +386,6 @@ UpdateChannels:
 	ret
 
 .ch4_rest
-	ldh a, [rNR52]
-	and %10000111 ; ch4 off
-	ldh [rNR52], a
 	ld hl, rNR40
 	jmp ClearChannel
 

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -995,7 +995,8 @@ ParseMusic:
 	ld a, [wChannelSelectorSwitches+3]
 	and a
 	jr nz, .notnoise
-	ld a, 1
+	ld a, [wCurMusicByte]
+	and $f0
 	ld [wNoiseHit], a
 .notnoise
 ; wCurMusicByte contains current note

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -115,6 +115,7 @@ _UpdateSound::
 	ld hl, wChannel1DutyCycle - wChannel1
 	add hl, bc
 	ld a, [hli]
+	and $c0
 	ld [wCurTrackDuty], a
 	; intensity
 	ld a, [hli]
@@ -694,7 +695,7 @@ HandleTrackVibrato:
 	add hl, bc
 	bit SOUND_DUTY_LOOP, [hl] ; duty
 	jr z, .next
-	ld hl, wChannel1SFXDutyLoop - wChannel1
+	ld hl, wChannel1DutyCycle - wChannel1
 	add hl, bc
 	ld a, [hl]
 	rlca
@@ -1527,11 +1528,6 @@ Music_SoundDuty:
 	call GetMusicByte
 	rrca
 	rrca
-	ld hl, wChannel1SFXDutyLoop - wChannel1
-	add hl, bc
-	ld [hl], a
-	; update duty cycle
-	and $c0 ; only uses top 2 bits
 	ld hl, wChannel1DutyCycle - wChannel1
 	add hl, bc
 	ld [hl], a
@@ -1618,6 +1614,9 @@ Music_DutyCycle1:
 Music_DutyCycle2:
 Music_DutyCycle3:
 ; duty cycle
+	ld hl, wChannel1Flags2 - wChannel1
+	add hl, bc
+	res SOUND_DUTY_LOOP, [hl]
 	ld a, [wCurMusicByte]
 	rrca
 	rrca

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -39,14 +39,9 @@ _InitSound::
 	jr nz, .clearsound
 
 	ld hl, wChannels ; start of channel data
-	ld de, wChannelsEnd - wChannels ; length of area to clear (entire sound wram area)
-.clearchannels ; clear wChannel1-$c2bf
+	ld bc, wChannelsEnd - wChannels ; length of area to clear (entire sound wram area)
 	xor a
-	ld [hli], a
-	dec de
-	ld a, e
-	or d
-	jr nz, .clearchannels
+	rst ByteFill
 
 	ld a, MAX_VOLUME
 	ld [wVolume], a
@@ -1018,7 +1013,6 @@ ParseMusic:
 	ld a, [wCurMusicByte]
 	and $f
 	call SetNoteDuration
-	; get note pitch (top nybble)
 
 	ld a, [wCurChannel]
 	cp CHAN5
@@ -1034,6 +1028,7 @@ ParseMusic:
 	jr .rest
 
 .notMuted
+	; get note pitch (top nybble)
 	ld a, [wCurMusicByte]
 	swap a
 	and $f
@@ -2385,9 +2380,6 @@ LoadChannel:
 	ld a, [hli]
 	ld c, a
 	ld b, [hl] ; bc = channel pointer
-	ld hl, wChannel1Flags - wChannel1
-	add hl, bc
-	res SOUND_CHANNEL_ON, [hl] ; channel off
 	call ChannelInit
 	; load music pointer
 	ld hl, wChannel1MusicAddress - wChannel1

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -2436,8 +2436,7 @@ ChannelInit:
 	pop de
 	ret
 
-ReloadWaveform::
-	; called from the music player
+ReloadWaveform:
 	ld a, [wCurTrackIntensity]
 	and $f ; only NUM_WAVEFORMS are valid
 	; each wavepattern is $f bytes long, so seeking is done in $10s

--- a/audio/engine.asm
+++ b/audio/engine.asm
@@ -1198,7 +1198,7 @@ GetNoiseSample:
 	swap a
 	; non-rest note?
 	and $f
-	ret z
+	jr z, .rest
 	; use 'pitch' to seek noise sample set
 	ld e, a
 	ld d, 0
@@ -1213,6 +1213,12 @@ GetNoiseSample:
 	; clear ????
 	xor a
 	ld [wNoiseSampleDelay], a
+	ret
+
+.rest
+	ld hl, wChannel1NoteFlags - wChannel1
+	add hl, bc
+	set NOTE_REST, [hl]
 	ret
 
 MusicCommands:

--- a/audio/music/b2w2/marinetube.asm
+++ b/audio/music/b2w2/marinetube.asm
@@ -12,7 +12,7 @@ Music_MarineTubeB2W2:
 
 Music_MarineTubeB2W2_Ch1:
 	tempo 132
-	duty_cycle_pattern 3, 3, 3, 3
+	duty_cycle 3
 	vibrato 18, 1, 5
 	pitch_offset 1
 	note_type 12, 6, 1
@@ -217,7 +217,7 @@ Music_MarineTubeB2W2_Ch1:
 	octave 3
 	note F#, 8
 	note F_, 8
-	duty_cycle_pattern 2, 2, 2, 2
+	duty_cycle 2
 	volume_envelope 6, 0
 	note D_, 8
 	note C_, 8
@@ -255,7 +255,7 @@ Music_MarineTubeB2W2_Ch1:
 	note D#, 6
 	note F_, 8
 	note F_, 6
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	volume_envelope 8, 4
 	octave 1
 	note G_, 2
@@ -470,7 +470,7 @@ Music_MarineTubeB2W2_Ch2:
 	vibrato 8, 2, 6
 	pitch_offset 1
 	note_type 12, 10, 0
-	duty_cycle_pattern 2, 2, 2, 2
+	duty_cycle 2
 	octave 5
 	note F_, 8
 	volume_envelope 10, 7
@@ -550,7 +550,7 @@ Music_MarineTubeB2W2_Ch2:
 	note A#, 4
 	volume_envelope 10, 7
 	note A#, 12
-	duty_cycle_pattern 0, 0, 0, 0
+	duty_cycle 0
 	note C_, 4
 	octave 4
 	volume_envelope 10, 0
@@ -633,7 +633,7 @@ Music_MarineTubeB2W2_Ch2:
 	note G_, 16
 	rest 16
 	rest 12
-	duty_cycle_pattern 0, 0, 0, 0
+	duty_cycle 0
 	volume_envelope 2, 0
 	octave 1
 	note A#, 2

--- a/audio/music/go/gymbattle.asm
+++ b/audio/music/go/gymbattle.asm
@@ -344,7 +344,7 @@ Music_GymLeaderBattleGo_Ch1_ditty7:
 	sound_ret
 
 Music_GymLeaderBattleGo_Ch2:
-	duty_cycle_pattern 3, 3, 3, 3
+	duty_cycle 3
 	vibrato 7, 9, 5
 	octave 3
 	note_type 12, 10, 5
@@ -356,7 +356,7 @@ Music_GymLeaderBattleGo_Ch2_loop_1:
 	note D#, 2
 	sound_loop 4, Music_GymLeaderBattleGo_Ch2_loop_1
 Music_GymLeaderBattleGo_Ch2_loop:
-	duty_cycle_pattern 0, 0, 0, 0
+	duty_cycle 0
 	volume_envelope 12, 5
 	vibrato 0, 3, 3
 Music_GymLeaderBattleGo_Ch2_loop_2:
@@ -369,7 +369,7 @@ Music_GymLeaderBattleGo_Ch2_loop_2:
 	note F_, 2
 	note E_, 2
 	sound_loop 2, Music_GymLeaderBattleGo_Ch2_loop_2
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	volume_envelope 10, 8
 	vibrato 9, 3, 3
 	octave 4
@@ -429,7 +429,7 @@ Music_GymLeaderBattleGo_Ch2_loop_2:
 	note G_, 1
 	note F_, 1
 	note E_, 6
-	duty_cycle_pattern 0, 0, 0, 0
+	duty_cycle 0
 	volume_envelope 12, 1
 	octave 3
 	sound_call Music_GymLeaderBattleGo_Ch1_ditty8
@@ -437,7 +437,7 @@ Music_GymLeaderBattleGo_Ch2_loop_2:
 	sound_call Music_GymLeaderBattleGo_Ch1_ditty8
 	octave 5
 	note C_, 1
-	duty_cycle_pattern 3, 3, 3, 3
+	duty_cycle 3
 	volume_envelope 12, 8
 	vibrato 15, 5, 3
 	octave 4
@@ -453,7 +453,7 @@ Music_GymLeaderBattleGo_Ch2_loop_2:
 	volume_envelope 12, 8
 	octave 4
 	note C_, 1
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	octave 3
 	sound_call Music_GymLeaderBattleGo_Ch2_ditty3
 	octave 4
@@ -527,7 +527,7 @@ Music_GymLeaderBattleGo_Ch2_loop_2:
 	octave 4
 	note G_, 4
 	rest 4
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	octave 3
 	note E_, 4
 	note D_, 4
@@ -548,7 +548,7 @@ Music_GymLeaderBattleGo_Ch2_loop_3:
 	sound_loop 3, Music_GymLeaderBattleGo_Ch2_loop_3
 	note D_, 4
 	rest 12
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	sound_call Music_GymLeaderBattleGo_Ch2_ditty4
 	note G_, 12
 	octave 4
@@ -623,7 +623,7 @@ Music_GymLeaderBattleGo_Ch2_loop_3:
 	note B_, 1
 	duty_cycle_pattern 1, 1, 2, 2
 	sound_call Music_GymLeaderBattleGo_Ch1_ditty9
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	note C_, 8
 	note C#, 8
 	octave 2

--- a/audio/music/go/wildbattle.asm
+++ b/audio/music/go/wildbattle.asm
@@ -48,7 +48,7 @@ Music_WildBattleGo_Ch1_loop:
 	rest 3
 	note C#, 4
 	rest 2
-	duty_cycle_pattern 2, 2, 2, 2
+	duty_cycle 2
 	sound_call Music_WildBattleGo_Ch1_ditty1
 	sound_call Music_WildBattleGo_Ch1_ditty2
 	sound_call Music_WildBattleGo_Ch1_ditty1
@@ -71,7 +71,7 @@ Music_WildBattleGo_Ch1_loop:
 	sound_call Music_WildBattleGo_Ch1_ditty1
 	sound_call Music_WildBattleGo_Ch1_ditty1
 	rest 4
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	volume_envelope 15, 3
 	vibrato 5, 1, 3
 	octave 2
@@ -165,7 +165,7 @@ Music_WildBattleGo_Ch2_loop:
 	rest 3
 	note C#, 4
 	rest 2
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	volume_envelope 10, 8
 	vibrato 8, 1, 3
 	octave 4

--- a/audio/music/hgss/ceruleancity.asm
+++ b/audio/music/hgss/ceruleancity.asm
@@ -304,11 +304,9 @@ Music_CeruleanCityHGSS_Loop2:
 	note E_, 1
 	rest 3
 	duty_cycle_pattern 0, 0, 2, 2
-	duty_cycle 0
 	octave 4
 	note G#, 4
 	note E_, 4
-	duty_cycle 1
 	duty_cycle 1
 	octave 3
 	note D#, 1
@@ -318,11 +316,9 @@ Music_CeruleanCityHGSS_Loop2:
 	note F#, 1
 	rest 3
 	duty_cycle_pattern 0, 0, 2, 2
-	duty_cycle 0
 	octave 4
 	note B_, 4
 	note F#, 4
-	duty_cycle 1
 	duty_cycle 1
 	octave 3
 	note C#, 1
@@ -356,7 +352,6 @@ Music_CeruleanCityHGSS_Loop2:
 	note B_, 8
 	duty_cycle_pattern 0, 0, 2, 2
 	volume_envelope 12, 6
-	duty_cycle 2
 	octave 4
 	note E_, 8
 	octave 3

--- a/audio/music/hgss/ceruleancity.asm
+++ b/audio/music/hgss/ceruleancity.asm
@@ -308,7 +308,7 @@ Music_CeruleanCityHGSS_Loop2:
 	octave 4
 	note G#, 4
 	note E_, 4
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	duty_cycle 1
 	octave 3
 	note D#, 1
@@ -322,7 +322,7 @@ Music_CeruleanCityHGSS_Loop2:
 	octave 4
 	note B_, 4
 	note F#, 4
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	duty_cycle 1
 	octave 3
 	note C#, 1
@@ -372,7 +372,7 @@ Music_CeruleanCityHGSS_Loop2:
 	note D#, 4
 	note C#, 4
 	note D#, 4
-	duty_cycle_pattern 2, 2, 2, 2
+	duty_cycle 2
 	note_type 2, 12, 2
 	rest 2
 	note_type 12, 12, 2

--- a/audio/music/stadium/mewtwobattle.asm
+++ b/audio/music/stadium/mewtwobattle.asm
@@ -15,7 +15,7 @@ Music_MewtwoBattleStadium_Ch1:
 	stereo_panning TRUE, TRUE
 	note_type 12, 0, 0
 	rest 16
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	vibrato 5, 2, 1
 	octave 4
 	note_type 10, 15, 2
@@ -158,7 +158,7 @@ Music_MewtwoBattleStadium_Ch1_loop_1:
 	sound_call Music_MewtwoBattleStadium_Ch1_ditty1
 	sound_loop 31, Music_MewtwoBattleStadium_Ch1_loop_1
 Music_MewtwoBattleStadium_Ch1_loop:
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	vibrato 0, 1, 3
 	octave 3
 	note_type 15, 12, 7
@@ -237,7 +237,7 @@ Music_MewtwoBattleStadium_Ch1_loop:
 	note G_, 1
 	note A_, 15
 	rest 1
-	duty_cycle_pattern 0, 0, 0, 0
+	duty_cycle 0
 	vibrato 0, 0, 0
 	note A_, 7
 	rest 1
@@ -259,7 +259,7 @@ Music_MewtwoBattleStadium_Ch1_loop:
 	rest 16
 	rest 16
 	rest 16
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	volume_envelope 13, 2
 	octave 4
 	note G_, 2
@@ -306,7 +306,7 @@ Music_MewtwoBattleStadium_Ch1_loop:
 	rest 6
 	note C_, 2
 	rest 15
-	duty_cycle_pattern 2, 2, 2, 2
+	duty_cycle 2
 	volume_envelope 15, 1
 	octave 3
 	note C_, 1
@@ -631,7 +631,7 @@ Music_MewtwoBattleStadium_Ch1_loop:
 	note C_, 1
 	octave 3
 	note A#, 1
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	note_type 8, 15, 1
 	note A#, 1
 	octave 4
@@ -721,7 +721,7 @@ Music_MewtwoBattleStadium_Ch1_loop_2:
 	note A_, 2
 	sound_loop 2, Music_MewtwoBattleStadium_Ch1_loop_2
 	rest 16
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	volume_envelope 12, 7
 	note A_, 14
 	note_type 12, 12, 7
@@ -742,7 +742,7 @@ Music_MewtwoBattleStadium_Ch1_loop_2:
 	octave 4
 	note D_, 1
 	rest 8
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	volume_envelope 12, 7
 	note C_, 7
 	rest 9
@@ -760,7 +760,7 @@ Music_MewtwoBattleStadium_Ch1_loop_2:
 	note B_, 1
 	note A_, 1
 	rest 8
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	volume_envelope 12, 7
 	note A_, 7
 	rest 1
@@ -788,7 +788,7 @@ Music_MewtwoBattleStadium_Ch1_ditty1:
 	sound_ret
 
 Music_MewtwoBattleStadium_Ch2:
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	octave 3
 	note_type 6, 12, 1
 	note B_, 1
@@ -876,7 +876,7 @@ Music_MewtwoBattleStadium_Ch2_loop_1:
 	note E_, 15
 	rest 1
 Music_MewtwoBattleStadium_Ch2_loop:
-	duty_cycle_pattern 2, 2, 2, 2
+	duty_cycle 2
 	vibrato 2, 2, 4
 	octave 3
 	note_type 15, 12, 5
@@ -952,7 +952,7 @@ Music_MewtwoBattleStadium_Ch2_loop:
 	note G_, 1
 	note E_, 8
 	rest 8
-	duty_cycle_pattern 0, 0, 0, 0
+	duty_cycle 0
 	vibrato 0, 0, 0
 	note B_, 15
 	rest 1
@@ -980,7 +980,7 @@ Music_MewtwoBattleStadium_Ch2_loop:
 	note_type 1, 12, 5
 	rest 3
 	note_type 9, 12, 5
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	octave 3
 	note_type 12, 13, 2
 	note G_, 1

--- a/audio/music/undertale/megalovania.asm
+++ b/audio/music/undertale/megalovania.asm
@@ -18,7 +18,7 @@ Music_Megalovania_Ch1_loop:
 	rest 16
 	rest 16
 	rest 16
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	volume_envelope 15, 3
 Music_Megalovania_Ch1_loop_1:
 	octave 4
@@ -37,7 +37,7 @@ Music_Megalovania_Ch1_loop_1:
 	note A#, 1
 	sound_call Music_Megalovania_Ch1_ditty_2
 	sound_loop 2, Music_Megalovania_Ch1_loop_1
-	duty_cycle_pattern 0, 0, 0, 0
+	duty_cycle 0
 	volume_envelope 9, 1
 	sound_call Music_Megalovania_Ch1Ch3_ditty_2
 	octave 3
@@ -117,7 +117,7 @@ Music_Megalovania_Ch1_loop_1:
 	note F_, 1
 	note D_, 1
 	sound_call Music_Megalovania_Ch1Ch2_ditty_1
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	volume_envelope 10, 3
 	octave 2
 	note A_, 4
@@ -225,7 +225,7 @@ Music_Megalovania_Ch1_loop_1:
 	note C#, 1
 	note_type 12, 10, 6
 	note D_, 8
-	duty_cycle_pattern 0, 0, 0, 0
+	duty_cycle 0
 	vibrato 0, 1, 3
 	sound_call Music_Megalovania_Ch1_ditty_5
 	volume_envelope 3, -7
@@ -236,7 +236,7 @@ Music_Megalovania_Ch1_loop_1:
 	note F_, 12
 	rest 4
 	sound_call Music_Megalovania_Ch1_ditty_5
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	volume_envelope 10, 1
 	vibrato 15, 1, 3
 	octave 3
@@ -576,7 +576,7 @@ Music_Megalovania_Ch1_ditty_7:
 	sound_ret
 
 Music_Megalovania_Ch1Ch2_ditty_1:
-	duty_cycle_pattern 0, 0, 0, 0
+	duty_cycle 0
 	volume_envelope 15, 1
 	octave 4
 	note F_, 1
@@ -782,7 +782,7 @@ Music_Megalovania_Ch2_loop:
 	note F_, 2
 	note D_, 1
 	note F_, 1
-	duty_cycle_pattern 2, 2, 2, 2
+	duty_cycle 2
 	vibrato 5, 1, 3
 	octave 4
 	note_type 6, 13, 3
@@ -937,7 +937,7 @@ Music_Megalovania_Ch2_loop:
 	note_type 3, 10, 1
 	note F_, 1
 	note A_, 1
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	vibrato 15, 1, 15
 	octave 4
 	note_type 9, 10, 7
@@ -952,7 +952,7 @@ Music_Megalovania_Ch2_loop:
 	note_type 3, 10, 1
 	note F_, 1
 	note A_, 1
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	vibrato 15, 1, 15
 	octave 4
 	note_type 9, 10, 7
@@ -972,7 +972,7 @@ Music_Megalovania_Ch2_loop:
 	rest 16
 	rest 1
 	note_type 12, 6, -1
-	duty_cycle_pattern 0, 0, 0, 0
+	duty_cycle 0
 	vibrato 0, 2, 2
 	octave 2
 	note D_, 1
@@ -1066,7 +1066,7 @@ Music_Megalovania_Ch2_ditty3:
 	note_type 3, 10, 1
 	note D_, 1
 	note F_, 1
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	note_type 9, 10, 7
 	vibrato 15, 1, 15
 	note A#, 16
@@ -1078,7 +1078,7 @@ Music_Megalovania_Ch2_ditty3:
 	note C_, 2
 	note E_, 1
 	note G_, 1
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	vibrato 15, 1, 15
 	octave 4
 	note_type 15, 10, 7
@@ -1091,7 +1091,7 @@ Music_Megalovania_Ch2_ditty3:
 	note_type 3, 10, 1
 	note F_, 1
 	note A_, 2
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	note_type 9, 10, 7
 	vibrato 15, 1, 15
 	octave 4
@@ -1105,7 +1105,7 @@ Music_Megalovania_Ch2_ditty3:
 	note D_, 4
 	note F_, 1
 	note A_, 1
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	vibrato 15, 1, 15
 	octave 4
 	note_type 13, 10, 7
@@ -1121,7 +1121,7 @@ Music_Megalovania_Ch2_ditty3:
 	note_type 3, 10, 1
 	note D_, 1
 	note F_, 1
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	note_type 9, 10, 7
 	vibrato 15, 1, 15
 	note A#, 16
@@ -1133,7 +1133,7 @@ Music_Megalovania_Ch2_ditty3:
 	note C_, 2
 	note E_, 1
 	note G_, 1
-	duty_cycle_pattern 1, 1, 1, 1
+	duty_cycle 1
 	vibrato 15, 1, 15
 	octave 4
 	note_type 15, 10, 7

--- a/audio/music_player.asm
+++ b/audio/music_player.asm
@@ -500,8 +500,7 @@ endr
 	and $f0
 	or b
 	ld [wChannel3Intensity], a
-	ld [wCurTrackIntensity], a
-	farjp ReloadWaveform
+	ret
 
 .up_noise:
 ; next noise set

--- a/audio/music_player.asm
+++ b/audio/music_player.asm
@@ -474,6 +474,8 @@ endr
 .change_ch1_2:
 	ld [hl], a
 	ld [wCurTrackDuty], a
+	call GetFlags2Addr
+	res SOUND_DUTY_LOOP, [hl]
 	ret
 
 .up_wave:
@@ -1370,6 +1372,10 @@ GetPitchAddr:
 
 GetOctaveAddr:
 	ld hl, wChannel1Octave
+	jr _GetChannelMemberAddr
+
+GetFlags2Addr:
+	ld hl, wChannel1Flags2
 	jr _GetChannelMemberAddr
 
 GetDutyCycleAddr:

--- a/constants/audio_constants.asm
+++ b/constants/audio_constants.asm
@@ -54,7 +54,6 @@ DEF CHANNEL_FIELD16                     rb
 DEF CHANNEL_LOOP_COUNT                  rb
 DEF CHANNEL_TEMPO                       rw
 DEF CHANNEL_TRACKS                      rb
-DEF CHANNEL_DUTY_CYCLE_PATTERN          rb
 DEF CHANNEL_VIBRATO_DELAY               rb
 DEF CHANNEL_VIBRATO_DELAY_COUNT         rb
 DEF CHANNEL_VIBRATO_EXTENT              rb

--- a/engine/menus/options_menu.asm
+++ b/engine/menus/options_menu.asm
@@ -351,9 +351,6 @@ Options_Sound:
 	set STEREO, [hl]
 	ld de, .Stereo
 .Display:
-	ldh a, [hJoyPressed]
-	and D_LEFT | D_RIGHT
-	call nz, RestartMapMusic
 	hlcoord 11, 13
 	rst PlaceString
 	and a

--- a/macros/ram.asm
+++ b/macros/ram.asm
@@ -180,7 +180,6 @@ MACRO channel_struct
 \1LoopCount::         db
 \1Tempo::             dw
 \1Tracks::            db ; hi:left lo:right
-\1SFXDutyLoop::       db
 \1VibratoDelay::      db ; number of frames a note plays until vibrato starts
 \1VibratoDelayCount:: db ; initialized by \1VibratoDelay
 \1VibratoExtent::     db

--- a/ram/wram0.asm
+++ b/ram/wram0.asm
@@ -96,6 +96,9 @@ wMapMusic:: db
 wDontPlayMapMusicOnReload:: db
 wMusicEnd::
 
+; Has to be outside the area used to save/load audio state
+wCh3LoadedWaveform:: db
+
 ; Music player
 ; audio engine input
 wChannelSelectorSwitches:: ds 4


### PR DESCRIPTION
Removes all stereo-dependant branches, engine is essentially stereo only, with stereo/mono mixing handled when writing rNR51. The options menu no longer restarts the music as the change applies instantly

Fixes #837 but i'm not entirely sure the fix is correct