### PR TITLE
Fix grotto exit on route36 player standing on grass

### DIFF
--- a/data/maps/setup_script_pointers.asm
+++ b/data/maps/setup_script_pointers.asm
@@ -59,3 +59,4 @@ MapSetupCommands:
 	add_mapsetup SetCurrentWeather ; 34
 	add_mapsetup MapConnOWFadePalettesInit ; 35
 	add_mapsetup LoadMapObjects_Connection ; 36
+	add_mapsetup GrottoUpdatePlayerTallGrassFlags ; 37

--- a/data/maps/setup_scripts.asm
+++ b/data/maps/setup_scripts.asm
@@ -43,6 +43,7 @@ MapSetupScript_Warp:
 	mapsetup DecompressMetatiles
 	mapsetup LoadMapTimeOfDay
 	mapsetup LoadMapObjects
+	mapsetup GrottoUpdatePlayerTallGrassFlags
 	mapsetup EnableLCD
 	mapsetup LoadMapPalettes
 	mapsetup SpawnInFacingDown
@@ -130,6 +131,7 @@ MapSetupScript_Train:
 	mapsetup FadeOutMapMusic
 	mapsetup EnableLCD
 	mapsetup LoadMapObjects
+	mapsetup GrottoUpdatePlayerTallGrassFlags
 	mapsetup LoadMapPalettes
 	mapsetup EnableDynPalUpdatesNoApply
 	mapsetup RefreshMapSprites

--- a/engine/overworld/map_objects.asm
+++ b/engine/overworld/map_objects.asm
@@ -245,6 +245,19 @@ CopyCurCoordsToNextCoords:
 	ld [hl], a
 	ret
 
+GrottoUpdatePlayerTallGrassFlags::
+	ld bc, wPlayerStruct
+	ld hl, OBJECT_MAP_X
+	add hl, bc
+	ld d, [hl]
+	ld hl, OBJECT_MAP_Y
+	add hl, bc
+	ld e, [hl]
+	push bc
+	call GetCoordTileCollision
+	pop bc
+	jr SetTallGrassFlags
+
 UpdateTallGrassFlags:
 	ld hl, OBJECT_FLAGS2
 	add hl, bc


### PR DESCRIPTION
Player will no longer be standing "above" the grass when exiting the grotto into grass. If there are other grottos that may exit onto grass, you simply need to call `UpdatePlayerTallGrassFlags` from the maps OBJECT callback.

Reference #905