### PR TITLE
Add missing learnset terminator for Delibird and clean up other minor issues

### DIFF
--- a/constants/pokemon_constants.asm
+++ b/constants/pokemon_constants.asm
@@ -18,7 +18,7 @@
 ; - ValidPokemonLevels (see data/pokemon/valid_levels.asm)
 ; - FootprintPointers (see data/pokemon/footprint_pointers.asm)
 ; - AnimationPointers (see gfx/pokemon/anim_pointers.asm)
-; - AnimationIdlePointers (see gfx/pokemon/idle_pointers.asm)
+; - AnimationIdlePointers (see gfx/pokemon/extra_pointers.asm)
 ; - BitmasksPointers (see gfx/pokemon/bitmask_pointers.asm)
 ; - FramesPointers (see gfx/pokemon/frame_pointers.asm)
 	const_def 1

--- a/data/pokemon/base_stats/mr__rime.asm
+++ b/data/pokemon/base_stats/mr__rime.asm
@@ -5,7 +5,7 @@
 	db 45 ; catch rate
 	db 207 ; base exp
 	db NO_ITEM, NO_ITEM ; held items
-	dn GENDER_F50, 4; gender ratio, step cycles to hatch
+	dn GENDER_F50, HATCH_MEDIUM_SLOW ; gender ratio, step cycles to hatch
 
 	abilities_for MR__RIME, TANGLED_FEET, SCREEN_CLEANER, ICE_BODY
 	db GROWTH_MEDIUM_FAST ; growth rate

--- a/data/pokemon/egg_move_pointers.asm
+++ b/data/pokemon/egg_move_pointers.asm
@@ -1,348 +1,348 @@
 EggMovePointers::
 	table_width 2, EggMovePointers
-	dw BulbasaurEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw CharmanderEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw SquirtleEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw PidgeyEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw RattataPlainEggMoves
-	dw NoEggMoves
-	dw SpearowEggMoves
-	dw NoEggMoves
-	dw EkansEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw SandshrewPlainEggMoves
-	dw NoEggMoves
-	dw NidoranFEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NidoranMEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw VulpixPlainEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw ZubatEggMoves
-	dw NoEggMoves
-	dw OddishEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw ParasEggMoves
-	dw NoEggMoves
-	dw VenonatEggMoves
-	dw NoEggMoves
-	dw DiglettPlainEggMoves
-	dw NoEggMoves
-	dw MeowthPlainEggMoves
-	dw NoEggMoves
-	dw PsyduckEggMoves
-	dw NoEggMoves
-	dw MankeyEggMoves
-	dw NoEggMoves
-	dw GrowlitheEggMoves
-	dw NoEggMoves
-	dw PoliwagEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw AbraEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw MachopEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw BellsproutEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw TentacoolEggMoves
-	dw NoEggMoves
-	dw GeodudePlainEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw PonytaPlainEggMoves
-	dw NoEggMoves
-	dw SlowpokePlainEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw FarfetchDPlainEggMoves
-	dw DoduoEggMoves
-	dw NoEggMoves
-	dw SeelEggMoves
-	dw NoEggMoves
-	dw GrimerPlainEggMoves
-	dw NoEggMoves
-	dw ShellderEggMoves
-	dw NoEggMoves
-	dw GastlyEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw OnixEggMoves
-	dw DrowzeeEggMoves
-	dw NoEggMoves
-	dw KrabbyEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw ExeggcuteEggMoves
-	dw NoEggMoves
-	dw CuboneEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw LickitungEggMoves
-	dw KoffingEggMoves
-	dw NoEggMoves
-	dw RhyhornEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw TangelaEggMoves
-	dw KangaskhanEggMoves
-	dw HorseaEggMoves
-	dw NoEggMoves
-	dw GoldeenEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw ScytherEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw PinsirEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw LaprasEggMoves
-	dw NoEggMoves
-	dw EeveeEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw OmanyteEggMoves
-	dw NoEggMoves
-	dw KabutoEggMoves
-	dw NoEggMoves
-	dw AerodactylEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw DratiniEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw ChikoritaEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw CyndaquilEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw TotodileEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw SentretEggMoves
-	dw NoEggMoves
-	dw HoothootEggMoves
-	dw NoEggMoves
-	dw LedybaEggMoves
-	dw NoEggMoves
-	dw SpinarakEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw ChinchouEggMoves
-	dw NoEggMoves
-	dw PichuEggMoves
-	dw CleffaEggMoves
-	dw IgglybuffEggMoves
-	dw TogepiEggMoves
-	dw NoEggMoves
-	dw NatuEggMoves
-	dw NoEggMoves
-	dw MareepEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw HoppipEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw AipomEggMoves
-	dw SunkernEggMoves
-	dw NoEggMoves
-	dw YanmaEggMoves
-	dw WooperPlainEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw MurkrowEggMoves
-	dw NoEggMoves
-	dw MisdreavusEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw GirafarigEggMoves
-	dw PinecoEggMoves
-	dw NoEggMoves
-	dw DunsparceEggMoves
-	dw GligarEggMoves
-	dw NoEggMoves
-	dw SnubbullEggMoves
-	dw NoEggMoves
-	dw QwilfishEggMoves
-	dw NoEggMoves
-	dw ShuckleEggMoves
-	dw HeracrossEggMoves
-	dw SneaselEggMoves
-	dw TeddiursaEggMoves
-	dw NoEggMoves
-	dw SlugmaEggMoves
-	dw NoEggMoves
-	dw SwinubEggMoves
-	dw NoEggMoves
-	dw CorsolaPlainEggMoves
-	dw RemoraidEggMoves
-	dw NoEggMoves
-	dw DelibirdEggMoves
-	dw NoEggMoves
-	dw SkarmoryEggMoves
-	dw HoundourEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw PhanpyEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw StantlerEggMoves
-	dw NoEggMoves
-	dw TyrogueEggMoves
-	dw NoEggMoves
-	dw SmoochumEggMoves
-	dw ElekidEggMoves
-	dw MagbyEggMoves
-	dw MiltankEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw LarvitarEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw AzurillEggMoves
-	dw WynautEggMoves
-	dw NoEggMoves
-	dw NoEggMoves ; EGG
-	dw NoEggMoves ; $100
-	dw NoEggMoves
-	dw NoEggMoves
-	dw BonslyEggMoves
-	dw MimeJrEggMoves
-	dw HappinyEggMoves
-	dw MunchlaxEggMoves
-	dw MantykeEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
+	dw BulbasaurEggMoves      ; Bulbasaur
+	dw NoEggMoves             ; Ivysaur
+	dw NoEggMoves             ; Venusaur
+	dw CharmanderEggMoves     ; Charmander
+	dw NoEggMoves             ; Charmeleon
+	dw NoEggMoves             ; Charizard
+	dw SquirtleEggMoves       ; Squirtle
+	dw NoEggMoves             ; Wartortle
+	dw NoEggMoves             ; Blastoise
+	dw NoEggMoves             ; Caterpie
+	dw NoEggMoves             ; Metapod
+	dw NoEggMoves             ; Butterfree
+	dw NoEggMoves             ; Weedle
+	dw NoEggMoves             ; Kakuna
+	dw NoEggMoves             ; Beedrill
+	dw PidgeyEggMoves         ; Pidgey
+	dw NoEggMoves             ; Pidgeotto
+	dw NoEggMoves             ; Pidgeot
+	dw RattataPlainEggMoves   ; Rattata
+	dw NoEggMoves             ; Raticate
+	dw SpearowEggMoves        ; Spearow
+	dw NoEggMoves             ; Fearow
+	dw EkansEggMoves          ; Ekans
+	dw NoEggMoves             ; Arbok
+	dw NoEggMoves             ; Pikachu
+	dw NoEggMoves             ; Raichu
+	dw SandshrewPlainEggMoves ; Sandshrew
+	dw NoEggMoves             ; Sandslash
+	dw NidoranFEggMoves       ; NidoranF
+	dw NoEggMoves             ; Nidorina
+	dw NoEggMoves             ; Nidoqueen
+	dw NidoranMEggMoves       ; NidoranM
+	dw NoEggMoves             ; Nidorino
+	dw NoEggMoves             ; Nidoking
+	dw NoEggMoves             ; Clefairy
+	dw NoEggMoves             ; Clefable
+	dw VulpixPlainEggMoves    ; Vulpix
+	dw NoEggMoves             ; Ninetales
+	dw NoEggMoves             ; Jigglypuff
+	dw NoEggMoves             ; Wigglytuff
+	dw ZubatEggMoves          ; Zubat
+	dw NoEggMoves             ; Golbat
+	dw OddishEggMoves         ; Oddish
+	dw NoEggMoves             ; Gloom
+	dw NoEggMoves             ; Vileplume
+	dw ParasEggMoves          ; Paras
+	dw NoEggMoves             ; Parasect
+	dw VenonatEggMoves        ; Venonat
+	dw NoEggMoves             ; Venomoth
+	dw DiglettPlainEggMoves   ; Diglett
+	dw NoEggMoves             ; Dugtrio
+	dw MeowthPlainEggMoves    ; Meowth
+	dw NoEggMoves             ; Persian
+	dw PsyduckEggMoves        ; Psyduck
+	dw NoEggMoves             ; Golduck
+	dw MankeyEggMoves         ; Mankey
+	dw NoEggMoves             ; Primeape
+	dw GrowlitheEggMoves      ; Growlithe
+	dw NoEggMoves             ; Arcanine
+	dw PoliwagEggMoves        ; Poliwag
+	dw NoEggMoves             ; Poliwhirl
+	dw NoEggMoves             ; Poliwrath
+	dw AbraEggMoves           ; Abra
+	dw NoEggMoves             ; Kadabra
+	dw NoEggMoves             ; Alakazam
+	dw MachopEggMoves         ; Machop
+	dw NoEggMoves             ; Machoke
+	dw NoEggMoves             ; Machamp
+	dw BellsproutEggMoves     ; Bellsprout
+	dw NoEggMoves             ; Weepinbell
+	dw NoEggMoves             ; Victreebel
+	dw TentacoolEggMoves      ; Tentacool
+	dw NoEggMoves             ; Tentacruel
+	dw GeodudePlainEggMoves   ; Geodude
+	dw NoEggMoves             ; Graveler
+	dw NoEggMoves             ; Golem
+	dw PonytaPlainEggMoves    ; Ponyta
+	dw NoEggMoves             ; Rapidash
+	dw SlowpokePlainEggMoves  ; Slowpoke
+	dw NoEggMoves             ; Slowbro
+	dw NoEggMoves             ; Magnemite
+	dw NoEggMoves             ; Magneton
+	dw FarfetchDPlainEggMoves ; FarfetchD
+	dw DoduoEggMoves          ; Doduo
+	dw NoEggMoves             ; Dodrio
+	dw SeelEggMoves           ; Seel
+	dw NoEggMoves             ; Dewgong
+	dw GrimerPlainEggMoves    ; Grimer
+	dw NoEggMoves             ; Muk
+	dw ShellderEggMoves       ; Shellder
+	dw NoEggMoves             ; Cloyster
+	dw GastlyEggMoves         ; Gastly
+	dw NoEggMoves             ; Haunter
+	dw NoEggMoves             ; Gengar
+	dw OnixEggMoves           ; Onix
+	dw DrowzeeEggMoves        ; Drowzee
+	dw NoEggMoves             ; Hypno
+	dw KrabbyEggMoves         ; Krabby
+	dw NoEggMoves             ; Kingler
+	dw NoEggMoves             ; Voltorb
+	dw NoEggMoves             ; Electrode
+	dw ExeggcuteEggMoves      ; Exeggcute
+	dw NoEggMoves             ; Exeggutor
+	dw CuboneEggMoves         ; Cubone
+	dw NoEggMoves             ; Marowak
+	dw NoEggMoves             ; Hitmonlee
+	dw NoEggMoves             ; Hitmonchan
+	dw LickitungEggMoves      ; Lickitung
+	dw KoffingEggMoves        ; Koffing
+	dw NoEggMoves             ; Weezing
+	dw RhyhornEggMoves        ; Rhyhorn
+	dw NoEggMoves             ; Rhydon
+	dw NoEggMoves             ; Chansey
+	dw TangelaEggMoves        ; Tangela
+	dw KangaskhanEggMoves     ; Kangaskhan
+	dw HorseaEggMoves         ; Horsea
+	dw NoEggMoves             ; Seadra
+	dw GoldeenEggMoves        ; Goldeen
+	dw NoEggMoves             ; Seaking
+	dw NoEggMoves             ; Staryu
+	dw NoEggMoves             ; Starmie
+	dw NoEggMoves             ; Mr.Mime
+	dw ScytherEggMoves        ; Scyther
+	dw NoEggMoves             ; Jynx
+	dw NoEggMoves             ; Electabuzz
+	dw NoEggMoves             ; Magmar
+	dw PinsirEggMoves         ; Pinsir
+	dw NoEggMoves             ; Tauros
+	dw NoEggMoves             ; Magikarp
+	dw NoEggMoves             ; Gyarados
+	dw LaprasEggMoves         ; Lapras
+	dw NoEggMoves             ; Ditto
+	dw EeveeEggMoves          ; Eevee
+	dw NoEggMoves             ; Vaporeon
+	dw NoEggMoves             ; Jolteon
+	dw NoEggMoves             ; Flareon
+	dw NoEggMoves             ; Porygon
+	dw OmanyteEggMoves        ; Omanyte
+	dw NoEggMoves             ; Omastar
+	dw KabutoEggMoves         ; Kabuto
+	dw NoEggMoves             ; Kabutops
+	dw AerodactylEggMoves     ; Aerodactyl
+	dw NoEggMoves             ; Snorlax
+	dw NoEggMoves             ; Articuno
+	dw NoEggMoves             ; Zapdos
+	dw NoEggMoves             ; Moltres
+	dw DratiniEggMoves        ; Dratini
+	dw NoEggMoves             ; Dragonair
+	dw NoEggMoves             ; Dragonite
+	dw NoEggMoves             ; Mewtwo
+	dw NoEggMoves             ; Mew
+	dw ChikoritaEggMoves      ; Chikorita
+	dw NoEggMoves             ; Bayleef
+	dw NoEggMoves             ; Meganium
+	dw CyndaquilEggMoves      ; Cyndaquil
+	dw NoEggMoves             ; Quilava
+	dw NoEggMoves             ; Typhlosion
+	dw TotodileEggMoves       ; Totodile
+	dw NoEggMoves             ; Croconaw
+	dw NoEggMoves             ; Feraligatr
+	dw SentretEggMoves        ; Sentret
+	dw NoEggMoves             ; Furret
+	dw HoothootEggMoves       ; Hoothoot
+	dw NoEggMoves             ; Noctowl
+	dw LedybaEggMoves         ; Ledyba
+	dw NoEggMoves             ; Ledian
+	dw SpinarakEggMoves       ; Spinarak
+	dw NoEggMoves             ; Ariados
+	dw NoEggMoves             ; Crobat
+	dw ChinchouEggMoves       ; Chinchou
+	dw NoEggMoves             ; Lanturn
+	dw PichuEggMoves          ; Pichu
+	dw CleffaEggMoves         ; Cleffa
+	dw IgglybuffEggMoves      ; Igglybuff
+	dw TogepiEggMoves         ; Togepi
+	dw NoEggMoves             ; Togetic
+	dw NatuEggMoves           ; Natu
+	dw NoEggMoves             ; Xatu
+	dw MareepEggMoves         ; Mareep
+	dw NoEggMoves             ; Flaaffy
+	dw NoEggMoves             ; Ampharos
+	dw NoEggMoves             ; Bellossom
+	dw NoEggMoves             ; Marill
+	dw NoEggMoves             ; Azumarill
+	dw NoEggMoves             ; Sudowoodo
+	dw NoEggMoves             ; Politoed
+	dw HoppipEggMoves         ; Hoppip
+	dw NoEggMoves             ; Skiploom
+	dw NoEggMoves             ; Jumpluff
+	dw AipomEggMoves          ; Aipom
+	dw SunkernEggMoves        ; Sunkern
+	dw NoEggMoves             ; Sunflora
+	dw YanmaEggMoves          ; Yanma
+	dw WooperPlainEggMoves    ; Wooper
+	dw NoEggMoves             ; Quagsire
+	dw NoEggMoves             ; Espeon
+	dw NoEggMoves             ; Umbreon
+	dw MurkrowEggMoves        ; Murkrow
+	dw NoEggMoves             ; Slowking
+	dw MisdreavusEggMoves     ; Misdreavus
+	dw NoEggMoves             ; Unown
+	dw NoEggMoves             ; Wobbuffet
+	dw GirafarigEggMoves      ; Girafarig
+	dw PinecoEggMoves         ; Pineco
+	dw NoEggMoves             ; Forretress
+	dw DunsparceEggMoves      ; Dunsparce
+	dw GligarEggMoves         ; Gligar
+	dw NoEggMoves             ; Steelix
+	dw SnubbullEggMoves       ; Snubbull
+	dw NoEggMoves             ; Granbull
+	dw QwilfishEggMoves       ; Qwilfish
+	dw NoEggMoves             ; Scizor
+	dw ShuckleEggMoves        ; Shuckle
+	dw HeracrossEggMoves      ; Heracross
+	dw SneaselEggMoves        ; Sneasel
+	dw TeddiursaEggMoves      ; Teddiursa
+	dw NoEggMoves             ; Ursaring
+	dw SlugmaEggMoves         ; Slugma
+	dw NoEggMoves             ; Magcargo
+	dw SwinubEggMoves         ; Swinub
+	dw NoEggMoves             ; Piloswine
+	dw CorsolaPlainEggMoves   ; Corsola
+	dw RemoraidEggMoves       ; Remoraid
+	dw NoEggMoves             ; Octillery
+	dw DelibirdEggMoves       ; Delibird
+	dw NoEggMoves             ; Mantine
+	dw SkarmoryEggMoves       ; Skarmory
+	dw HoundourEggMoves       ; Houndour
+	dw NoEggMoves             ; Houndoom
+	dw NoEggMoves             ; Kingdra
+	dw PhanpyEggMoves         ; Phanpy
+	dw NoEggMoves             ; Donphan
+	dw NoEggMoves             ; Porygon2
+	dw StantlerEggMoves       ; Stantler
+	dw NoEggMoves             ; Smeargle
+	dw TyrogueEggMoves        ; Tyrogue
+	dw NoEggMoves             ; Hitmontop
+	dw SmoochumEggMoves       ; Smoochum
+	dw ElekidEggMoves         ; Elekid
+	dw MagbyEggMoves          ; Magby
+	dw MiltankEggMoves        ; Miltank
+	dw NoEggMoves             ; Blissey
+	dw NoEggMoves             ; Raikou
+	dw NoEggMoves             ; Entei
+	dw NoEggMoves             ; Suicune
+	dw LarvitarEggMoves       ; Larvitar
+	dw NoEggMoves             ; Pupitar
+	dw NoEggMoves             ; Tyranitar
+	dw NoEggMoves             ; Lugia
+	dw NoEggMoves             ; HoOh
+	dw NoEggMoves             ; Celebi
+	dw AzurillEggMoves        ; Azurill
+	dw WynautEggMoves         ; Wynaut
+	dw NoEggMoves             ; Ambipom
+	dw NoEggMoves             ; Egg
+	dw NoEggMoves             ; $100
+	dw NoEggMoves             ; Mismagius
+	dw NoEggMoves             ; Honchkrow
+	dw BonslyEggMoves         ; Bonsly
+	dw MimeJrEggMoves         ; Mime Jr.
+	dw HappinyEggMoves        ; Happiny
+	dw MunchlaxEggMoves       ; Munchlax
+	dw MantykeEggMoves        ; Mantyke
+	dw NoEggMoves             ; Weavile
+	dw NoEggMoves             ; Magnezone
+	dw NoEggMoves             ; Lickilicky
+	dw NoEggMoves             ; Rhyperior
+	dw NoEggMoves             ; Tangrowth
+	dw NoEggMoves             ; Electivire
+	dw NoEggMoves             ; Magmortar
+	dw NoEggMoves             ; Togekiss
+	dw NoEggMoves             ; Yanmega
+	dw NoEggMoves             ; Leafeon
+	dw NoEggMoves             ; Glaceon
+	dw NoEggMoves             ; Gliscor
+	dw NoEggMoves             ; Mamoswine
+	dw NoEggMoves             ; PorygonZ
+	dw NoEggMoves             ; Sylveon
+	dw NoEggMoves             ; Perrserker
+	dw NoEggMoves             ; Cursola
+	dw NoEggMoves             ; SirfetchD
+	dw NoEggMoves             ; Mr.Rime
+	dw NoEggMoves             ; Wyrdeer
+	dw NoEggMoves             ; Kleavor
+	dw NoEggMoves             ; Ursaluna
+	dw NoEggMoves             ; Sneasler
+	dw NoEggMoves             ; Overqwil
+	dw NoEggMoves             ; Dudunsparce
+	dw NoEggMoves             ; Farigiraf
+	dw NoEggMoves             ; Clodsire
+	dw NoEggMoves             ; Annihilape
 	assert_table_length NUM_SPECIES
 
-	dw NoEggMoves
+	dw NoEggMoves                ; Gyarados (Red Form)
 
-	dw NoEggMoves
+	dw NoEggMoves                ; Mewtwo (Armored Form)
 
-	dw NoEggMoves
+	dw NoEggMoves                ; Dundunsparse (Three Segment Form)
 
-	dw RattataAlolanEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw SandshrewAlolanEggMoves
-	dw NoEggMoves
-	dw VulpixAlolanEggMoves
-	dw NoEggMoves
-	dw DiglettAlolanEggMoves
-	dw NoEggMoves
-	dw MeowthAlolanEggMoves
-	dw NoEggMoves
-	dw GeodudeAlolanEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw GrimerAlolanEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
+	dw RattataAlolanEggMoves     ; Rattata (Alolan Form)
+	dw NoEggMoves                ; Raticate (Alolan Form)
+	dw NoEggMoves                ; Raichu (Alolan Form)
+	dw SandshrewAlolanEggMoves   ; Sandshrew (Alolan Form)
+	dw NoEggMoves                ; Sandslash (Alolan Form)
+	dw VulpixAlolanEggMoves      ; Vulpix (Alolan Form)
+	dw NoEggMoves                ; Ninetales (Alolan Form)
+	dw DiglettAlolanEggMoves     ; Diglett (Alolan Form)
+	dw NoEggMoves                ; Dugtrio (Alolan Form)
+	dw MeowthAlolanEggMoves      ; Meowth (Alolan Form)
+	dw NoEggMoves                ; Persian (Alolan Form)
+	dw GeodudeAlolanEggMoves     ; Geodude (Alolan Form)
+	dw NoEggMoves                ; Graveler (Alolan Form)
+	dw NoEggMoves                ; Golem (Alolan Form)
+	dw GrimerAlolanEggMoves      ; Grimer (Alolan Form)
+	dw NoEggMoves                ; Muk (Alolan Form)
+	dw NoEggMoves                ; Exeggutor (Alolan Form)
+	dw NoEggMoves                ; Marowak (Alolan Form)
 
-	dw MeowthGalarianEggMoves
-	dw PonytaGalarianEggMoves
-	dw NoEggMoves
-	dw SlowpokeGalarianEggMoves
-	dw NoEggMoves
-	dw FarfetchDGalarianEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw CorsolaGalarianEggMoves
+	dw MeowthGalarianEggMoves    ; Meowth (Galarian Form)
+	dw PonytaGalarianEggMoves    ; Ponyta (Galarian Form)
+	dw NoEggMoves                ; Rapidash (Galarian Form)
+	dw SlowpokeGalarianEggMoves  ; Slowpoke (Galarian Form)
+	dw NoEggMoves                ; Slowbro (Galarian Form)
+	dw FarfetchDGalarianEggMoves ; Farfetch'D (Galarian Form)
+	dw NoEggMoves                ; Weezing (Galarian Form)
+	dw NoEggMoves                ; Mr.Mime (Galarian Form)
+	dw NoEggMoves                ; Articuno (Galarian Form)
+	dw NoEggMoves                ; Zapdos (Galarian Form)
+	dw NoEggMoves                ; Moltres (Galarian Form)
+	dw NoEggMoves                ; Slowking (Galarian Form)
+	dw CorsolaGalarianEggMoves   ; Corsola (Galarian Form)
 
-	dw GrowlitheHisuianEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw QwilfishHisuianEggMoves
-	dw SneaselHisuianEggMoves
+	dw GrowlitheHisuianEggMoves  ; Growlithe (Hisuian Form)
+	dw NoEggMoves                ; Arcanine (Hisuian Form)
+	dw NoEggMoves                ; Voltorb (Hisuian Form)
+	dw NoEggMoves                ; Electrode (Hisuian Form)
+	dw NoEggMoves                ; Typhlosion (Hisuian Form)
+	dw QwilfishHisuianEggMoves   ; Qwilfish (Hisuian Form)
+	dw SneaselHisuianEggMoves    ; Sneasel (Hisuian Form)
 
-	dw WooperPaldeanEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
-	dw NoEggMoves
+	dw WooperPaldeanEggMoves     ; Wooper (Paldean Form)
+	dw NoEggMoves                ; Tauros (Paldean Form)
+	dw NoEggMoves                ; Tauros (Paldean Fire Form)
+	dw NoEggMoves                ; Tauros (Paldean Water Form)
 
 	assert_table_length NUM_EXT_POKEMON

--- a/data/pokemon/evos_attacks.asm
+++ b/data/pokemon/evos_attacks.asm
@@ -5274,6 +5274,7 @@ DelibirdEvosAttacks:
 	db 49, BELLY_DRUM
 	db 53, HURRICANE
 	db 57, BLIZZARD
+	db -1 ; no more level-up moves
 
 MantineEvosAttacks:
 	db -1 ; no more evolutions


### PR DESCRIPTION
Noticed a couple things while writing data scraping utilities that I thought I'd fix and PR.

* Most notable, Delibird's learnset doesn't actually have a terminator and falls through overlapping Mantine's below. Technically this overlap could be intentionally utilized to save a magical 100 or so bytes, but this seems to just be an error
* `pokemon_constants` refers to a missing file `idle_pointers.asm`, which seems to have been renamed to `extra_pointers.asm`. I'm not clear if the list in `pokemon_constants` is otherwise complete, but nothing else matches the substring `assert_table_length NUM_SPECIES` so I assume it's fine
* Mr. Rime has a hardcoded 4 instead of a `HATCH_MEDIUM_SLOW` constant. It seems to be the only mon that did this
* While a lot of lookup tables based on pokemon species lack comments, it's usually pretty easy contextually tell what's going on. That isn't the case with `egg_move_pointers`, which has a lot of `NoEggMoves`, so I added comments. After checking a handful of files otherwise referenced by `pokemon_constants`, it was inconsistent with using the constant names or the natural names, so I just picked one, if you'd prefer I use constant names instead that's an easy enough swap.