### PR TITLE
Fix lagging tail, quick claw, and quick draw

### DIFF
--- a/home/battle.asm
+++ b/home/battle.asm
@@ -762,7 +762,7 @@ CheckMoveSpeed::
 .quick_claw
 	ld a, 100
 	call BattleRandomRange
-	cp 20
+	cp c
 	pop de
 	ret nc
 .activate_item

--- a/home/battle.asm
+++ b/home/battle.asm
@@ -726,7 +726,7 @@ CheckMoveSpeed::
 	ld b, a
 	farcall BufferAbility
 	ld a, 100
-	call RandomRange
+	call BattleRandomRange
 	cp 30
 	jr nc, .quick_draw_done
 
@@ -762,7 +762,7 @@ CheckMoveSpeed::
 .quick_claw
 	ld a, 100
 	call BattleRandomRange
-	cp c
+	cp 20
 	pop de
 	ret nc
 .activate_item

--- a/home/battle.asm
+++ b/home/battle.asm
@@ -735,7 +735,7 @@ CheckMoveSpeed::
 	ld hl, BattleText_UserItemLetItMoveFirst
 	call StdBattleTextbox
 	farcall EnableAnimations
-	jr .set_priority
+	jr .go_first
 
 .quick_draw_done
 	predef GetUserItemAfterUnnerve
@@ -745,15 +745,8 @@ CheckMoveSpeed::
 	cp HELD_CUSTAP_BERRY
 	jr z, .custap_berry
 	cp HELD_LAGGING_TAIL
+	jr z, .go_last
 	pop de
-	ret nz
-
-	; Lagging tail gives the foe priority
-	ldh a, [hBattleTurn]
-	and a
-	ret nz
-	dec d
-	dec d
 	ret
 
 .custap_berry
@@ -779,10 +772,16 @@ CheckMoveSpeed::
 	call GetCurItemName
 	ld hl, BattleText_UserItemLetItMoveFirst
 	call StdBattleTextbox
+.go_first
+	ldh a, [hBattleTurn]
+	jr .set_priority
+.go_last
+	ldh a, [hBattleTurn]
+	; Give the foe priority
+	xor 1
 .set_priority
 	pop de
 	inc d
-	ldh a, [hBattleTurn]
 	and a
 	ret z
 	dec d


### PR DESCRIPTION
Lagging tail was missing an `inc d` like `.set_priority` has to properly do the +1/-1 based on battle turn, instead doing +0/-2, which meant lagging tail did not work for enemy trainers. Further, a player with lagging tail and an enemy with quick claw could create -3, which is not considered part of the valid range for `d` in this routine. `.set_priority` was changed to be used for both increasing and decreasing priority called from the nicely named `.go_first` and `.go_last` labels.

I initially discovered this when implementing the Stall ability, the `.go_first` `.go_last` labels make that slightly more reasonable, and it makes the code here more readable, so I decided to bundle it with the lagging tail fix.