### PR TITLE
Various bug fixes

### DIFF
--- a/engine/events/specials.asm
+++ b/engine/events/specials.asm
@@ -340,12 +340,13 @@ CheckIfTrendyPhraseIsLucky:
 	db "Lucky@"
 
 RespawnOneOffs:
-	eventflagreset EVENT_BEAT_LAWRENCE
 	eventflagreset EVENT_BEAT_FLANNERY
-	eventflagreset EVENT_BEAT_MAYLENE
-	eventflagreset EVENT_BEAT_MARLON_AGAIN
-	eventflagreset EVENT_BEAT_KUKUI
 	eventflagreset EVENT_BEAT_KATY
+	eventflagreset EVENT_BEAT_KUKUI
+	eventflagreset EVENT_BEAT_LAWRENCE
+	eventflagreset EVENT_BEAT_MARLON_AGAIN
+	eventflagreset EVENT_BEAT_MAYLENE
+	eventflagreset EVENT_BEAT_PIERS_AGAIN
 
 	eventflagcheck EVENT_GOT_MUSCLE_BAND_FROM_STEVEN
 	jr z, .SkipSteven

--- a/engine/pc/bills_pc_ui.asm
+++ b/engine/pc/bills_pc_ui.asm
@@ -1555,38 +1555,38 @@ BillsPC_Stats:
 BillsPC_MoveCursorAfterStatScreen:
 ; Uses wTempMonBox+wTempMonSlot to determine where the cursor should be after scrolling through the stats screen
 ; Check if we're dealing with party or box
-    ld a, [wTempMonBox]
-    and a
-    ld a, [wTempMonSlot]
-    jr z, .party
-    
-    ; boxmon
-    dec a
+	ld a, [wTempMonBox]
+	and a
+	ld a, [wTempMonSlot]
+	jr z, .party
 
-    ; Store wTempMonSlot in b. It can be 0-19, or $00-$13.
-    ld b, a
+	; boxmon
+	dec a
 
-    ; Move the Y offset to the high nibble Also zeroes the lower 2 bits. Convenient.
-    add a
-    add a
+	; Store wTempMonSlot in b. It can be 0-19, or $00-$13.
+	ld b, a
 
-    ; Combine it with b, which holds cursor X in the lower 2 bits.
-    or b
+	; Move the Y offset to the high nibble Also zeroes the lower 2 bits. Convenient.
+	add a
+	add a
 
-    ; Zero out the upper 2 bits of the lower nibble (useless, and holds nothing of worth).
-    and $f3
+	; Combine it with b, which holds cursor X in the lower 2 bits.
+	or b
 
-    ; Now we have Y at the high nibble and X in the low one. Add a baseline XY offset to repoint it
-    ; to the PC cursor position for boxmon data.
-    add $12
-    jr .got_cursor_pos
+	; Zero out the upper 2 bits of the lower nibble (useless, and holds nothing of worth).
+	and $f3
+
+	; Now we have Y at the high nibble and X in the low one. Add a baseline XY offset to repoint it
+	; to the PC cursor position for boxmon data.
+	add $12
+	jr .got_cursor_pos
 
 .party
-    dec a
-    
-    ; This sets carry depending on whether we are on the left or right party column.
-    ; Carry was previously unset with "and a" above, so we don't need to worry about it.
-    rra
+	dec a
+
+	; This sets carry depending on whether we are on the left or right party column.
+	; Carry was previously unset with "and a" above, so we don't need to worry about it.
+	rra
 
 	; This is done to save the carry that swap will reset
 	ld b, 0
@@ -1599,12 +1599,12 @@ BillsPC_MoveCursorAfterStatScreen:
 	add b
 
 	; Add the PC cursor offset for party.
-    add $30
-
+	add $30
+	
 .got_cursor_pos
 	ld [wBillsPC_CursorPos], a
 	ret
-
+	
 BillsPC_CursorPick1:
 ; Plays the first part of the cursor pickup animation
 	ld hl, wBillsPC_CursorAnimFlag

--- a/engine/pc/bills_pc_ui.asm
+++ b/engine/pc/bills_pc_ui.asm
@@ -1592,10 +1592,10 @@ BillsPC_MoveCursorAfterStatScreen:
 	ld b, 0
 	rl b
 
-    ; Moves the Y coordinate to the correct position.
-    swap a
+	; Moves the Y coordinate to the correct position.
+	swap a
 
-    ; Adds the X coordinate.
+	; Adds the X coordinate.
 	add b
 
 	; Add the PC cursor offset for party.

--- a/engine/pc/bills_pc_ui.asm
+++ b/engine/pc/bills_pc_ui.asm
@@ -1549,7 +1549,66 @@ BillsPC_MenuJumptable:
 BillsPC_Stats:
 	call BillsPC_PrepareTransistion
 	farcall _OpenPartyStats
+	call BillsPC_MoveCursorAfterStatsScreen
 	jmp BillsPC_ReturnFromTransistion
+
+BillsPC_MoveCursorAfterStatsScreen:
+; Uses wTempMonBox+wTempMonSlot to determine where the cursor should be after scrolling through the stats screen
+; eor = end of row
+	ld a, [wTempMonBox]
+	and a
+	jr nz, .box
+
+.party
+	ld c, 2
+	ld a, [wTempMonSlot]
+	call SimpleDivide
+	and a
+	jr nz, .party_not_eor
+
+.party_eor
+	add 1
+	ld c, a
+	swap a
+	add b
+	add 2
+	swap a
+	jr .finish
+
+.party_not_eor
+	ld a, 0
+	add b
+	add 3
+	swap a
+	jr .finish
+
+.box
+	ld c, 4
+	ld a, [wTempMonSlot]
+	call SimpleDivide
+	and a
+	jr nz, .box_not_eor
+
+.box_eor
+	add 5
+	ld c, a
+	swap a
+	add b
+	swap a
+	jr .finish
+
+.box_not_eor
+	add 1
+	ld c, a
+	swap a
+	add b
+	add 1
+	swap a
+	jr .finish
+
+.finish
+	ld [wBillsPC_CursorPos], a
+	ret
 
 BillsPC_CursorPick1:
 ; Plays the first part of the cursor pickup animation

--- a/engine/pc/bills_pc_ui.asm
+++ b/engine/pc/bills_pc_ui.asm
@@ -1549,64 +1549,59 @@ BillsPC_MenuJumptable:
 BillsPC_Stats:
 	call BillsPC_PrepareTransistion
 	farcall _OpenPartyStats
-	call BillsPC_MoveCursorAfterStatsScreen
+	call BillsPC_MoveCursorAfterStatScreen
 	jmp BillsPC_ReturnFromTransistion
 
-BillsPC_MoveCursorAfterStatsScreen:
+BillsPC_MoveCursorAfterStatScreen:
 ; Uses wTempMonBox+wTempMonSlot to determine where the cursor should be after scrolling through the stats screen
-; eor = end of row
-	ld a, [wTempMonBox]
-	and a
-	jr nz, .box
+; Check if we're dealing with party or box
+    ld a, [wTempMonBox]
+    and a
+    ld a, [wTempMonSlot]
+    jr z, .party
+    
+    ; boxmon
+    dec a
+
+    ; Store wTempMonSlot in b. It can be 0-19, or $00-$13.
+    ld b, a
+
+    ; Move the Y offset to the high nibble Also zeroes the lower 2 bits. Convenient.
+    add a
+    add a
+
+    ; Combine it with b, which holds cursor X in the lower 2 bits.
+    or b
+
+    ; Zero out the upper 2 bits of the lower nibble (useless, and holds nothing of worth).
+    and $f3
+
+    ; Now we have Y at the high nibble and X in the low one. Add a baseline XY offset to repoint it
+    ; to the PC cursor position for boxmon data.
+    add $12
+    jr .got_cursor_pos
 
 .party
-	ld c, 2
-	ld a, [wTempMonSlot]
-	call SimpleDivide
-	and a
-	jr nz, .party_not_eor
+    dec a
+    
+    ; This sets carry depending on whether we are on the left or right party column.
+    ; Carry was previously unset with "and a" above, so we don't need to worry about it.
+    rra
 
-.party_eor
-	add 1
-	ld c, a
-	swap a
+	; This is done to save the carry that swap will reset
+	ld b, 0
+	rl b
+
+    ; Moves the Y coordinate to the correct position.
+    swap a
+
+    ; Adds the X coordinate.
 	add b
-	add 2
-	swap a
-	jr .finish
 
-.party_not_eor
-	ld a, 0
-	add b
-	add 3
-	swap a
-	jr .finish
+	; Add the PC cursor offset for party.
+    add $30
 
-.box
-	ld c, 4
-	ld a, [wTempMonSlot]
-	call SimpleDivide
-	and a
-	jr nz, .box_not_eor
-
-.box_eor
-	add 5
-	ld c, a
-	swap a
-	add b
-	swap a
-	jr .finish
-
-.box_not_eor
-	add 1
-	ld c, a
-	swap a
-	add b
-	add 1
-	swap a
-	jr .finish
-
-.finish
+.got_cursor_pos
 	ld [wBillsPC_CursorPos], a
 	ret
 
@@ -2181,6 +2176,7 @@ BillsPC_Moves:
 	jmp nz, BillsPC_PrintText
 	call BillsPC_PrepareTransistion
 	farcall _ManagePokemonMoves
+	call BillsPC_MoveCursorAfterStatScreen
 	jr BillsPC_ReturnFromTransistion
 
 .CantCheckEggMoves:

--- a/maps/GoldenrodGameCorner.asm
+++ b/maps/GoldenrodGameCorner.asm
@@ -1,3 +1,10 @@
+DEF GOLDENRODGAMECORNER_TM35_COINS EQU 4000
+DEF GOLDENRODGAMECORNER_TM24_COINS EQU 4000
+DEF GOLDENRODGAMECORNER_TM13_COINS EQU 4000
+DEF GOLDENRODGAMECORNER_ABRA_COINS     EQU 200
+DEF GOLDENRODGAMECORNER_CUBONE_COINS   EQU 800
+DEF GOLDENRODGAMECORNER_CLEFAIRY_COINS EQU 1500
+
 GoldenrodGameCorner_MapScriptHeader:
 	def_scene_scripts
 
@@ -111,37 +118,37 @@ GoldenrodGameCornerTMVendor_LoopScript: ; 056c36
 .flamethrower:
 	checktmhm TM_FLAMETHROWER
 	iftruefwd GoldenrodGameCornerPrizeVendor_AlreadyHaveTMScript
-	checkcoins 4000
+	checkcoins GOLDENRODGAMECORNER_TM35_COINS
 	ifequalfwd $2, GoldenrodGameCornerPrizeVendor_NotEnoughCoinsScript
 	gettmhmname TM_FLAMETHROWER, $0
 	scall GoldenrodGameCornerPrizeVendor_ConfirmPurchaseScript
 	iffalse_jumpopenedtext GoldenrodGameCornerPrizeVendorQuitText
 	givetmhm TM_FLAMETHROWER
-	takecoins 4000
+	takecoins GOLDENRODGAMECORNER_TM35_COINS
 	sjumpfwd GoldenrodGameCornerTMVendor_FinishScript
 
 .thunderbolt:
 	checktmhm TM_THUNDERBOLT
 	iftruefwd GoldenrodGameCornerPrizeVendor_AlreadyHaveTMScript
-	checkcoins 4000
+	checkcoins GOLDENRODGAMECORNER_TM24_COINS
 	ifequalfwd $2, GoldenrodGameCornerPrizeVendor_NotEnoughCoinsScript
 	gettmhmname TM_THUNDERBOLT, $0
 	scall GoldenrodGameCornerPrizeVendor_ConfirmPurchaseScript
 	iffalse_jumpopenedtext GoldenrodGameCornerPrizeVendorQuitText
 	givetmhm TM_THUNDERBOLT
-	takecoins 4000
+	takecoins GOLDENRODGAMECORNER_TM24_COINS
 	sjumpfwd GoldenrodGameCornerTMVendor_FinishScript
 
 .ice_beam:
 	checktmhm TM_ICE_BEAM
 	iftruefwd GoldenrodGameCornerPrizeVendor_AlreadyHaveTMScript
-	checkcoins 4000
+	checkcoins GOLDENRODGAMECORNER_TM13_COINS
 	ifequalfwd $2, GoldenrodGameCornerPrizeVendor_NotEnoughCoinsScript
 	gettmhmname TM_ICE_BEAM, $0
 	scall GoldenrodGameCornerPrizeVendor_ConfirmPurchaseScript
 	iffalse_jumpopenedtext GoldenrodGameCornerPrizeVendorQuitText
 	givetmhm TM_ICE_BEAM
-	takecoins 4000
+	takecoins GOLDENRODGAMECORNER_TM13_COINS
 	sjumpfwd GoldenrodGameCornerTMVendor_FinishScript
 
 GoldenrodGameCornerPrizeVendor_ConfirmPurchaseScript:
@@ -173,9 +180,9 @@ GoldenrodGameCornerTMVendorMenuData:
 .MenuData2:
 	db $80 ; flags
 	db 4 ; items
-	db "TM35    4000@"
-	db "TM24    4000@"
-	db "TM13    4000@"
+	db "TM35    {d:GOLDENRODGAMECORNER_TM35_COINS}@"
+	db "TM24    {d:GOLDENRODGAMECORNER_TM24_COINS}@"
+	db "TM13    {d:GOLDENRODGAMECORNER_TM13_COINS}@"
 	db "Cancel@"
 
 GoldenrodGameCornerPrizeMonVendorScript:
@@ -197,7 +204,7 @@ GoldenrodGameCornerPrizeMonVendorScript:
 	jumpopenedtext GoldenrodGameCornerPrizeVendorQuitText
 
 .abra
-	checkcoins 200
+	checkcoins GOLDENRODGAMECORNER_ABRA_COINS
 	ifequal $2, GoldenrodGameCornerPrizeVendor_NotEnoughCoinsScript
 	getmonname ABRA, $0
 	scall GoldenrodGameCornerPrizeVendor_ConfirmPurchaseScript
@@ -210,11 +217,11 @@ GoldenrodGameCornerPrizeMonVendorScript:
 	iffalse_jumpopenedtext GoldenrodGameCornerPrizeVendorNoMoreRoomText
 	setmonval ABRA
 	special Special_GameCornerPrizeMonCheckDex
-	takecoins 200
+	takecoins GOLDENRODGAMECORNER_ABRA_COINS
 	sjump .loop
 
 .cubone
-	checkcoins 800
+	checkcoins GOLDENRODGAMECORNER_CUBONE_COINS
 	ifequal $2, GoldenrodGameCornerPrizeVendor_NotEnoughCoinsScript
 	getmonname CUBONE, $0
 	scall GoldenrodGameCornerPrizeVendor_ConfirmPurchaseScript
@@ -227,11 +234,11 @@ GoldenrodGameCornerPrizeMonVendorScript:
 	iffalse_jumpopenedtext GoldenrodGameCornerPrizeVendorNoMoreRoomText
 	setmonval CUBONE
 	special Special_GameCornerPrizeMonCheckDex
-	takecoins 800
+	takecoins GOLDENRODGAMECORNER_CUBONE_COINS
 	sjump .loop
 
 .clefairy
-	checkcoins 1500
+	checkcoins GOLDENRODGAMECORNER_CLEFAIRY_COINS
 	ifequal $2, GoldenrodGameCornerPrizeVendor_NotEnoughCoinsScript
 	getmonname CLEFAIRY, $0
 	scall GoldenrodGameCornerPrizeVendor_ConfirmPurchaseScript
@@ -244,7 +251,7 @@ GoldenrodGameCornerPrizeMonVendorScript:
 	iffalse_jumpopenedtext GoldenrodGameCornerPrizeVendorNoMoreRoomText
 	setmonval CLEFAIRY
 	special Special_GameCornerPrizeMonCheckDex
-	takecoins 1500
+	takecoins GOLDENRODGAMECORNER_CLEFAIRY_COINS
 	sjump .loop
 
 .MenuDataHeader:
@@ -256,9 +263,9 @@ GoldenrodGameCornerPrizeMonVendorScript:
 .MenuData2:
 	db $80 ; flags
 	db 4 ; items
-	db "Abra        200@"
-	db "Cubone      800@"
-	db "Clefairy   1500@"
+	db "Abra        {d:GOLDENRODGAMECORNER_ABRA_COINS}@"
+	db "Cubone      {d:GOLDENRODGAMECORNER_CUBONE_COINS}@"
+	db "Clefairy   {d:GOLDENRODGAMECORNER_CLEFAIRY_COINS}@"
 	db "Cancel@"
 
 GoldenrodGameCornerPharmacistScript:


### PR DESCRIPTION
Went through some of the issues list. Added Piers rematch to the E4 reset, adjusted some file structure of GoldenrodGameCorner to match CeladonGameCorner (was doing this when looking into Issue #656, which I cannot recreate at all, I think that one can be closed), and the larger one is adding the functionality to move the cursor to the currently showed pokemon on the stats screen when scrolling through the box/party in the PC.

Piers Rematch: https://github.com/Rangi42/polishedcrystal/issues/814

GameCorner Coin Refund: (cannot recreate this, I don't think this can happen anymore if it did) https://github.com/Rangi42/polishedcrystal/issues/656

Cursor not moving after statscreen: https://github.com/Rangi42/polishedcrystal/issues/624