### PR TITLE
Fix Stats screen at max volume

### DIFF
--- a/engine/pokemon/mon_menu.asm
+++ b/engine/pokemon/mon_menu.asm
@@ -735,9 +735,11 @@ _OpenPartyStats:
 	predef StatsScreenInit
 	; This ensures that MaxVolume works as it should if we're in the middle of
 	; playing a cry.
-	ld a, $77
+	ld a, MAX_VOLUME
 	ld [wLastVolume], a
 	call MaxVolume
+	xor a
+	ld [wLastVolume], a
 	call ExitMenu
 	xor a
 	ret


### PR DESCRIPTION
I opened this as a PR mainly because I don't fully understand why the this fixes the problem.. but it does fix it.  
  
This was fixed in CSE.. see the issue there:  
reference fellowship-of-the-roms/CrystalShireEngine#27  
  
Furthermore, this is _probably_ also related to Darsh' comment here: [https://github.com/Rangi42/polishedcrystal/issues/857#issuecomment-1826199307](https://github.com/Rangi42/polishedcrystal/issues/857#issuecomment-1826199307)  
  
\>I do think there's something wrong with the sound engine. A Pokemon's cry in the status screen isn't always going to have consistent volume (Voltorb is a good example of this). Not clear what's causing the issue.