### PR TITLE
Fix evos_attacks.asm Evo_Data Orders

### DIFF
--- a/data/pokemon/evos_attacks.asm
+++ b/data/pokemon/evos_attacks.asm
@@ -2626,8 +2626,8 @@ LickitungEvosAttacks:
 	db -1 ; no more level-up moves
 
 KoffingEvosAttacks:
-	evo_data EVOLVE_LEVEL, 35, WEEZING, PLAIN_FORM
 	evo_data EVOLVE_HOLDING, CHARCOAL, TR_ANYTIME, WEEZING, GALARIAN_FORM
+	evo_data EVOLVE_LEVEL, 35, WEEZING, PLAIN_FORM
 	db -1 ; no more evolutions
 	db 1, TACKLE
 	db 4, ACID ; Smog → new move
@@ -5873,9 +5873,9 @@ BonslyEvosAttacks:
 	db -1 ; no more level-up moves
 
 MimeJrEvosAttacks:
+	evo_data EVOLVE_LOCATION, ICE_PATH, MR__MIME, GALARIAN_FORM
 	evo_data EVOLVE_LEVEL, 30, MR__MIME, PLAIN_FORM
 	evo_data EVOLVE_ITEM, ICE_STONE, MR__MIME, GALARIAN_FORM
-	evo_data EVOLVE_LOCATION, ICE_PATH, MR__MIME, GALARIAN_FORM
 	db -1 ; no more evolutions
 	db 1, BARRIER
 	db 1, CONFUSION


### PR DESCRIPTION
Changes to the order of evo_data listings for Koffing and Mime Jr. to allow both to evolve into their regional forms at or past the level they would otherwise evolve into their regular forms.