### PR TITLE
Add "Learned" to teach TM/HM screen

### DIFF
--- a/engine/pokemon/party_menu.asm
+++ b/engine/pokemon/party_menu.asm
@@ -852,7 +852,7 @@ PlacePartyMonTMHMCompatibility:
 	pop hl
 	pop hl
 
-	call .PlaceLearned
+	ld de, .string_learned
 	rst PlaceString
 	jr .next
 
@@ -874,10 +874,6 @@ PlacePartyMonTMHMCompatibility:
 
 .string_not_able
 	db "Not able@"
-
-.PlaceLearned:
-	ld de, .string_learned
-	ret
 
 .string_learned
 	db "Learned@"

--- a/engine/pokemon/party_menu.asm
+++ b/engine/pokemon/party_menu.asm
@@ -793,7 +793,7 @@ PlacePartyMonTMHMCompatibility:
 	ret z
 	ld c, a
 	ld b, 0
-	ld a, 0
+	xor a
 	ld [wCurPartyMon], a
 	hlcoord 12, 2
 .loop


### PR DESCRIPTION
Addresses enhancement issue: #988 

Adds same logic as [KnowsMove subroutine](https://github.com/Rangi42/polishedcrystal/blob/9bit/engine/items/tmhm2.asm#L585-L604) to the party menu's `PlacePartyMonTMHMCompatibility` subroutine to check whether a Pokemon already knows a move before placing the "able" or "not able" text next to the Pokemon's name. 

## Notes / Questons:
- This may not be the cleanest implementation! Let me know and I'll try and address.
- Is there any other place we'll need to implement this? I didn't see anywhere else while I was looking around the code.
- I needed to manually to manually increment the `wCurPartyMon` variable, or else the knows move logic kept comparing against the last Pokemon in the party. Is this necessary / is there a better way to do this?
- I didn't call the `KnowsMove` subroutine because it makes a call to `PrintText` if the move is already known

## Screenshot:
<img width="322" alt="image" src="https://github.com/user-attachments/assets/5dc5e592-1f1e-4491-9c1d-cf428cb60a4f" />
