### PR TITLE
Add Event Flag Checksums

### DIFF
--- a/constants/ram_constants.asm
+++ b/constants/ram_constants.asm
@@ -513,3 +513,8 @@ DEF NO_DYN_PAL_APPLY EQU (1 << NO_DYN_PAL_APPLY_ONCE_F) | (1 << NO_DYN_PAL_APPLY
 ; wMapSetupFlags
 	const_def
 	const MAPSETUP_CONNECTION_F ; 0
+
+; wEventChecksumFlags
+	const_def
+	const EVENT_CHECKSUM_FULL_DONE_F              ; 0
+	const EVENT_CHECKSUM_VBLANK_ROUTINE_RUNNING_F ; 1

--- a/engine/events/event_checksums.asm
+++ b/engine/events/event_checksums.asm
@@ -1,0 +1,108 @@
+CheckEventChecksumRecalculate:
+	ld hl, wEventChecksumFlags
+	bit EVENT_CHECKSUM_FULL_DONE_F, [hl]
+	ret nz
+; fallthrough
+RecalculateEventChecksum::
+	ld hl, wEventChecksumFlags
+	res EVENT_CHECKSUM_VBLANK_ROUTINE_RUNNING_F, [hl]
+	res EVENT_CHECKSUM_FULL_DONE_F, [hl]
+	call CalculateEventChecksum
+	ld [wEventChecksum], a
+	call ResetVBlankEventChecksum
+	ld hl, wEventChecksumFlags
+	set EVENT_CHECKSUM_VBLANK_ROUTINE_RUNNING_F, [hl]
+	set EVENT_CHECKSUM_FULL_DONE_F, [hl]
+	ret
+
+CalculateEventChecksum:
+	push hl
+	push de
+	push bc
+	ld hl, wEventFlags
+	ld bc, wEventFlagsEnd - wEventFlags
+	xor a
+	ld d, a
+.loop
+	ld a, [hli]
+	add d
+	ld d, a
+	dec bc
+	ld a, b
+	or c
+	jr nz, .loop
+	ld a, d
+	jmp PopBCDEHL
+
+VBlankEventChecksum:
+	push hl
+	push de
+	push bc
+
+	ldh a, [rSVBK]
+	push af
+	ld a, BANK(wEventChecksumFlags)
+	ld [rSVBK], a
+
+	ld hl, wEventChecksumFlags
+	bit EVENT_CHECKSUM_VBLANK_ROUTINE_RUNNING_F, [hl]
+	jr z, .done
+
+	ld hl, wEventChecksumCurAddress
+	ld a, [hli]
+	ld h, [hl]
+	ld l, a
+	or h
+	call z, ResetVBlankEventChecksum ; If the address is 0, reset the routine
+
+	ld a, [wEventChecksumCurSummation]
+	ld b, a
+	ld a, [hli]
+	add b
+	ld c, a
+
+	ld a, h
+	cp HIGH(wEventFlagsEnd)
+	jr nz, .store_done
+	ld a, l
+	cp LOW(wEventFlagsEnd)
+	jr nz, .store_done
+	ld a, [wEventChecksum]
+	cp c
+	jr nz, .error_checksum
+	ld hl, wEventFlags
+	ld c, 0
+.store_done
+	ld a, l
+	ld [wEventChecksumCurAddress], a
+	ld a, h
+	ld [wEventChecksumCurAddress + 1], a
+	ld a, c
+	ld [wEventChecksumCurSummation], a
+
+.done
+	pop af
+	ld [rSVBK], a
+	jmp PopBCDEHL
+
+.error_checksum
+	ld hl, wEventChecksumFlags
+	res EVENT_CHECKSUM_VBLANK_ROUTINE_RUNNING_F, [hl]
+	pop af
+	ld [rSVBK], a
+	pop bc
+	pop de
+	pop hl
+	ld a, ERR_CHECKSUM_MISMATCH
+	jmp Crash
+
+ResetVBlankEventChecksum:
+	push hl
+	ld a, LOW(wEventFlags)
+	ld [wEventChecksumCurAddress], a
+	ld a, HIGH(wEventFlags)
+	ld [wEventChecksumCurAddress + 1], a
+	xor a
+	ld [wEventChecksumCurSummation], a
+	pop hl
+	ret

--- a/engine/events/initialize_events.asm
+++ b/engine/events/initialize_events.asm
@@ -1,5 +1,8 @@
 InitializeEvents:
 ; initialize events
+	ld hl, wEventChecksumFlags
+	res EVENT_CHECKSUM_FULL_DONE_F, [hl]
+	res EVENT_CHECKSUM_VBLANK_ROUTINE_RUNNING_F, [hl]
 	ld hl, InitialEvents
 .events_loop
 	call .GetDWInDE
@@ -10,6 +13,7 @@ InitializeEvents:
 	pop hl
 	jr .events_loop
 .events_done
+	farcall RecalculateEventChecksum
 
 ; initialize engine flags
 	ld hl, InitialEngineFlags

--- a/engine/menus/intro_menu.asm
+++ b/engine/menus/intro_menu.asm
@@ -48,6 +48,7 @@ NewGamePlus:
 	ldh [hBGMapMode], a
 	farcall TryLoadSaveFile
 	ret c
+	farcall CheckEventChecksumRecalculate
 	jr _NewGame_FinishSetup
 
 NewGame:
@@ -314,6 +315,7 @@ LoadOrRegenerateLuckyIDNumber:
 Continue:
 	farcall TryLoadSaveFile
 	ret c
+	farcall CheckEventChecksumRecalculate
 
 	call LoadStandardMenuHeader
 	call DisplaySaveInfoOnContinue

--- a/engine/overworld/warp_connection.asm
+++ b/engine/overworld/warp_connection.asm
@@ -24,9 +24,12 @@ ResetOWMapState:
 	ld hl, wStatusFlags
 	res 2, [hl]
 .keep_flash
-	xor a
 ; reset map buffer event flags
+	ld hl, wEventChecksumFlags
+	res EVENT_CHECKSUM_VBLANK_ROUTINE_RUNNING_F, [hl]
+	xor a
 	ld [wEventFlags], a
+	farcall RecalculateEventChecksum
 ; reset ow state
 	ld hl, wOWState
 	ld [hli], a

--- a/home/flag.asm
+++ b/home/flag.asm
@@ -1,5 +1,15 @@
 EventFlagAction::
 	ld hl, wEventFlags
+	ld a, b
+	cp CHECK_FLAG
+	jr z, FlagAction
+	push hl
+	ld hl, wEventChecksumFlags
+	res EVENT_CHECKSUM_VBLANK_ROUTINE_RUNNING_F, [hl]
+	pop hl
+	call FlagAction
+	farjp RecalculateEventChecksum
+
 FlagAction::
 ; Perform action b on bit de in flag array hl.
 

--- a/home/vblank.asm
+++ b/home/vblank.asm
@@ -154,6 +154,8 @@ VBlank0::
 	call PushOAM
 	; vblank-sensitive operations are done
 
+	farcall VBlankEventChecksum
+
 	; inc frame counter
 	ld hl, hVBlankCounter
 	inc [hl]

--- a/macros/code.asm
+++ b/macros/code.asm
@@ -52,9 +52,21 @@ DEF bcpixel EQUS "ldpixel bc,"
 
 ; Design patterns
 
-DEF eventflagset   EQUS "flagset wEventFlags,"
-DEF eventflagreset EQUS "flagreset wEventFlags,"
 DEF eventflagcheck EQUS "flagcheck wEventFlags,"
+
+MACRO eventflagset
+	ld hl, wEventChecksumFlags
+	res EVENT_CHECKSUM_VBLANK_ROUTINE_RUNNING_F, [hl]
+	flagset wEventFlags, \1
+	farcall RecalculateEventChecksum
+ENDM
+
+MACRO eventflagreset
+	ld hl, wEventChecksumFlags
+	res EVENT_CHECKSUM_VBLANK_ROUTINE_RUNNING_F, [hl]
+	flagreset wEventFlags, \1
+	farcall RecalculateEventChecksum
+ENDM
 
 MACRO flagset
 	ld hl, \1 + (\2 >> 3)

--- a/main.asm
+++ b/main.asm
@@ -727,3 +727,7 @@ SECTION "Weather System", ROMX
 
 INCLUDE "engine/overworld/weather.asm"
 INCLUDE "engine/events/weather.asm"
+
+SECTION "Event Checksums", ROMX
+
+INCLUDE "engine/events/event_checksums.asm"

--- a/ram/wramx.asm
+++ b/ram/wramx.asm
@@ -1165,6 +1165,7 @@ wParryFightCount::   db
 wErinFightCount::    db
 
 wEventFlags:: flag_array NUM_EVENTS
+wEventFlagsEnd::
 
 wCurBox:: db
 
@@ -1179,7 +1180,12 @@ wNeededPalIndex:: db
 
 wEmotePal:: db
 
-	ds 70 ; unused
+	ds 65 ; unused
+
+wEventChecksum:: db
+wEventChecksumFlags:: db
+wEventChecksumCurAddress:: dw
+wEventChecksumCurSummation:: db
 
 wWingAmounts::
 wHealthWingAmount:: dw


### PR DESCRIPTION
Example of an active event checksum.

- Calculates the summation checksum (modulo 256) of the entire event space and stores it if not done so already.
- Recalculates the checksum when we modify any event flag.
- VBlank routine calculates one byte at a time (~5 secs total to do all event bytes) and then crashes on mismatch.