### PR TITLE
Rename "items" comment to "held items" in base stats files

### DIFF
--- a/data/pokemon/base_stats/goldeen.asm
+++ b/data/pokemon/base_stats/goldeen.asm
@@ -4,7 +4,7 @@
 	db WATER, WATER ; type
 	db 225 ; catch rate
 	db 111 ; base exp
-	db NO_ITEM, NO_ITEM ; items
+	db NO_ITEM, NO_ITEM ; held items
 	dn GENDER_F50, HATCH_MEDIUM_FAST ; gender ratio
 
 	abilities_for GOLDEEN, SWIFT_SWIM, WATER_VEIL, LIGHTNING_ROD

--- a/data/pokemon/base_stats/seaking.asm
+++ b/data/pokemon/base_stats/seaking.asm
@@ -13,7 +13,7 @@ if DEF(FAITHFUL)
 else
 	db 180 ; base exp
 endc
-	db NO_ITEM, NO_ITEM ; items
+	db NO_ITEM, NO_ITEM ; held items
 	dn GENDER_F50, HATCH_MEDIUM_FAST ; gender ratio
 
 	abilities_for SEAKING, SWIFT_SWIM, WATER_VEIL, LIGHTNING_ROD

--- a/data/pokemon/base_stats/smoochum.asm
+++ b/data/pokemon/base_stats/smoochum.asm
@@ -4,7 +4,7 @@
 	db ICE, PSYCHIC ; type
 	db 45 ; catch rate
 	db 87 ; base exp
-	db ALWAYS_ITEM_2, ASPEAR_BERRY ; items
+	db ALWAYS_ITEM_2, ASPEAR_BERRY ; held items
 	dn GENDER_F100, HATCH_MEDIUM_SLOW ; gender ratio, step cycles to hatch
 
 if DEF(FAITHFUL)


### PR DESCRIPTION
Only Goldeen, Seaking, and Smoochum were commented differently for some reason. This is just a cosmetic difference I noticed while parsing the files for the wiki.