### PR TITLE
Prevent frame of incorrect palette on mon swap in party

### DIFF
--- a/engine/pokemon/mon_menu.asm
+++ b/engine/pokemon/mon_menu.asm
@@ -133,7 +133,6 @@ SwitchPartyMons:
 
 	farcall InitPartySwap
 	call ApplyTilemapInVBlank
-	call SetPalettes
 	call DelayFrame
 
 	ld a, A_BUTTON | B_BUTTON | SELECT
@@ -149,6 +148,7 @@ SwitchPartyMons:
 	ld [wPartyMenuActionText], a
 
 	farcall LoadPartyMenuGFX
+	call SetPalettes
 	farcall InitPartyMenuWithCancel
 	farcall InitPartyMenuGFX
 


### PR DESCRIPTION
Added moved the call to SetPalette after LoadPartyMenuGFX but before InitPartyMenuGFX to prevent a frame of incorrect palette after swapping mons.