### PR TITLE
Swap party mon incorrect initial frame palette fix

### DIFF
--- a/engine/menus/start_menu.asm
+++ b/engine/menus/start_menu.asm
@@ -405,6 +405,7 @@ StartMenu_Pokemon:
 	and SELECT
 	jr z, .not_switch
 	call SwitchPartyMons
+	call SetPalettes
 	jr .after_action
 .not_switch
 	call PokemonActionSubmenu


### PR DESCRIPTION
Added a call to SetPalette before InitPartyMenuGFX to prevent a frame of incorrect palette after swapping mons.