### PR TITLE
DynPal: Fix darkness/overcast pal problems

### DIFF
--- a/engine/gfx/sprite_palettes.asm
+++ b/engine/gfx/sprite_palettes.asm
@@ -23,7 +23,7 @@ CopySpritePal::
 
 .not_copy_bg
 	; skip darkness/overcast if USE_DAYTIME_PAL_F
-	ld a, [wNeededPalIndex]
+	ld a, [wPalFlags]
 	bit USE_DAYTIME_PAL_F, a
 	jr nz, .not_overcast
 


### PR DESCRIPTION
Can't believe this didn't cause more problems. Fixes the pokeball's using wrong pals when in darkness:

