### PR TITLE
Fix for FastShip CaptainsCabin scene transition

### DIFF
--- a/home/palettes.asm
+++ b/home/palettes.asm
@@ -257,3 +257,18 @@ Special_ReloadSpritesNoPalettes::
 	ld a, 1
 	ldh [hCGBPalUpdate], a
 	jmp DelayFrame
+
+SetBlackObjectPals::
+	ldh a, [rSVBK]
+	push af
+	ld a, BANK(wOBPals2)
+	ldh [rSVBK], a
+	ld hl, wOBPals2
+	ld bc, 8 palettes
+	xor a
+	rst ByteFill
+	pop af
+	ldh [rSVBK], a
+	ld a, 1
+	ldh [hCGBPalUpdate], a
+	jmp DelayFrame

--- a/maps/FastShipCabins_SE_SSE_CaptainsCabin.asm
+++ b/maps/FastShipCabins_SE_SSE_CaptainsCabin.asm
@@ -44,13 +44,17 @@ SSAquaGranddaughterBefore:
 	showtextfaceplayer SSAquaGranddaughterHasToFindGrandpaText
 	special Special_FadeBlackQuickly
 	special Special_ReloadSpritesNoPalettes
+	callasm DisableDynPalUpdates
 	disappear FASTSHIPCABINS_SE_SSE_CAPTAINSCABIN_TWIN2
 	applymovement PLAYER, SSAquaCaptainsCabinWarpsToGrandpasCabinMovement
 	moveobject FASTSHIPCABINS_SE_SSE_CAPTAINSCABIN_TWIN1, 3, 19
 	appear FASTSHIPCABINS_SE_SSE_CAPTAINSCABIN_TWIN1
 	turnobject PLAYER, UP
 	turnobject FASTSHIPCABINS_SE_SSE_CAPTAINSCABIN_TWIN1, UP
-	special Special_FadeInQuickly
+	loadmem wObject1Palette, 1
+	callasm SetBlackObjectPals
+	turnobject FASTSHIPCABINS_SE_SSE_CAPTAINSCABIN_GENTLEMAN, RIGHT
+	callasm FadeInPalettes_EnableDynNoApply
 	turnobject FASTSHIPCABINS_SE_SSE_CAPTAINSCABIN_GENTLEMAN, DOWN
 	showemote EMOTE_SHOCK, FASTSHIPCABINS_SE_SSE_CAPTAINSCABIN_GENTLEMAN, 15
 	applymovement FASTSHIPCABINS_SE_SSE_CAPTAINSCABIN_TWIN1, SSAquaGranddaughterEntersCabinMovement


### PR DESCRIPTION
This is still not quite perfect yet... but its better. The main issue here has to do with the fact that this scene has the player move through the void from one room to another while the pals a "faded out". This triggers the dynpal system when new objects are loaded. 

Also it seems that `Special_FadeBlackQuickly` was setting the BG pals to grey.. and all OBJ pals to grey except for OBJ0 which was being set to Black. Since the player is typically OBJ0... They show up as black on a grey background in this scene.... 

So I made a `FadeToBlackQuickly` for now... Which just fades ALL pals to black.. and then we reload them before fading back in.

The fade in is still a little gittery.. i'll look into this a bit more. I'll also take suggestions.