### PR TITLE
Decompress radio text before normal radio logic

### DIFF
--- a/engine/pokegear/radio.asm
+++ b/engine/pokegear/radio.asm
@@ -1803,10 +1803,15 @@ CopyRadioTextToRAM:
 	ld a, [hl]
 	cp "<FAR>"
 	jmp z, FarCopyRadioText
-	ld de, wRadioText
+	ld de, wRadioCompressedText
 	ld bc, SCREEN_WIDTH * 2
 	rst CopyBytes
-	ret
+	ld hl, wRadioCompressedText
+	ld de, wRadioText
+	ld a, [hli]
+	ld [de], a
+	inc de
+	jmp DecompressStringToRAM
 
 StartRadioStation:
 	ld a, [wNumRadioLinesPrinted]

--- a/home/string.asm
+++ b/home/string.asm
@@ -42,9 +42,15 @@ FarCopyRadioText::
 	rst Bankswitch
 	ld l, e
 	ld h, d
-	ld de, wRadioText
-	ld bc, 2 * SCREEN_WIDTH
+	ld de, wRadioCompressedText
+	ld bc, SCREEN_WIDTH * 2
 	rst CopyBytes
+	ld hl, wRadioCompressedText
+	ld de, wRadioText
+	ld a, [hli]
+	ld [de], a
+	inc de
+	call DecompressStringToRAM
 	pop af
 	rst Bankswitch
 	ret

--- a/home/text.asm
+++ b/home/text.asm
@@ -702,33 +702,8 @@ DecompressString::
 
 	push de ; push current coords
 
-	xor a ; start at node $00
-.tree_loop
-	; "c = [hli]" when b reaches 0, then carry = next bit from c
-	dec b
-	jr nz, .no_reload
-	ld c, [hl] ; no-optimize b|c|d|e = *hl++|*hl--
-	inc hl
-	ld b, 8
-.no_reload
-	sla c
-	; de = TextCompressionHuffmanTree[node=a][branch=carry]
-	adc a
-	add LOW(TextCompressionHuffmanTree)
-	ld e, a
-	adc HIGH(TextCompressionHuffmanTree)
-	sub e
-	ld d, a
-	; keep traversing the tree until a leaf node ($7f and above)
-	ld a, [de]
-	cp $7f
-	jr c, .tree_loop
+	call ReadHuffmanChar
 
-	; leaf node IDs $ec-$fb correspond to characters $4d-$5c
-	cp $ec
-	jr c, .got_char
-	sub $ec - $4d
-.got_char
 	; buffer character for printing
 	ldh [hCompressedTextBuffer], a
 
@@ -801,4 +776,86 @@ DecompressString::
 	ld l, a
 	ldh a, [hPlaceStringCoords+1]
 	ld h, a
+	ret
+
+DecompressStringToRAM::
+; Inputs:
+; HL = Address of compressed string
+; DE = Destination address
+
+	ld a, [hl]
+	cp "<CTXT>"
+	jr nz, .not_compressed
+
+	inc hl ; skip "<CTXT>"
+
+	ld b, 1 ; start with no bits to read a byte right away
+.character_loop
+
+	push de
+	call ReadHuffmanChar
+	pop de
+	; check for characters that signal end of compression
+	; (same ones that finish PlaceString)
+	cp "<DONE>"
+	jr z, .end
+	cp "<PROMPT>"
+	jr z, .end
+	cp "@"
+	jr z, .end
+
+	; Store decompressed char to WRAM and advance
+	ld [de], a
+	inc de
+	jr .character_loop
+
+.end
+	; Append terminator
+	ld [de], a
+	ret
+
+.not_compressed
+	; copy until terminator
+.loop
+	ld a, [hli]
+	cp "<DONE>"
+	jr z, .end2
+	cp "<PROMPT>"
+	jr z, .end2
+	cp "@"
+	jr z, .end2
+	ld [de], a
+	inc de
+	jr .loop
+.end2
+	ld [de], a
+	ret
+
+ReadHuffmanChar:
+	xor a ; start at node $00
+.tree_loop
+	; "c = [hli]" when b reaches 0, then carry = next bit from c
+	dec b
+	jr nz, .no_reload
+	ld c, [hl] ; no-optimize b|c|d|e = *hl++|*hl--
+	inc hl
+	ld b, 8
+.no_reload
+	sla c
+	; de = TextCompressionHuffmanTree[node=a][branch=carry]
+	adc a
+	add LOW(TextCompressionHuffmanTree)
+	ld e, a
+	adc HIGH(TextCompressionHuffmanTree)
+	sub e
+	ld d, a
+	; keep traversing the tree until a leaf node ($7f and above)
+	ld a, [de]
+	cp $7f
+	jr c, .tree_loop
+
+	; leaf node IDs $ec-$fb correspond to characters $4d-$5c
+	cp $ec
+	ret c
+	sub $ec - $4d
 	ret

--- a/ram/wram0.asm
+++ b/ram/wram0.asm
@@ -786,7 +786,9 @@ wNamingScreenKeyboardWidth:: db
 
 SECTION UNION "Misc 404", WRAM0
 ; pokegear
-	ds 172
+	ds 132
+
+wRadioCompressedText:: ds 2 * SCREEN_WIDTH
 
 wPokegearPhoneLoadNameBuffer:: db
 wPokegearPhoneCursorPosition:: db


### PR DESCRIPTION
1. Copy radio line into `wRadioCompressedText`
2. Check if text is compressed.
3. If compressed, decompress `wRadioCompressedText + 1` into `wRadioText + 1`, normal copy otherwise. (We assumed the first byte is `<START>` and the second byte may be `<CTXT>` if compressed)