### PR TITLE
Add an initial option for no experience gain

### DIFF
--- a/constants/ram_constants.asm
+++ b/constants/ram_constants.asm
@@ -111,18 +111,18 @@ DEF ABILITIES_OPTMASK EQU 1 << ABILITIES_OPT
 DEF LINK_OPTMASK EQU (1 << NATURES_OPT) | (1 << ABILITIES_OPT) | (1 << PERFECT_IVS_OPT) | (1 << PSS_OPT)
 
 ; wInitialOptions2::
-	const_def 3
+	const_def 2
+	const NO_EXP_OPT           ; 2
 	const RTC_OPT              ; 3
 	const EVOLVE_IN_BATTLE_OPT ; 4
 	const_skip 2
 	const RESET_INIT_OPTS      ; 7
-DEF EV_OPTMASK EQU %11
 
 	const_def
 	const EVS_OPT_DISABLED ; %00
 	const EVS_OPT_CLASSIC  ; %01
 	const EVS_OPT_MODERN   ; %10
-
+DEF EV_OPTMASK EQU %11
 
 ; wForgettingMove::
 	const_def 6

--- a/data/items/descriptions.asm
+++ b/data/items/descriptions.asm
@@ -1712,5 +1712,5 @@ ExpCandyMDesc:
 ExpCandyLDesc:
 ExpCandyXLDesc:
 	text "A candy that"
-	next "gives Exp. Points."
+	next "gives Exp.Points."
 	done

--- a/data/options/descriptions.asm
+++ b/data/options/descriptions.asm
@@ -6,7 +6,7 @@ InitialOptionDescriptions:
 	dw .InitialOptionDesc_Abilities
 	dw .InitialOptionDesc_PSS
 	dw .InitialOptionDesc_EVs
-	dw .InitialOptionDesc_ExpScaling
+	dw .InitialOptionDesc_Experience
 	dw .InitialOptionDesc_AffectionBonus
 	dw .InitialOptionDesc_NextPage
 
@@ -66,18 +66,31 @@ InitialOptionDescriptions:
 	line "erience in Gen 3."
 	prompt
 
-.InitialOptionDesc_ExpScaling:
-	text "Experience gain"
-	line "is greater from"
+.InitialOptionDesc_Experience:
+	text "The old experience"
+	line "gain formula, in"
 
-	para "defeating higher-"
-	line "leveled foes,"
+	para "Gen 1 to Gen 4,"
+	line "was unscaled."
+
+	para "The new one, in"
+	line "Gen 5 and reintro-"
+	cont "duced in Gen 7,"
+
+	para "gives more Exp. by"
+	line "defeating higher-"
+	cont "leveled foes,"
 
 	para "and less from low-"
 	line "er leveled ones."
 
-	para "Introduced in"
-	line "Gen 5 and 7."
+	para "Exp. gain can also"
+	line "be turned off for"
+	cont "a challenge, but"
+
+	para "Exp.Candy and Rare"
+	line "Candy will still"
+	cont "work if you do so."
 	prompt
 
 .InitialOptionDesc_AffectionBonus:
@@ -136,7 +149,7 @@ InitialOptionDescriptions:
 	line "will obey you and"
 	cont "can be nicknamed,"
 
-	para "but Exp. Points"
+	para "but Exp.Points"
 	line "won't be boosted."
 	prompt
 

--- a/data/text/common.asm
+++ b/data/text/common.asm
@@ -1786,14 +1786,14 @@ Text_ABoostedStringBuffer2ExpPoints::
 	line "a boosted"
 	cont ""
 	text_decimal wStringBuffer2, 3, 6
-	text " Exp. Points!"
+	text " Exp.Points!"
 	prompt
 
 SECTION "Text_StringBuffer2ExpPoints", ROMX
 Text_StringBuffer2ExpPoints::
 	line ""
 	text_decimal wStringBuffer2, 3, 6
-	text " Exp. Points!"
+	text " Exp.Points!"
 	prompt
 
 SECTION "Text_GoPkmn", ROMX

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -6393,6 +6393,11 @@ GiveExperiencePoints:
 .participating
 	call GiveBattleEVs
 
+	; No experience if disabled
+	ld a, [wInitialOptions2]
+	bit NO_EXP_OPT, a
+	jmp nz, .next_mon
+
 	; No experience at level 100
 	ld hl, MON_LEVEL
 	add hl, bc

--- a/ram/wram0.asm
+++ b/ram/wram0.asm
@@ -1446,15 +1446,16 @@ wInitialOptions::
 ; bit 3: perfect IVs off/on
 ; bit 4: traded behavior off/on
 ; bit 5: affection bonuses off/on
-; bit 6: scaled exp on/off
+; bit 6: scaled exp on/off (cannot be set together with no exp)
 ; bit 7: physical-special split on/off
 	db
 
 wInitialOptions2::
-; bit 0: EVs disabled
-; bit 1: classic EVs (no 510 cap)
-; bit 2: modern EVs (510 cap)
-; (only one of bits 0-2 can be set)
+; bits 0-1: EVs (cannot be set to %11)
+; - %00: EVs disabled
+; - %01: classic EVs (no 510 cap)
+; - %10: modern EVs (510 cap)
+; bit 2: no exp on/off (cannot be set together with scaled exp)
 ; bit 3: use RTC
 ; bit 4: evolve in battle
 ; bits 5-6: unused


### PR DESCRIPTION
This allows a challenge that cannot be self-imposed.

The PR also notices that bit 2 of `wInitialOptions2` is not actually used for EV gain (just bis 0 and 1 store the three possible EV option values), so uses it for this option.

This PR also consistently removes a space from "Exp.Points", just like "Prof.Oak", "Prof. Elm", "Dept.Store", etc.

![image](https://github.com/user-attachments/assets/8b1382e4-2964-4a3c-84c8-a09d06ab4fe8)
