### PR TITLE
add secondary rock typing to galarian corsola line

### DIFF
--- a/data/pokemon/base_stats/corsola_galarian.asm
+++ b/data/pokemon/base_stats/corsola_galarian.asm
@@ -1,7 +1,11 @@
 	db  60,  55, 100,  30,  65, 100 ; 410 BST
 	;   hp  atk  def  spe  sat  sdf
 
+if DEF(FAITHFUL)
 	db GHOST, GHOST ; type
+else
+	db GHOST, ROCK ; type
+endc
 	db 60 ; catch rate
 	db 113 ; base exp
 	db NO_ITEM, NO_ITEM ; held items

--- a/data/pokemon/base_stats/cursola.asm
+++ b/data/pokemon/base_stats/cursola.asm
@@ -1,7 +1,11 @@
 	db  60,  95,  50,  30, 145, 130 ; 510 BST
 	;   hp  atk  def  spe  sat  sdf
 
+if DEF(FAITHFUL)
 	db GHOST, GHOST ; type
+else
+	db GHOST, ROCK ; type
+endc
 	db 30 ; catch rate
 	db 196 ; base exp
 	db NO_ITEM, NO_ITEM ; held items


### PR DESCRIPTION
Changes both galarian corsola and cursola to Ghost/Rock in unfaithful build.