### PR TITLE
[Refactor] Move RockItems table out of "engine/" and into "data/"

### DIFF
--- a/data/wild/treemons.asm
+++ b/data/wild/treemons.asm
@@ -128,3 +128,20 @@ TreeMonSet_Rock:
 	tree_mon 25, GEODUDE,    15
 	tree_mon  5, SHUCKLE,    15
 	db -1
+
+RockItems:
+	db 1, HELIX_FOSSIL
+	db 1, DOME_FOSSIL
+	db 1, OLD_AMBER
+	db 1, BIG_NUGGET
+	db 2, RARE_BONE
+	db 4, NUGGET
+	db 6, STAR_PIECE
+	db 12, BIG_PEARL
+	db 18, STARDUST
+	db 24, HARD_STONE
+	db 24, SOFT_SAND
+	db 48, PEARL
+	db 64, BRICK_PIECE
+	db 48, NO_ITEM
+	db -1

--- a/engine/events/treemons.asm
+++ b/engine/events/treemons.asm
@@ -94,7 +94,7 @@ GetWings:
 	ret
 
 RockItemEncounter:
-	ld hl, .RockItems
+	ld hl, RockItems
 	call Random
 .loop
 	sub [hl]
@@ -111,23 +111,6 @@ RockItemEncounter:
 .done
 	ldh [hScriptVar], a
 	ret
-
-.RockItems:
-	db 1, HELIX_FOSSIL
-	db 1, DOME_FOSSIL
-	db 1, OLD_AMBER
-	db 1, BIG_NUGGET
-	db 2, RARE_BONE
-	db 4, NUGGET
-	db 6, STAR_PIECE
-	db 12, BIG_PEARL
-	db 18, STARDUST
-	db 24, HARD_STONE
-	db 24, SOFT_SAND
-	db 48, PEARL
-	db 64, BRICK_PIECE
-	db 48, NO_ITEM
-	db -1
 
 TreeMonEncounter:
 	xor a


### PR DESCRIPTION
Just a small refactor to move a data table out of engine code and into data code; improving overall code organization and readability.

This makes `RockItems` similar to `FishItems` (which is located in `data/wild/fish.asm`) by moving the `RockItems` table out of `engine/events/treemons.asm` and into `data/wild/treemons.asm`.