### PR TITLE
[9-Bit] Removes Outdated EV Evolution Text

### DIFF
--- a/maps/CliffEdgeGate.asm
+++ b/maps/CliffEdgeGate.asm
@@ -118,16 +118,6 @@ ProfOaksAide3ExplainText:
 	para "grow more from"
 	line "battling, but"
 	cont "slows it down."
-
-	para "According to"
-	line "Prof.Elm, some"
-	cont "#mon evolve"
-
-	para "when one stat has"
-	line "grown enough."
-
-	para "Use it to com-"
-	line "plete the #dex!"
 	done
 
 GruntM12SeenText:

--- a/maps/GoldenrodDeptStore4F.asm
+++ b/maps/GoldenrodDeptStore4F.asm
@@ -37,17 +37,12 @@ GoldenrodDeptStore4FBugCatcherText:
 	text "There are four"
 	line "#mon that"
 
-	para "evolve if they"
-	line "eat enough of a"
-	cont "certain vitamin:"
+	para "evolve if given"
+	line "a Linking Cord:"
 
 	para "Machoke, Graveler,"
 	line "Kadabra, and"
 	cont "Haunter!"
-
-	para "But I don't know"
-	line "which needs which"
-	cont "vitamin."
 	done
 
 GoldenrodDeptStore4FGameboyKidText:

--- a/maps/GoldenrodDeptStore4F.asm
+++ b/maps/GoldenrodDeptStore4F.asm
@@ -37,8 +37,8 @@ GoldenrodDeptStore4FBugCatcherText:
 	text "There are four"
 	line "#mon that"
 
-	para "evolve if given"
-	line "a Linking Cord:"
+	para "evolve if exposed"
+	line "to a Linking Cord:"
 
 	para "Machoke, Graveler,"
 	line "Kadabra, and"


### PR DESCRIPTION
Since the Linking Cord replaced EV-Based Evolutions, this pull request edits GoldenrodDeptStore4F.asm and CliffEdgeGate.asm to reflect this change in the dialogue.