### PR TITLE
Fix Bug Catching Contest End Early FadeInPalettes

### DIFF
--- a/maps/Route36NationalParkGate.asm
+++ b/maps/Route36NationalParkGate.asm
@@ -96,12 +96,18 @@ Route36NationalParkGateLeftTheContestEarly:
 	closetext
 	special Special_FadeBlackQuickly
 	special Special_ReloadSpritesNoPalettes
+	callasm DisableDynPalUpdates
 	scall .CopyContestants
 	disappear ROUTE36NATIONALPARKGATE_OFFICER1
 	appear ROUTE36NATIONALPARKGATE_OFFICER2
 	applymovement PLAYER, Route36NationalParkGatePlayerWaitWithContestantsMovement
 	pause 15
-	special Special_FadeInQuickly
+	callasm SetBlackObjectPals
+	callasm ClearSavedObjPals
+	callasm EnableDynPalUpdatesNoApply
+	callasm _UpdateSprites
+	callasm DelayFrame
+	callasm FadeInPalettes
 	jumpstd bugcontestresults
 
 .GoBackToContest:


### PR DESCRIPTION
>After the Bug Catching Contest is over due to the player opting to end it early, the BG fades in from black, but the NPC sprites do not, meaning a second or two where the NPCs are all standing on a black void before the BG fades in

This PR resolves the above. Related to #905 