### PR TITLE
Allow holding B on cycling road to brake the bike

### DIFF
--- a/engine/overworld/player_movement.asm
+++ b/engine/overworld/player_movement.asm
@@ -27,6 +27,10 @@ DoPlayerMovement::
 	ret nz
 
 	ld a, c
+	and B_BUTTON ; holding b will brake
+	ret nz
+
+	ld a, c
 	or D_DOWN
 	ld [wCurInput], a
 	ret


### PR DESCRIPTION
Acts similar to the Gen I / Gen III remake behavior on Cycling Road. Holding B will brake the bike while going downhill on Cycling Road.