### PR TITLE
Fix typo

### DIFF
--- a/maps/Route16West.asm
+++ b/maps/Route16West.asm
@@ -86,7 +86,7 @@ GenericTrainerCosplayerKuroko:
 GenericTrainerCooltrainerfSera:
 	generictrainer COOLTRAINERF, SERA, EVENT_BEAT_COOLTRAINERF_SERA, .SeenText, .BeatenText
 
-	text "I've gone out as a"
+	text "I've gone out as"
 	line "a Cosplayer, but"
 
 	para "an Ace Trainer's"


### PR DESCRIPTION
"A" is said twice in a row.