### PR TITLE
Togepi egg event fix

### DIFF
--- a/home/pokemon.asm
+++ b/home/pokemon.asm
@@ -434,7 +434,7 @@ CompareSpeciesForm:
 	assert (MON_GENDER_F == 7)
 	add a
 	ld a, c
-	jr nc, .skip_gender_reset
+	jr c, .skip_gender_reset
 	res MON_GENDER_F, b
 .skip_gender_reset
 	; Effectively does a comparision between a and b.


### PR DESCRIPTION
The event in Elm's Lab doesn't trigger if you hatch a female Togepi. In the function that handles setting that event, gender is never reset, so it may be the reason why it glitches out. Reseting the gender flag fixes the issue.