### PR TITLE
Shift Nuzlocke Icon Left, Don't skip caught icon

### DIFF
--- a/engine/battle/trainer_huds.asm
+++ b/engine/battle/trainer_huds.asm
@@ -126,7 +126,10 @@ DrawEnemyHUDBorder:
 	dec a
 	ret nz
 	call CheckNuzlockeFlags
-	jr c, .nuzlocke
+	jr nc, .no_nuzlocke
+	hlcoord 0, 1
+	ld [hl], "<NONO>"
+.no_nuzlocke
 	ld a, [wOTPartyMon1Species]
 	ld c, a
 	ld a, [wOTPartyMon1Form]
@@ -135,11 +138,6 @@ DrawEnemyHUDBorder:
 	ret z
 	hlcoord 1, 1
 	ld [hl], "<BALL>"
-	ret
-
-.nuzlocke
-	hlcoord 1, 1
-	ld [hl], "<NONO>"
 	ret
 
 PlaceHUDBorderTiles:

--- a/engine/gfx/cgb_layouts.asm
+++ b/engine/gfx/cgb_layouts.asm
@@ -282,6 +282,7 @@ _CGB_FinishBattleScreenLayout:
 	call FillBoxWithByte
 
 	ld a, PAL_BATTLE_BG_EXP_GENDER
+	ldcoord_a 0, 1, wAttrmap
 	ldcoord_a 1, 1, wAttrmap
 	ldcoord_a 8, 1, wAttrmap
 	ldcoord_a 18, 8, wAttrmap


### PR DESCRIPTION
- Shift Nuzlocke icon left a square.
- Don't skip the caught icon is the Nuzlocke icon is showing

We'd probably have to re-arrange other things if we don't want to shift this far left. See how it looks now below.

![image](https://github.com/user-attachments/assets/21d2759c-eeb1-4c9c-87c2-0f5f38ccb686)

It being shifted left doesn't look bad when the caught icon is *also* showing.. but when its just the nuzlocke icon, it can look a little off.. I could adjust the code to only shift the nuzlocke icon if the caught icon *isn't* showing. Let me know what you think.