### PR TITLE
Change Disarm Voice accuracy to display correctly

### DIFF
--- a/data/moves/moves.asm
+++ b/data/moves/moves.asm
@@ -334,6 +334,6 @@ endc
 	move DARK_PULSE,      EFFECT_FLINCH_HIT,         80, DARK,      100, 15,  20, SPECIAL
 	move MOONBLAST,       EFFECT_SP_ATK_DOWN_HIT,    95, FAIRY,     100, 15,  30, SPECIAL
 	move PLAY_ROUGH,      EFFECT_ATTACK_DOWN_HIT,    90, FAIRY,      90, 10,  10, PHYSICAL
-	move DISARM_VOICE,    EFFECT_ALWAYS_HIT,         40, FAIRY,     100, 15,   0, SPECIAL
+	move DISARM_VOICE,    EFFECT_ALWAYS_HIT,         40, FAIRY,      -1, 15,   0, SPECIAL
 	move STRUGGLE,        EFFECT_RECOIL_HIT,         50, UNKNOWN_T,  -1,  1,   0, PHYSICAL
 	assert_table_length NUM_ATTACKS


### PR DESCRIPTION
Change accuracy value from 100% to ---% so Disarm Voice displays similar to other "always hit" moves.