### PR TITLE
Bugfix: Tackle animation sprite limit

### DIFF
--- a/data/moves/animations.asm
+++ b/data/moves/animations.asm
@@ -2351,7 +2351,7 @@ BattleAnim_ZenHeadbutt:
 
 BattleAnim_Tackle:
 	anim_1gfx ANIM_GFX_HIT
-	anim_call BattleAnim_TargetObj_2Row
+	anim_call BattleAnim_TargetObj_1Row
 	anim_bgeffect ANIM_BG_TACKLE, $0, $1, $0
 	anim_wait 4
 	anim_sound 0, 1, SFX_TACKLE


### PR DESCRIPTION
As discovered by a few individuals and finally confirmed while working on CSE with SourApple, 8bitZeta, and Monstarules. The vanilla pokecrystal tackle animation runs into a sprite limit due to an unneeded second row being copied from the enemy's "feet" to sprites. Pokemon Gold and Silver only copied a single row, and didn't have this problem. Unsure why Crystal decided to do this.

See the below as an example of what this looks like before this fix:

![image](https://github.com/Rangi42/polishedcrystal/assets/6394873/61faf7ef-30c8-4271-8be5-d5e41dbc8446)
