### PR TITLE
Moved where TownMap_InitFlyPossible is called to prevent odd map fly …

### DIFF
--- a/engine/pokegear/pokegear.asm
+++ b/engine/pokegear/pokegear.asm
@@ -86,7 +86,6 @@ PokeGear:
 	call Pokegear_LoadGFX
 	call ClearSpriteAnims
 	call InitPokegearModeIndicatorArrow
-	call TownMap_InitFlyPossible
 	ld a, 8
 	call SkipMusic
 	ld a, LCDC_DEFAULT
@@ -490,6 +489,7 @@ PokegearMap_CheckRegion:
 
 PokegearMap_Init:
 	call InitPokegearTilemap
+	call TownMap_InitFlyPossible
 	ld a, [wPokegearMapPlayerIconLandmark]
 	call PokegearMap_InitPlayerIcon
 	ld a, [wPokegearMapCursorLandmark]
@@ -1202,7 +1202,6 @@ _TownMap:
 	farcall InitPokegearPalettes
 	call Pokegear_LoadGFX
 	call ClearSpriteAnims
-	call TownMap_InitFlyPossible
 	ld a, 8
 	call SkipMusic
 	ld a, LCDC_DEFAULT


### PR DESCRIPTION
There was an issue where if you turned on the radio (and it played music) and then flipped back to the map and tried to fly it would not show the fly button press prompt BUT would also cause you to fly and just return to where you were.