### PR TITLE
Remove non-faithful stat boosts when they differ from regional formes

### DIFF
--- a/data/pokemon/base_stats/corsola_plain.asm
+++ b/data/pokemon/base_stats/corsola_plain.asm
@@ -1,18 +1,9 @@
-if DEF(FAITHFUL)
 	db  65,  55,  95,  35,  65,  95 ; 410 BST
 	;   hp  atk  def  spe  sat  sdf
-else
-	db  65,  55, 115,  35, 105, 115 ; 490 BST
-	;   hp  atk  def  spe  sat  sdf
-endc
 
 	db WATER, ROCK ; type
 	db 60 ; catch rate
-if DEF(FAITHFUL)
 	db 113 ; base exp
-else
-	db 128 ; base exp
-endc
 	db NO_ITEM, HARD_STONE ; held items
 	dn GENDER_F75, HATCH_MEDIUM_FAST ; gender ratio, step cycles to hatch
 

--- a/data/pokemon/base_stats/farfetch_d_plain.asm
+++ b/data/pokemon/base_stats/farfetch_d_plain.asm
@@ -1,10 +1,5 @@
-if DEF(FAITHFUL)
 	db  52,  90,  55,  60,  58,  62 ; 377 BST
 	;   hp  atk  def  spe  sat  sdf
-else
-	db  55, 110,  55, 105,  60,  65 ; 450 BST
-	;   hp  atk  def  spe  sat  sdf
-endc
 
 	db NORMAL, FLYING ; type
 	db 45 ; catch rate

--- a/data/pokemon/base_stats/mr__mime_plain.asm
+++ b/data/pokemon/base_stats/mr__mime_plain.asm
@@ -1,10 +1,5 @@
-if DEF(FAITHFUL)
 	db  40,  45,  65,  90, 100, 120 ; 460 BST
 	;   hp  atk  def  spe  sat  sdf
-else
-	db  50,  45,  65, 100, 100, 125 ; 485 BST
-	;   hp  atk  def  spe  sat  sdf
-endc
 
 	db PSYCHIC, FAIRY ; type
 	db 45 ; catch rate

--- a/data/pokemon/base_stats/qwilfish_plain.asm
+++ b/data/pokemon/base_stats/qwilfish_plain.asm
@@ -1,18 +1,9 @@
-if DEF(FAITHFUL)
 	db  65,  95,  85,  85,  55,  55 ; 440 BST
 	;   hp  atk  def  spe  sat  sdf
-else
-	db  65, 100, 100,  85,  75,  55 ; 480 BST
-	;   hp  atk  def  spe  sat  sdf
-endc
 
 	db WATER, POISON ; type
 	db 45 ; catch rate
-if DEF(FAITHFUL)
 	db 100 ; base exp
-else
-	db 109 ; base exp
-endc
 	db NO_ITEM, POISON_BARB ; held items
 	dn GENDER_F50, HATCH_MEDIUM_FAST ; gender ratio, step cycles to hatch
 


### PR DESCRIPTION
Farfetch'd, Mr. Mime, Qwilfish, and Corsola all have stat boosts in non-faithful. Like most such boosts, these were generally copied from Drayano's Sacred Gold/Storm Silver when PC was first being developed. Now there's less need for these single-stage Pokémon to be boosted, because they have regional formes that offer evolutions (Sirfetch'd, Mr. Rime, Overqwil, Cursola). On the other hand, this makes their standard forms less competitive.