### PR TITLE
Only enable LCD_STAT when needed.

### DIFF
--- a/engine/battle/battle_transition.asm
+++ b/engine/battle/battle_transition.asm
@@ -75,6 +75,9 @@ endc
 	call DmgToCgbBGPals
 	call DelayFrame
 
+	ld hl, rIE
+	res LCD_STAT, [hl]
+
 	xor a
 	ldh [hLCDCPointer], a
 	ldh [hLYOverrideStart], a
@@ -83,8 +86,6 @@ endc
 
 	ld a, BANK(wEnemyMon)
 	ldh [rSVBK], a
-	ld hl, rIE
-	res LCD_STAT, [hl]
 
 	pop af
 	ldh [hVBlank], a
@@ -225,6 +226,8 @@ StartTrainerBattle_SetUpForWavyOutro:
 
 	call StartTrainerBattle_NextScene
 
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, LOW(rSCX)
 	ldh [hLCDCPointer], a
 	xor a
@@ -234,8 +237,6 @@ StartTrainerBattle_SetUpForWavyOutro:
 	xor a
 	ld [wBattleTransitionCounter], a
 	ld [wBattleTransitionSineWaveOffset], a
-	ld hl, rIE
-	set LCD_STAT, [hl]
 	ret
 
 StartTrainerBattle_SineWave:

--- a/engine/battle/sliding_intro.asm
+++ b/engine/battle/sliding_intro.asm
@@ -1,20 +1,20 @@
 BattleIntroSlidingPics:
-	ld hl, rIE
-	set LCD_STAT, [hl]
 	ldh a, [rSVBK]
 	push af
 	ld a, $5
 	ldh [rSVBK], a
 	call .subfunction1
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, LOW(rSCX)
 	ldh [hLCDCPointer], a
 	call .subfunction2
+	ld hl, rIE
+	res LCD_STAT, [hl]
 	xor a
 	ldh [hLCDCPointer], a
 	pop af
 	ldh [rSVBK], a
-	ld hl, rIE
-	res LCD_STAT, [hl]
 	ret
 
 .subfunction1

--- a/engine/battle_anims/anim_commands.asm
+++ b/engine/battle_anims/anim_commands.asm
@@ -2,9 +2,6 @@
 
 PlayBattleAnim:
 	farcall CheckBattleAnimSubstitution
-	ld hl, rIE
-	set LCD_STAT, [hl]
-
 	ldh a, [rSVBK]
 	push af
 
@@ -15,9 +12,6 @@ PlayBattleAnim:
 
 	pop af
 	ldh [rSVBK], a
-
-	ld hl, rIE
-	res LCD_STAT, [hl]
 	ret
 
 _PlayBattleAnim:

--- a/engine/battle_anims/bg_effects.asm
+++ b/engine/battle_anims/bg_effects.asm
@@ -900,6 +900,8 @@ BattleBGEffect_Whirlpool:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, LOW(rSCY)
 	ldh [hLCDCPointer], a
 	xor a
@@ -911,6 +913,8 @@ BattleBGEffect_Whirlpool:
 
 BattleBGEffect_StartWater:
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, $42
 	call BattleBGEffect_SetLCDStatCustoms1
 	jmp EndBattleBGEffect
@@ -957,6 +961,8 @@ BattleBGEffect_Psychic:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, $43
 	ldh [hLCDCPointer], a
 	xor a
@@ -989,6 +995,8 @@ BattleBGEffect_Teleport:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, $43
 	call BattleBGEffect_SetLCDStatCustoms1
 	lb de, 6, 5
@@ -1004,6 +1012,8 @@ BattleBGEffect_NightShade:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, $42
 	call BattleBGEffect_SetLCDStatCustoms1
 	ld hl, BG_EFFECT_STRUCT_PARAM
@@ -1025,6 +1035,8 @@ BattleBGEffect_DoubleTeam:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, $43
 	call BattleBGEffect_SetLCDStatCustoms1
 	ldh a, [hLYOverrideEnd]
@@ -1107,6 +1119,8 @@ BattleBGEffect_AcidArmor:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, $42
 	call BattleBGEffect_SetLCDStatCustoms1
 	ld hl, BG_EFFECT_STRUCT_PARAM
@@ -1165,6 +1179,8 @@ BattleBGEffect_Withdraw:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, $42
 	call BattleBGEffect_SetLCDStatCustoms1
 	ldh a, [hLYOverrideEnd]
@@ -1210,6 +1226,8 @@ BattleBGEffect_Dig:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, $42
 	call BattleBGEffect_SetLCDStatCustoms1
 	ldh a, [hLYOverrideEnd]
@@ -1272,6 +1290,8 @@ BattleBGEffect_Tackle:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, $43
 	call BattleBGEffect_SetLCDStatCustoms1
 	ldh a, [hLYOverrideEnd]
@@ -1299,6 +1319,8 @@ BattleBGEffect_BodySlam:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, $43
 	call BattleBGEffect_SetLCDStatCustoms2
 	ldh a, [hLYOverrideEnd]
@@ -1415,6 +1437,8 @@ BattleBGEffect_BetaPursuit:
 BGEffect2d_2f_zero:
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, $43
 	call BattleBGEffect_SetLCDStatCustoms1
 	ldh a, [hLYOverrideEnd]
@@ -1450,6 +1474,8 @@ BattleBGEffect_WobbleMon:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, $43
 	call BattleBGEffect_SetLCDStatCustoms1
 	ldh a, [hLYOverrideEnd]
@@ -1484,6 +1510,8 @@ BattleBGEffect_Flail:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, $43
 	call BattleBGEffect_SetLCDStatCustoms1
 	ldh a, [hLYOverrideEnd]
@@ -1534,6 +1562,8 @@ BattleBGEffect_WaveDeformMon:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, $43
 	jmp BattleBGEffect_SetLCDStatCustoms1
 
@@ -1569,6 +1599,8 @@ BattleBGEffect_BounceDown:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, $42
 	call BattleBGEffect_SetLCDStatCustoms2
 	ldh a, [hLYOverrideEnd]
@@ -1619,6 +1651,8 @@ BattleBGEffect_BetaSendOutMon1:
 	call BattleBGEffects_IncrementJumptable
 	ld a, $e4
 	call BattleBGEffects_SetLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, $47
 	call BattleBGEffect_SetLCDStatCustoms1
 	ldh a, [hLYOverrideEnd]
@@ -1709,6 +1743,8 @@ BattleBGEffect_BetaSendOutMon2:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, $43
 	call BattleBGEffect_SetLCDStatCustoms1
 	ld hl, BG_EFFECT_STRUCT_BATTLE_TURN
@@ -1805,6 +1841,8 @@ BattleBGEffect_VibrateMon:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, $43
 	call BattleBGEffect_SetLCDStatCustoms1
 	ldh a, [hLYOverrideEnd]
@@ -1845,6 +1883,8 @@ BattleBGEffect_WobblePlayer:
 .zero
 	call BattleBGEffects_IncrementJumptable
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, $43
 	ldh [hLCDCPointer], a
 	xor a
@@ -2220,6 +2260,8 @@ BattleBGEffect_GetNextDMGPal:
 	ret
 
 BattleBGEffects_ResetVideoHRAM:
+	ld hl, rIE
+	res LCD_STAT, [hl]
 	xor a
 	ldh [hLCDCPointer], a
 	ld a, %11100100
@@ -2284,6 +2326,8 @@ BattleAnim_ResetLCDStatCustom:
 	ldh [hLYOverrideStart], a
 	ldh [hLYOverrideEnd], a
 	call BattleBGEffects_ClearLYOverrides
+	ld hl, rIE
+	res LCD_STAT, [hl]
 	xor a
 	ldh [hLCDCPointer], a
 	jmp EndBattleBGEffect

--- a/engine/battle_anims/functions.asm
+++ b/engine/battle_anims/functions.asm
@@ -1107,6 +1107,8 @@ BattleAnimFunction_Surf:
 
 .zero
 	call BattleAnim_IncAnonJumptableIndex
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, LOW(rSCY)
 	ldh [hLCDCPointer], a
 	ld a, $58
@@ -1164,6 +1166,8 @@ BattleAnimFunction_Surf:
 	ld a, [hl]
 	cp $70
 	jr c, .move_down
+	ld hl, rIE
+	res LCD_STAT, [hl]
 	xor a
 	ldh [hLCDCPointer], a
 	ldh [hLYOverrideStart], a

--- a/engine/events/magnet_train.asm
+++ b/engine/events/magnet_train.asm
@@ -30,8 +30,6 @@ Special_MagnetTrain:
 	ld a, d
 	ld [wMagnetTrainPlayerSpriteInitX], a
 
-	ld hl, rIE
-	set LCD_STAT, [hl]
 	ldh a, [hSCX]
 	push af
 	ldh a, [hSCY]
@@ -62,6 +60,8 @@ Special_MagnetTrain:
 	pop af
 	ldh [hVBlank], a
 	call ClearBGPalettes
+	ld hl, rIE
+	res LCD_STAT, [hl]
 	xor a
 	ldh [hLCDCPointer], a
 	ldh [hLYOverrideStart], a
@@ -78,8 +78,6 @@ Special_MagnetTrain:
 	ldh [hSCY], a
 	pop af
 	ldh [hSCX], a
-	ld hl, rIE
-	res LCD_STAT, [hl]
 	xor a
 	ldh [hBGMapMode], a
 
@@ -240,6 +238,8 @@ MagnetTrain_InitLYOverrides:
 	ld bc, wLYOverridesBackupEnd - wLYOverridesBackup
 	ld a, [wMagnetTrainInitPosition]
 	rst ByteFill
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, LOW(rSCX)
 	ldh [hLCDCPointer], a
 	ret

--- a/engine/events/map_name_sign.asm
+++ b/engine/events/map_name_sign.asm
@@ -100,6 +100,8 @@ InitMapNameSign::
 	ld a, SCREEN_HEIGHT_PX
 	ldh [rWY], a
 	ldh [hWY], a
+	ld hl, rIE
+	res LCD_STAT, [hl]
 	xor a
 	ldh [hLCDCPointer], a
 	ret
@@ -198,6 +200,8 @@ PlaceMapNameSign::
 	ldh [hWY], a
 	sub SCREEN_HEIGHT_PX
 	ret nz
+	ld hl, rIE
+	res LCD_STAT, [hl]
 	ldh [hLCDCPointer], a
 	ret
 

--- a/engine/link/link.asm
+++ b/engine/link/link.asm
@@ -1833,7 +1833,7 @@ WaitForOtherPlayerToExit:
 	push af
 	xor a
 	ldh [rIF], a
-	ld a, 1 << SERIAL | 1 << LCD_STAT | 1 << VBLANK
+	ld a, 1 << SERIAL | 1 << VBLANK
 	ldh [rIE], a
 	pop af
 	ldh [rIF], a

--- a/engine/link/link.asm
+++ b/engine/link/link.asm
@@ -258,9 +258,6 @@ Gen2ToGen2LinkComms:
 	push af
 	xor a
 	ldh [rIF], a
-	ldh a, [rIE]
-	set LCD_STAT, a
-	ldh [rIE], a
 	pop af
 	ldh [rIF], a
 

--- a/engine/menus/intro_menu.asm
+++ b/engine/menus/intro_menu.asm
@@ -1070,8 +1070,6 @@ CrystalIntroSequence:
 	farcall CrystalIntro
 
 StartTitleScreen:
-	ld hl, rIE
-	set LCD_STAT, [hl]
 	ldh a, [rSVBK]
 	push af
 	ld a, $5
@@ -1089,12 +1087,12 @@ StartTitleScreen:
 	pop af
 	ldh [rSVBK], a
 
-	ld hl, rIE
-	res LCD_STAT, [hl]
 	ld hl, rLCDC
 	res rLCDC_SPRITE_SIZE, [hl]
 	call ClearScreen
 	call ApplyAttrAndTilemapInVBlank
+	ld hl, rIE
+	res LCD_STAT, [hl]
 	xor a
 	ldh [hLCDCPointer], a
 	ldh [hSCX], a
@@ -1181,6 +1179,8 @@ TitleScreenEntrance:
 	ld hl, wJumptableIndex
 	inc [hl]
 
+	ld hl, rIE
+	res LCD_STAT, [hl]
 	xor a
 	ldh [hLCDCPointer], a
 

--- a/engine/movie/credits.asm
+++ b/engine/movie/credits.asm
@@ -55,11 +55,11 @@ Credits::
 	xor a
 	rst ByteFill
 
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, LOW(rSCX)
 	ldh [hLCDCPointer], a
 
-	ld hl, rIE
-	set LCD_STAT, [hl]
 	call GetCreditsPalette
 	call SetPalettes
 	ldh a, [hVBlank]
@@ -86,11 +86,11 @@ Credits::
 
 .exit_credits
 	call ClearBGPalettes
+	ld hl, rIE
+	res LCD_STAT, [hl]
 	xor a
 	ldh [hLCDCPointer], a
 	ldh [hBGMapAddress], a
-	ld hl, rIE
-	res LCD_STAT, [hl]
 	pop af
 	ldh [hVBlank], a
 	pop af

--- a/engine/movie/intro.asm
+++ b/engine/movie/intro.asm
@@ -1,6 +1,4 @@
 CrystalIntro:
-	ld hl, rIE
-	set LCD_STAT, [hl]
 	ldh a, [rSVBK]
 	push af
 	ld a, 5
@@ -44,8 +42,6 @@ CrystalIntro:
 	ldh [hInMenu], a
 	pop af
 	ldh [rSVBK], a
-	ld hl, rIE
-	res LCD_STAT, [hl]
 	ret
 
 .InitRAMAddrs:
@@ -203,6 +199,8 @@ IntroScene5:
 	call Intro_ClearBGPals
 	call ClearSprites
 	call ClearTileMap
+	ld hl, rIE
+	res LCD_STAT, [hl]
 	xor a
 	ldh [hBGMapMode], a
 	ldh [hLCDCPointer], a
@@ -356,6 +354,8 @@ IntroScene8:
 
 IntroScene9:
 ; Set up the next scene (same bg).
+	ld hl, rIE
+	res LCD_STAT, [hl]
 	xor a
 	ldh [hLCDCPointer], a
 	call ClearSprites
@@ -420,6 +420,8 @@ IntroScene11:
 	call Intro_ClearBGPals
 	call ClearSprites
 	call ClearTileMap
+	ld hl, rIE
+	res LCD_STAT, [hl]
 	xor a
 	ldh [hBGMapMode], a
 	ldh [hLCDCPointer], a
@@ -1506,6 +1508,8 @@ Intro_ResetLYOverrides:
 
 	pop af
 	ldh [rSVBK], a
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, LOW(rSCX)
 	ldh [hLCDCPointer], a
 	ret

--- a/engine/movie/title.asm
+++ b/engine/movie/title.asm
@@ -166,6 +166,8 @@ endc
 	rst ByteFill
 
 ; Let LCD Stat know we're messing around with SCX
+	ld hl, rIE
+	set LCD_STAT, [hl]
 	ld a, rSCX - rJOYP
 	ldh [hLCDCPointer], a
 

--- a/engine/overworld/init_map.asm
+++ b/engine/overworld/init_map.asm
@@ -7,6 +7,8 @@ ReanchorBGMap_NoOAMUpdate::
 	ldh a, [hBGMapMode]
 	push af
 
+	ld hl, rIE
+	res LCD_STAT, [hl]
 	xor a
 	ldh [hBGMapMode], a
 	ldh [hLCDCPointer], a
@@ -68,6 +70,8 @@ ReanchorBGMap_NoOAMUpdate_NoDelay::
 	ldh a, [hBGMapMode]
 	push af
 
+	ld hl, rIE
+	res LCD_STAT, [hl]
 	xor a
 	ldh [hBGMapMode], a
 	ldh [hLCDCPointer], a

--- a/home/lcd.asm
+++ b/home/lcd.asm
@@ -1,8 +1,4 @@
 LCDGeneric::
-	ldh a, [hLCDCPointer]
-	and a
-	jr z, .done
-
 ; At this point it's assumed we're in WRAM bank 5!
 	ldh a, [rLY]
 	cp SCREEN_HEIGHT_PX

--- a/home/serial.asm
+++ b/home/serial.asm
@@ -145,7 +145,7 @@ Serial_ExchangeByte::
 
 .doNotIncrementTimeoutCounter
 	ldh a, [rIE]
-	and 1 << SERIAL | 1 << TIMER | 1 << LCD_STAT | 1 << VBLANK
+	and 1 << SERIAL | 1 << TIMER | 1 << VBLANK
 	cp 1 << SERIAL
 	jr nz, .loop
 	ld a, [wLinkByteTimeout]
@@ -169,7 +169,7 @@ Serial_ExchangeByte::
 	xor a
 	ldh [hSerialReceivedNewData], a
 	ldh a, [rIE]
-	and 1 << SERIAL | 1 << TIMER | 1 << LCD_STAT | 1 << VBLANK
+	and 1 << SERIAL | 1 << TIMER | 1 << VBLANK
 	sub 1 << SERIAL
 	jr nz, .skipReloadingTimeoutCounter2
 
@@ -200,7 +200,7 @@ Serial_ExchangeByte::
 
 .done
 	ldh a, [rIE]
-	and 1 << SERIAL | 1 << TIMER | 1 << LCD_STAT | 1 << VBLANK
+	and 1 << SERIAL | 1 << TIMER | 1 << VBLANK
 	cp 1 << SERIAL
 	ld a, SERIAL_NO_DATA_BYTE
 	ret z

--- a/home/vblank.asm
+++ b/home/vblank.asm
@@ -328,9 +328,6 @@ VBlank1::
 
 	xor a
 	ldh [rIF], a
-	ld a, 1 << LCD_STAT
-	ldh [rIE], a
-	ldh [rIF], a
 
 	ei
 	call VBlankUpdateSound
@@ -379,9 +376,6 @@ VBlank5::
 	ldh [rIF], a
 	ldh a, [rIE]
 	push af
-	ld a, 1 << LCD_STAT
-	ldh [rIE], a
-	ldh [rIF], a
 
 	ei
 	call VBlankUpdateSound


### PR DESCRIPTION
The idea is to only enable LCD_STAT when its actually needed. This can be found by enabling it whenever `hLCDCPointer` has a non-zero value... and disabling it when it is set back to zero.