### PR TITLE
Allows specifying a different trainer pal

### DIFF
--- a/constants/trainer_constants.asm
+++ b/constants/trainer_constants.asm
@@ -28,12 +28,15 @@ ENDM
 DEF NUM_NONTRAINER_PHONECONTACTS EQU const_value - 1
 
 DEF KRIS EQU __trainer_class__
+DEF BLUE_TRAINER_PAL EQU __trainer_class__
 	trainerclass CARRIE ; 1
 
 DEF CHRIS EQU __trainer_class__
+DEF RED_TRAINER_PAL EQU __trainer_class__
 	trainerclass CAL ; 2
 
 DEF CRYS EQU __trainer_class__
+DEF GREEN_TRAINER_PAL EQU __trainer_class__
 	trainerclass JACKY ; 3
 
 	trainerclass FALKNER ; 4

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -7777,6 +7777,8 @@ StartBattle:
 	call ExitBattle
 	farcall LoadWeatherGraphics
 	farcall LoadWeatherPal
+	xor a
+	ld [wTrainerPal], a
 	pop af
 	ld [wTimeOfDayPal], a
 	scf

--- a/engine/gfx/color.asm
+++ b/engine/gfx/color.asm
@@ -670,6 +670,9 @@ GetPlayerOrMonPalettePointer:
 GetFrontpicPalettePointer:
 	and a
 	jr nz, GetMonNormalOrShinyPalettePointer
+	ld a, [wTrainerPal]
+	and a
+	jr nz, GetTrainerPalettePointer
 	ld a, [wTrainerClass]
 
 GetTrainerPalettePointer:
@@ -812,8 +815,12 @@ LoadTempMonPalette:
 	jr _FinishLoadNicknamedMonPalette
 
 LoadTrainerPalette:
+	ld a, [wTrainerPal]
+	and a
+	jr nz, .use_custom_pal
 	; a = class
 	ld a, [wTrainerClass]
+.use_custom_pal
 	; hl = palette
 	call GetTrainerPalettePointer
 	; load palette in BG 7

--- a/macros/scripts/maps.asm
+++ b/macros/scripts/maps.asm
@@ -179,7 +179,13 @@ MACRO trainer
 	; flag, group, id, seen text, win text, lost text, after script
 	dw \3
 	db \1, \2
-	dw \4, \5, \6, \7
+	dw \4, \5
+	if _NARG == 8
+		db \8
+	else
+		db 0
+	endc
+	dw \6, \7
 ENDM
 
 MACRO generictrainer
@@ -187,6 +193,11 @@ MACRO generictrainer
 	dw \3
 	db \1, \2
 	dw \4, \5
+	if _NARG == 6
+		db \6
+	else
+		db 0
+	endc
 ENDM
 
 

--- a/maps/CeladonGameCorner.asm
+++ b/maps/CeladonGameCorner.asm
@@ -59,7 +59,7 @@ CeladonGameCorner_MapScriptHeader:
 	object_event  8, 10, SPRITE_FAT_GUY, SPRITEMOVEDATA_STANDING_LEFT, 0, 0, (1 << DAY) | (1 << NITE), PAL_NPC_RED, OBJECTTYPE_SCRIPT, 0, CeladonGameCornerFisherScript, -1
 	object_event 11,  3, SPRITE_GYM_GUY, SPRITEMOVEDATA_STANDING_DOWN, 0, 0, -1, PAL_NPC_RED, OBJECTTYPE_COMMAND, jumptextfaceplayer, CeladonGymGuyText, -1
 	object_event  2,  8, SPRITE_GRAMPS, SPRITEMOVEDATA_STANDING_LEFT, 0, 0, -1, PAL_NPC_GREEN, OBJECTTYPE_SCRIPT, 0, CeladonGameCornerGrampsScript, -1
-	object_event  9,  1, SPRITE_RICH_BOY, SPRITEMOVEDATA_STANDING_UP, 0, 0, -1, 0, OBJECTTYPE_TRAINER, 1, CeladonGameCornerRichBoyTobin, EVENT_RICH_BOY_TOBIN
+	object_event  9,  1, SPRITE_RICH_BOY, SPRITEMOVEDATA_STANDING_UP, 0, 0, -1, PAL_NPC_RED, OBJECTTYPE_TRAINER, 1, CeladonGameCornerRichBoyTobin, EVENT_RICH_BOY_TOBIN
 
 	object_const_def
 	const CELADONGAMECORNER_CLERK
@@ -177,7 +177,7 @@ MapCeladonGameCornerSignpost9Script:
 	endtext
 
 CeladonGameCornerRichBoyTobin:
-	trainer RICH_BOY, TOBIN, EVENT_BEAT_RICH_BOY_TOBIN, .SeenText, .BeatenText, 0, .AfterScript
+	trainer RICH_BOY, TOBIN, EVENT_BEAT_RICH_BOY_TOBIN, .SeenText, .BeatenText, 0, .AfterScript, CHRIS
 
 .Script:
 	checkevent EVENT_BEAT_RICH_BOY_TOBIN

--- a/ram/wramx.asm
+++ b/ram/wramx.asm
@@ -157,6 +157,7 @@ wTempTrainerClass:: db
 wTempTrainerID:: db
 wSeenTextPointer:: dw
 wWinTextPointer:: dw
+wTrainerPal:: db
 wGenericTempTrainerHeaderEnd::
 wLossTextPointer:: dw
 wScriptAfterPointer:: dw


### PR DESCRIPTION
This implementation has the drawback of an extra byte for every trainer... so we loose some space, but the benefit is it allows us to change the trainer's frontpic palette similarly to the overworld object palette. This allows us to have the overworld palette match the frontpic palette and add more color variety.

I *could* try to create additional object types so we don't have to consume as many bytes.

Anyways Just want to see what you think Sylvie.