### PR TITLE
Magikarp length

### DIFF
--- a/constants/misc_constants.asm
+++ b/constants/misc_constants.asm
@@ -43,6 +43,9 @@ DEF HOF_MASTER_COUNT EQU 200
 ; Kirk ID
 DEF KIRK_SHUCKIE_ID EQU 00518
 
+; initial best Magikarp length (in mm)
+DEF BEST_MAGIKARP_LENGTH EQU 1053
+
 ; crash error codes
 	const_def
 	const ERR_RST_0

--- a/constants/misc_constants.asm
+++ b/constants/misc_constants.asm
@@ -44,7 +44,7 @@ DEF HOF_MASTER_COUNT EQU 200
 DEF KIRK_SHUCKIE_ID EQU 00518
 
 ; initial best Magikarp length (in mm)
-DEF BEST_MAGIKARP_LENGTH EQU 1053
+DEF BEST_MAGIKARP_LENGTH EQU 1067
 
 ; crash error codes
 	const_def

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -6151,7 +6151,7 @@ CheckValidMagikarpLength:
 	jr c, .CheckMagikarpArea
 ; Try again if length >= 1600 mm (i.e. if LOW(length) >= 3 inches)
 	ld a, [wMagikarpLengthMmLo]
-	cp LOW(1600)
+	cp LOW(1616)
 	jr nc, .redo
 
 ; 20% chance of skipping this check
@@ -6160,7 +6160,7 @@ CheckValidMagikarpLength:
 	jr c, .CheckMagikarpArea
 ; Try again if length >= 1575 mm (i.e. if LOW(length) >= 2 inches)
 	ld a, [wMagikarpLengthMmLo]
-	cp LOW(1575)
+	cp LOW(1600)
 	jr nc, .redo
 
 .CheckMagikarpArea:

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -6135,32 +6135,32 @@ CheckValidMagikarpLength:
 	cp MAGIKARP
 	jr nz, .okay
 
-	; Get Magikarp's length
+; Get Magikarp's length
 	ld de, wOTPartyMon1DVs
 	ld bc, wPlayerID
 	farcall CalcMagikarpLength
 
-	; We're clear if the length is < 5'
+; No reason to keep going if length > 1536 mm (i.e. if HIGH(length) > 5 feet)
 	ld a, [wMagikarpLengthMmHi]
-	cp 5 ; feet
+	cp HIGH(1536)
 	jr nz, .CheckMagikarpArea
 
-	; 5% chance of skipping size checks
+; 5% chance of skipping both size checks
 	call Random
 	cp 5 percent
 	jr c, .CheckMagikarpArea
-	; Try again if > 3"
+; Try again if length >= 1600 mm (i.e. if LOW(length) >= 3 inches)
 	ld a, [wMagikarpLengthMmLo]
-	cp 3 ; inches
+	cp LOW(1600)
 	jr nc, .redo
 
-	; 20% chance of skipping this check
+; 20% chance of skipping this check
 	call Random
 	cp 20 percent - 1
 	jr c, .CheckMagikarpArea
-	; Try again if > 2"
+; Try again if length >= 1575 mm (i.e. if LOW(length) >= 2 inches)
 	ld a, [wMagikarpLengthMmLo]
-	cp 2 ; inches
+	cp LOW(1575)
 	jr nc, .redo
 
 .CheckMagikarpArea:
@@ -6171,13 +6171,13 @@ CheckValidMagikarpLength:
 	cp MAP_LAKE_OF_RAGE
 	jr nz, .okay
 .LakeOfRageMagikarp
-	; 40% chance of not flooring
+; 40% chance of not flooring
 	call Random
 	cp 40 percent - 2
 	jr c, .okay
-	; Floor at length 3'
+; Try again if length < 1024 mm (i.e. if HIGH(length) < 3 feet)
 	ld a, [wMagikarpLengthMmHi]
-	cp 3 ; feet
+	cp HIGH(1024)
 	jr c, .redo
 
 .okay:

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -6149,7 +6149,7 @@ CheckValidMagikarpLength:
 	call Random
 	cp 5 percent
 	jr c, .CheckMagikarpArea
-; Try again if length >= 1600 mm (i.e. if LOW(length) >= 3 inches)
+; Try again if length >= 1616 mm (i.e. if LOW(length) >= 4 inches)
 	ld a, [wMagikarpLengthMmLo]
 	cp LOW(1616)
 	jr nc, .redo
@@ -6158,7 +6158,7 @@ CheckValidMagikarpLength:
 	call Random
 	cp 20 percent - 1
 	jr c, .CheckMagikarpArea
-; Try again if length >= 1575 mm (i.e. if LOW(length) >= 2 inches)
+; Try again if length >= 1600 mm (i.e. if LOW(length) >= 3 inches)
 	ld a, [wMagikarpLengthMmLo]
 	cp LOW(1600)
 	jr nc, .redo

--- a/engine/events/magikarp.asm
+++ b/engine/events/magikarp.asm
@@ -154,6 +154,11 @@ PrintMagikarpLength:
 	inc e
 	jr .inchloop
 .inchdone
+	ld a, [wMagikarpLengthMmHi]
+	ld b, a
+	ld a, [wMagikarpLengthMmLo]
+	ld c, a
+	push bc
 	ld a, e
 	ld [wMagikarpLengthMmHi], a
 	ld a, l
@@ -170,6 +175,11 @@ PrintMagikarpLength:
 	ld a, "″"
 	ld [hli], a
 	ld [hl], "@"
+	pop bc
+	ld hl, wMagikarpLengthMmHi
+	ld a, b
+	ld [hli], a
+	ld [hl], c
 	ret
 
 CalcMagikarpLength:

--- a/engine/menus/intro_menu.asm
+++ b/engine/menus/intro_menu.asm
@@ -271,9 +271,9 @@ _ResetWRAM_InitList:
 
 InitializeMagikarpHouse:
 	ld hl, wBestMagikarpLengthMmHi
-	ld a, $3
+	ld a, HIGH(BEST_MAGIKARP_LENGTH)
 	ld [hli], a
-	ld a, $6
+	ld a, LOW(BEST_MAGIKARP_LENGTH)
 	ld [hli], a
 	ld de, .Ralph
 	jmp CopyName2


### PR DESCRIPTION
Making this pull request purely for posterity, as it could deserve a save patch. This would close #1131 

Really, there are three issues this is resolving:

1. When starting a new save file, the game initially stores the record Magikarp's length as $0306. This is a vestige from when the Polished codebase was in imperial units and the intended length was 3'6". However, the codebase is now in metric units, but the Magikarp length code hasn't been updated. Effectively this means the initial longest Magikarp is a pathetic 776mm, or about 2'6". The game now initializes to the initial record Magikarp being 1067mm, or 3'6". Note that this is longer than in other versions that used metric units (they initialized to 105.3mm in GSC and 106.5mm in HGSS), but preserving existing Polished balance will be a theme of this pull request.

2. When the fishing guru checks your Magikarp length, the game calculates that length in millimeters and stores it in `wMagikarpLengthMm`. However, if the player is using imperial units, the game overwrites `wMagikarpLengthMm` with the length in feet in the high byte and inches in the low byte. This leads to the bizarre result of the check working correctly if the player is using metric units and incorrectly if the player is using imperial units. Storing the metric units on the stack before writing the imperial units and restoring them when done fixes this issue.

3. Polished actually had the inverse problem of vanilla when determining the lengths of wild Magikarp - checks were done in imperial units when the data itself were in metric units. ~~I should note that the millimeter thresholds I used are not identical to vanilla, which was 95% to reroll any Magikarp over 1616mm (5'4") and a total of 75% to reroll and Magikarp over 1600mm (5'3"). I instead used 1600mm (5'3") and 1575mm (5'2") respectively, as Polished had the reroll thresholds at 5'3" and 5'2". I don't know if that was intended or an oversight, but again, this is a bugfix and I'd like to avoid any sort of rebalancing.~~ **EDIT:** Upon re-reading the initial comments, it seems the intention was indeed to match vanilla thresholds, but the code was off by one. Therefore, I decided to just use what vanilla already uses.

**For the savepatch**, since the name of the recordholder is initialized to Ralph, you could check if the name stored is indeed Ralph and check if the value of `wMagikarpLengthMm` is $0306, then update that to $042b. It's stored big-endian. It is of course possible that the player's name could also be Ralph, so I would strongly suggest checking for equality with $0306 rather than checking if it's less than $042b. I don't think the player gets a prize for tying the record, so it should be safe to update.