### PR TITLE
Fix summary screen alignment which was correct on accident

### DIFF
--- a/ram/wram0.asm
+++ b/ram/wram0.asm
@@ -999,7 +999,7 @@ wSummaryMoveSwap:: db
 ; Used to align window buffer for DMA copying
 ; Feel free to use or move data, an assert will fail if the memory becomes misaligned
 ds 13
-assert (@ - STARTOF("Misc 1326")) % 16 == 0
+assert @ % 16 == 0
 
 wSummaryScreenWindowBuffer:: ds 32 * 10
 


### PR DESCRIPTION
`Misc 1326` just happened to be 16 byte aligned. Ran into this in another project, best to future proof.