### PR TITLE
Implement pluralizer for pluralizing item names, among other things

### DIFF
--- a/constants/charmap.asm
+++ b/constants/charmap.asm
@@ -18,6 +18,7 @@ ENDM
 	charmap "<SOUND>",  $06
 	charmap "<DAY>",    $07
 	charmap "<FAR>",    $08
+	charmap "<PLURAL>", $09
 
 	; n-grams: $09 - $51 (defined below)
 
@@ -229,7 +230,7 @@ DEF FIRST_REGULAR_TEXT_CHAR EQU $7f
 	charmap "┘",        $ff
 
 
-DEF NGRAMS_START EQU $09
+DEF NGRAMS_START EQU $0a
 
 	newcharmap compressing, no_ngrams
 
@@ -243,7 +244,6 @@ DEF NGRAMS_VAR_START EQU $4f
 
 	newcharmap default, compressing
 
-	charmap "e ",       $09
 	charmap "ou",       $0a
 	charmap "th",       $0b
 	charmap "in",       $0c
@@ -310,7 +310,7 @@ DEF NGRAMS_VAR_START EQU $4f
 	charmap "ed ",      $49
 	charmap "It's ",    $4a
 	charmap "that ",    $4b
-	charmap " you ",    $4c
+	charmap "e ",       $4c
 
 DEF NGRAMS_END EQU $51
 

--- a/data/items/names.asm
+++ b/data/items/names.asm
@@ -1,4 +1,5 @@
 	; use rawchars so VWF will work in the PC
+	; also check the plural table (Pluralize)
 	setcharmap no_ngrams
 
 ItemNames::

--- a/data/text/common.asm
+++ b/data/text/common.asm
@@ -2413,7 +2413,7 @@ _AskQuantityThrowAwayText::
 	text_decimal wItemQuantityChangeBuffer, 1, 2
 	line ""
 	text_ram wStringBuffer2
-	text "(s)?"
+	text "<PLURAL>?"
 	done
 
 SECTION "_ThrewAwayText", ROMX
@@ -3109,15 +3109,6 @@ _StartMenuContestEndText::
 SECTION "_ItemsTossOutHowManyText", ROMX
 _ItemsTossOutHowManyText::
 	text "Toss out how many"
-	line ""
-	text_ram wStringBuffer2
-	text "(s)?"
-	done
-
-SECTION "_ItemsThrowAwayText", ROMX
-_ItemsThrowAwayText::
-	text "Throw away "
-	text_decimal wItemQuantityChangeBuffer, 1, 2
 	line ""
 	text_ram wStringBuffer2
 	text "(s)?"

--- a/data/text/ngrams.asm
+++ b/data/text/ngrams.asm
@@ -1,6 +1,5 @@
 NgramStrings:
 	table_width 1
-	dr .e_
 	dr .ou
 	dr .th
 	dr .in
@@ -67,7 +66,7 @@ NgramStrings:
 	dr .ed_
 	dr .It#s_
 	dr .that_
-	dr ._you_
+	dr .e_
 	dr .Poke
 	dr .Pokemon
 	assert_table_length NGRAMS_VAR_START - NGRAMS_START

--- a/engine/pokemon/mon_menu.asm
+++ b/engine/pokemon/mon_menu.asm
@@ -54,7 +54,7 @@ TossItemFromPC:
 
 .ConfirmToss:
 	; Throw away @ @ (S)?
-	text_far _ItemsThrowAwayText
+	text_far _AskQuantityThrowAwayText
 	text_end
 
 .TossedThisMany:

--- a/home/text.asm
+++ b/home/text.asm
@@ -408,6 +408,83 @@ PlaceCommandCharacter::
 	pop de
 	jmp NextChar
 
+MACRO plural ; TODO: move this elsewhere?
+  for i, charlen(\1)
+    db charsub(\1, charlen(\1) - i)
+  endr
+  db "@", \2, "@"
+ENDM
+
+TextCommand_PLURAL:
+; Pluralize the last word. Might perform edits on it (Candy -> Candies).
+	; If wItemQuantityBuffer is 1, do nothing.
+	ld a, [wItemQuantityChangeBuffer]
+	dec a
+	ret z
+
+	; Try to pattern match the previous string with the plural table below.
+	push hl
+	push bc
+
+	ld hl, .PluralTable
+
+.check_match_loop
+	; Iterate until the pattern no longer matches our string.
+	dec bc
+	ld a, [bc]
+	cp [hl]
+	ld a, [hli] ; To check if we found the terminator.
+	jr z, .check_match_loop
+
+	; Did we hit the terminator?
+	cp "@"
+	jr nz, .no_match
+
+	; We have a match. Print out the adjusted string.
+	inc bc
+	ld d, h
+	ld e, l
+	ld h, b
+	ld l, c
+	pop bc
+	call PlaceString
+	pop hl
+	ret
+
+.no_match
+	ld b, 2
+.no_match_loop
+	ld a, [hli]
+	cp "@"
+	jr nz, .no_match_loop
+	dec b
+	jr nz, .no_match_loop
+	pop bc
+	push bc
+	jr .check_match_loop
+
+.PluralTable:
+	plural "e of Rage", "es of Rage" ; Cakes of Rage
+	plural "Honey", "Honey" ; (Sweet) Honey
+	plural "ay", "ays" ; Light Clays
+	plural "y", "ies" ; Rare Candies
+	plural "x", "xes" ; PP Maxes
+	plural "ilk", "ilk" ; Moomoo Milk
+	plural "Crunch", "Crunchies" ; PewterCrunchies
+	plural "h", "hes" ; Sacred Ashes
+	plural "Powder", "Powder" ; EnergyPowder
+	plural "c.", "cs." ; Guard Specs.
+	plural "ts", "ts" ; Heavy Boots
+	plural "ef", "efs" ; X Sp.Defs
+	plural "f", "ves" ; Silk Scarves
+	plural "Sand", "Sand" ; Soft Sand
+	plural "es", "es" ; BlackGlasses
+	plural "rs", "rs" ; Leftovers
+	plural "ds", "ds" ; Protect Pads
+	plural "Dice", "Dice" ; Loaded Dice
+	plural "s", "ses" ; Scope Lenses
+	plural "", "s" ; everything else
+
 TextScroll::
 	hlcoord TEXTBOX_INNERX, TEXTBOX_INNERY
 	decoord TEXTBOX_INNERX, TEXTBOX_INNERY - 1
@@ -508,6 +585,7 @@ TextCommands::
 	dw TextCommand_SOUND         ; $06 <SOUND>
 	dw TextCommand_DAY           ; $07 <DAY>
 	dw TextCommand_FAR           ; $08 <FAR>
+	dw TextCommand_PLURAL        ; $09 <PLURAL>
 	assert_table_length NGRAMS_START
 
 _ImplicitlyStartedText:


### PR DESCRIPTION
This implements a pluralize function for pluralizing item names. Strictly speaking, it can pluralize any string depending on `wItemQuantityChangeBuffer`, but the plural table is designed for items.

The pluralizer itself is finished, but currently mostly unused (I added one case for testing). I'll go ahead and add them in various places now.