### PR TITLE
[10bit] Tidy up and switch to MBC3O

### DIFF
--- a/data/moves/semi_invulnerable_moves.asm
+++ b/data/moves/semi_invulnerable_moves.asm
@@ -1,0 +1,6 @@
+SemiInvulnerableMoves:
+	dw FLY
+	dw BOUNCE
+	dw DIG
+	dw DIVE
+	dw -1

--- a/engine/battle/ai/scoring.asm
+++ b/engine/battle/ai/scoring.asm
@@ -1153,7 +1153,7 @@ AI_Smart_Encore:
 	push hl
 	ld a, [wPlayerSelectedMove]
 	ld hl, EncoreMoves
-	call AI_CheckMoveInList
+	call CheckMoveInList
 	pop hl
 	jr nc, .discourage
 
@@ -1315,7 +1315,7 @@ AI_Smart_Disable:
 	push hl
 	ld a, [wPlayerSelectedMove]
 	ld hl, UsefulMoves
-	call AI_CheckMoveInList
+	call CheckMoveInList
 
 	pop hl
 	jr nc, .notencourage
@@ -2266,7 +2266,7 @@ AI_Opportunist:
 	push de
 	push bc
 	ld hl, StallMoves
-	call AI_CheckMoveInList
+	call CheckMoveInList
 
 	pop bc
 	pop de
@@ -2548,7 +2548,7 @@ AI_Cautious:
 	push de
 	push bc
 	ld hl, ResidualMoves
-	call AI_CheckMoveInList
+	call CheckMoveInList
 
 	pop bc
 	pop de
@@ -2806,12 +2806,3 @@ AI_50_50:
 	call Random
 	cp 50 percent + 1
 	ret
-
-AI_CheckMoveInList:
-	push hl
-	call GetMoveIndexFromID
-	ld b, h
-	ld c, l
-	pop hl
-	ld de, 2
-	jp IsInWordArray

--- a/engine/battle/ai/switch.asm
+++ b/engine/battle/ai/switch.asm
@@ -245,7 +245,7 @@ AICheckMatchupForEnemyMon:
 	ret
 
 .set_matchup
-	call CheckTypeMatchup
+	farcall CheckTypeMatchup
 	ld a, [wTypeMatchup]
 	and a
 	ret z ; no effect

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -237,7 +237,7 @@ BattleTurn:
 	ld a, BATTLE_VARS_MOVE_ANIM
 	call GetBattleVarAddr
 	ld bc, FOCUS_PUNCH
-	farcall CompareMove
+	call CompareMove
 	ret nz
 
 	ld hl, FOCUS_ENERGY
@@ -523,7 +523,7 @@ ParsePlayerAction:
 	jr nz, .locked_in
 	ld a, [wBattlePlayerAction]
 	cp $2
-	jmp z, .reset_rage
+	jr z, .reset_rage
 	and a
 	jr nz, .reset_bide
 	xor a
@@ -5797,7 +5797,7 @@ CheckUsableMove:
 	ld c, l
 	ld a, BATTLE_VARS_LAST_MOVE
 	call GetBattleVar
-	farcall CompareMove
+	call CompareMove
 	pop bc
 	ld a, MOVE_UNUSABLE_TORMENT
 	ret

--- a/engine/battle/effect_commands.asm
+++ b/engine/battle/effect_commands.asm
@@ -4,10 +4,9 @@ INCLUDE "data/moves/continuous_moves.asm"
 INCLUDE "data/moves/critical_hit_moves.asm"
 INCLUDE "data/moves/powder_moves.asm"
 INCLUDE "data/moves/reversal_power.asm"
+INCLUDE "data/moves/semi_invulnerable_moves.asm"
 INCLUDE "data/pokemon/fury_attack_users.asm"
 INCLUDE "data/pokemon/withdraw_harden_users.asm"
-INCLUDE "data/types/inverse_type_matchups.asm"
-INCLUDE "data/types/type_matchups.asm"
 
 INCLUDE "engine/battle/ai/switch.asm"
 INCLUDE "engine/battle/move_effects/attract.asm"
@@ -228,7 +227,7 @@ BattleCommand_checkturn:
 	cp EFFECT_FOCUS_PUNCH
 	jr nz, .no_focus_punch
 	ld a, 1 << PHYSICAL | 1 << SPECIAL
-	farcall HasOpponentDamagedUs
+	call HasOpponentDamagedUs
 	jr z, .no_focus_punch
 
 	ld hl, LostFocusText
@@ -1358,7 +1357,7 @@ BattleCommand_critical:
 	cp LEEK
 	jr nz, .FocusEnergy
 .crit_item
-	call UserValidBattleItem
+	farcall UserValidBattleItem
 	jr nz, .FocusEnergy
 	ld c, 2
 	; fallthrough
@@ -1436,79 +1435,6 @@ BattleCommand_critical:
 	ld [wCriticalHit], a
 	ret
 
-TrueUserValidBattleItem:
-; Items (and Abilities) never apply to external Future Sight users.
-	call GetFutureSightUser
-	ret nz
-	; fallthrough
-UserValidBattleItem:
-; Checks if the user's held item applies to the species+form.
-; Used for items like Leek, Lucky Punch, Thick Club, etc.
-; Returns z if the item is valid.
-	push hl
-	push de
-	push bc
-
-	; Get item, species and form data.
-	ld hl, wBattleMonItem
-	call GetUserMonAttr
-	ld a, [hl]
-	ld de, wBattleMonSpecies - wBattleMonItem
-	add hl, de
-	ld c, [hl]
-	ld de, wBattleMonForm - wBattleMonSpecies
-	add hl, de
-	ld b, [hl]
-	ld d, a
-	ld hl, .ValidBattleItemTable
-
-.loop
-	; Check if we reached the end of the table.
-	ld a, [hli]
-	inc a
-	jr z, .failed
-
-	; Does the item match the held one?
-	dec a
-	cp d
-	ld a, [hli]
-	jr nz, .next
-
-	; Does the item apply to the species?
-	cp c
-	jr nz, .next
-
-	; Check exact species+form.
-	ld a, [hl]
-	call CompareSpeciesForm
-	jr z, .matched
-.next
-	inc hl
-	jr .loop
-.matched
-	xor a
-	jr .done
-.failed
-	or 1
-.done
-	jmp PopBCDEHL
-
-MACRO species_battle_item
-	db \1
-	shift
-	dp \#
-ENDM
-
-.ValidBattleItemTable:
-	species_battle_item LIGHT_BALL, PIKACHU
-	species_battle_item LEEK, FARFETCH_D
-	species_battle_item LEEK, SIRFETCH_D
-	species_battle_item LUCKY_PUNCH, CHANSEY
-	species_battle_item QUICK_POWDER, DITTO
-	species_battle_item THICK_CLUB, CUBONE
-	species_battle_item THICK_CLUB, MAROWAK
-	db -1
-
 CheckAirBalloon:
 ; Returns z if the target is holding an Air Balloon
 	push bc
@@ -1536,7 +1462,7 @@ BattleCommand_stab:
 	ret z
 
 	; Apply type matchups
-	call BattleCheckTypeMatchup
+	farcall BattleCheckTypeMatchup
 	; Store wTypeModifier (handles effectiveness)
 	ld a, [wTypeMatchup]
 	ld [wTypeModifier], a
@@ -1674,265 +1600,6 @@ BattleCommand_stab:
 	ld [hl], a
 	ret
 
-CheckAirborneAfterMoldBreaker:
-	push de
-	call SwitchTurn
-	call GetOpponentAbilityAfterMoldBreaker
-	ld b, a
-	call SwitchTurn
-	jr CheckAirborne_GotAbility
-
-CheckAirborne:
-	push de
-	call GetTrueUserAbility
-	ld b, a
-CheckAirborne_GotAbility:
-; d=1: Skip type checks (used for Inverse Battle Ground->Flying matchup)
-; Returns a=0 and z if grounded. Returns nz if not.
-; a contains ATKFAIL_MISSED for air balloon, ATKFAIL_IMMUNE for flying type,
-; ATKFAIL_ABILITY for Levitate.
-
-	; Check Gravity
-	ld a, [wFieldEffects]
-	and FIELD_GRAVITY
-	jr z, .no_gravity
-	; All pokemon are grounded during Gravity
-	pop de
-	xor a
-	ret
-.no_gravity
-	ld a, BATTLE_VARS_SUBSTATUS5
-	call GetBattleVar
-	bit SUBSTATUS_INGRAIN, a
-	jr z, .no_ingrain
-	xor a
-	ret
-.no_ingrain
-
-	; Check Iron Ball
-	push bc
-	predef GetUserItemAfterUnnerve
-	ld a, b
-	pop bc
-	pop de
-	ld c, a
-	sub HELD_IRON_BALL
-	ret z
-
-	; Check Magnet Rise
-	ldh a, [hBattleTurn]
-	and a
-	ld hl, wPlayerYawnMagnetRiseCount
-	jr z, .got_magnet_rise
-	ld hl, wEnemyYawnMagnetRiseCount
-.got_magnet_rise
-	ld a, [hl]
-	and $0F
-	jr nz, .airborne
-
-	; d=1 (inverse matchup checks/ring target) skips hardcoded immunity check
-	ld a, d
-	and a
-	jr nz, .typecheck_done
-	push bc
-	call CheckIfUserIsFlyingType
-	pop bc
-	ld a, ATKFAIL_IMMUNE
-	jr z, .airborne
-.typecheck_done
-	ld a, c
-	cp HELD_AIR_BALLOON
-	ld a, ATKFAIL_MISSED
-	jr z, .airborne
-	ld a, b
-	cp LEVITATE
-	ld a, ATKFAIL_ABILITY
-	jr z, .airborne
-	xor a
-.airborne
-	and a
-	ret
-
-BattleCheckTypeMatchup:
-	ldh a, [hBattleTurn]
-	and a
-	ld hl, wEnemyMonType1
-	jr z, CheckTypeMatchup
-	ld hl, wBattleMonType1
-	; fallthrough
-CheckTypeMatchup:
-; Wrapper that handles ability immunities, because type matchups take predecence,
-; this matters for Ground pokémon with Lightning Rod (and Trace edge-cases).
-; Yes, Lightning Rod is useless on ground types since GSC has no doubles.
-	push hl
-	push de
-	push bc
-	call _CheckTypeMatchup
-	; if the attack is ineffective, bypass ability checks
-	ld a, [wTypeMatchup]
-	and a
-	jr z, .end
-
-	; check Ground-type attacks
-	ld a, BATTLE_VARS_MOVE_TYPE
-	call GetBattleVar
-	cp GROUND
-	jr nz, .done_ground_type
-
-	call SwitchTurn
-
-	; Ring Target or Inverse battles bypass the type matchup check.
-	push bc
-	predef GetUserItemAfterUnnerve
-	ld a, b
-	pop bc
-	cp HELD_RING_TARGET
-	ld d, 1
-	jr z, .check_airborne
-	ld a, [wBattleType]
-	cp BATTLETYPE_INVERSE
-	jr z, .check_airborne
-	dec d
-.check_airborne
-	call CheckAirborneAfterMoldBreaker
-	push af
-	call SwitchTurn
-	pop af
-	jr z, .done_ground_type
-	cp ATKFAIL_ABILITY
-	jr nz, .no_levitate
-	ld [wAttackMissed], a
-
-.no_levitate
-	xor a
-	ld [wTypeMatchup], a
-
-.done_ground_type
-	farcall CheckNullificationAbilities
-.end
-	jmp PopBCDEHL
-
-_CheckTypeMatchup:
-	push hl
-; Handle powder moves
-	ld a, BATTLE_VARS_MOVE_ANIM
-	call GetBattleVar
-	call GetMoveIndexFromID
-	ld b, h
-	ld c, l
-	ld hl, PowderMoves
-	ld de, 2
-	call IsInWordArray
-	jr nc, .skip_powder
-	call GetOpponentItemAfterUnnerve
-	ld a, b
-	cp HELD_SAFETY_GOGGLES
-	jmp z, .Immune
-	pop hl
-	push hl
-	ld a, [hli]
-	cp GRASS
-	jmp z, .Immune
-	ld a, [hl]
-	cp GRASS
-	jmp z, .Immune
-	call GetOpponentAbilityAfterMoldBreaker
-	cp OVERCOAT
-	jr nz, .skip_powder
-	ld a, ATKFAIL_ABILITY
-	ld [wAttackMissed], a
-	jr .Immune
-
-.skip_powder
-	pop hl
-	push hl
-	ld a, BATTLE_VARS_MOVE_TYPE
-	call GetBattleVar
-	ld d, a
-	ld a, [hli]
-	ld c, [hl]
-	ld b, a
-	ld a, $10 ; 1.0
-	ld [wTypeMatchup], a
-	ld hl, InverseTypeMatchups
-	ld a, [wBattleType]
-	cp BATTLETYPE_INVERSE
-	jr z, .TypesLoop
-	ld hl, TypeMatchups
-.TypesLoop:
-	ld a, [hli]
-	; terminator
-	cp $ff
-	jr z, .end
-	cp $fe
-	jr nz, .Next
-	; stuff beyond this point is ignored if the foe is identified or we have Scrappy
-	ld a, BATTLE_VARS_SUBSTATUS1_OPP
-	call GetBattleVar
-	bit SUBSTATUS_IDENTIFIED, a
-	jr nz, .end
-	call GetTrueUserAbility
-	cp SCRAPPY
-	jr z, .end
-	cp MINDS_EYE
-	jr nz, .TypesLoop
-.end
-	pop hl
-	ret
-
-.Next:
-	; attacking type
-	cp d
-	jr nz, .Nope
-	ld a, [hli]
-	; defending types
-	cp b
-	jr z, .Yup
-	cp c
-	jr z, .Yup
-	jr .Nope2
-
-.Nope:
-	inc hl
-.Nope2:
-	inc hl
-	jr .TypesLoop
-
-.Yup:
-	; no need to continue if we encountered a 0x matchup
-	ld a, [hli]
-	and a
-	jr z, .RingTarget
-	cp SUPER_EFFECTIVE
-	jr z, .se
-	cp NOT_VERY_EFFECTIVE
-	jr z, .nve
-	jr .TypesLoop
-.se
-	ld a, [wTypeMatchup]
-	add a
-	ld [wTypeMatchup], a
-	jr .TypesLoop
-.nve
-	ld a, [wTypeMatchup]
-	srl a
-	ld [wTypeMatchup], a
-	jr .TypesLoop
-
-.RingTarget:
-	; if opponent is holding Ring Target, ignore type-based immunity
-	push hl
-	call GetOpponentItemAfterUnnerve
-	pop hl
-	ld a, b
-	cp HELD_RING_TARGET
-	jr z, .TypesLoop
-.Immune:
-	xor a
-	ld [wTypeMatchup], a
-	pop hl
-	ret
-
 BattleCommand_checkpowder:
 	ld a, BATTLE_VARS_MOVE_ANIM
 	call GetBattleVar
@@ -2010,7 +1677,7 @@ BattleCommand_checkpowder:
 BattleCommand_resettypematchup:
 ; Reset the type matchup multiplier to 1.0, if the type matchup is not 0.
 ; If there is immunity in play, the move automatically misses.
-	call BattleCheckTypeMatchup
+	farcall BattleCheckTypeMatchup
 	ld a, [wTypeMatchup]
 	and a
 	ld a, $10 ; 1.0
@@ -2955,7 +2622,7 @@ BattleCommand_applydamage:
 	jr nc, .no_endure
 .enduring
 	push bc
-	call BattleCommand_falseswipe
+	farcall BattleCommand_falseswipe
 	pop bc
 	jr c, .okay
 .no_endure
@@ -3367,24 +3034,6 @@ BattleCommand_supereffectivetext:
 	ld [wAlreadyExecuted], a
 	jmp SwitchTurn
 
-CheckSheerForceNegation:
-; Check if a secondary effect was suppressed due to Sheer Force.
-; Most likely a bug introduced in Gen V, it is an established
-; mechanic at this point (VII) that if Sheer Force negates the
-; secondary effect of a move, various side effects don't trigger.
-; Returns z if an effect is negated.
-	call GetTrueUserAbility
-	cp SHEER_FORCE
-	ret nz
-	ld a, [wEffectFailed]
-	and a
-	jr z, .ret_nz
-	xor a
-	ret
-.ret_nz
-	or 1
-	ret
-
 ConsumeStolenOpponentItem::
 ; Separate function, since used items/cud chew berry shouldn't (necessarily)
 ; be updated when force-eating a berry via Bug Bite
@@ -3750,7 +3399,7 @@ BattleCommand_posthiteffects:
 CheckEndMoveEffects:
 ; Effects handled at move end skipped by Sheer Force negation except for rampage
 	call HandleRampage
-	call CheckSheerForceNegation
+	farcall CheckSheerForceNegation
 	ret z
 	call GetFutureSightUser
 	ret nz
@@ -4376,7 +4025,9 @@ CheckAttackItemBoost:
 	call TrueUserPartyAttr
 	cp b
 	pop hl
-	call z, TrueUserValidBattleItem
+	jr nz, .skip_call
+	farcall TrueUserValidBattleItem
+.skip_call
 	pop de
 	pop bc
 	ret nz
@@ -6059,7 +5710,7 @@ CheckIfTrappedByAbility:
 .has_arena_trap
 	; Doesn't work on airborne mons
 	ld d, 0
-	call CheckAirborne
+	farcall CheckAirborne
 	jr nz, .not_trapped
 	xor a
 	ret
@@ -7324,39 +6975,6 @@ CheckBattleEffects:
 .off
 	scf
 	ret
-
-CompareMove:
-	; checks if the move ID in a matches the move in bc
-	push hl
-	call GetMoveIndexFromID
-	ld a, h
-	cp b
-	ld a, l
-	pop hl
-	ret nz
-	cp c
-	ret
-CheckMoveInList:
-	; checks if the move ID in a belongs to a list of moves in hl
-	push bc
-	push de
-	push hl
-	call GetMoveIndexFromID
-	ld b, h
-	ld c, l
-	pop hl
-	ld de, 2
-	call IsInWordArray
-	pop de
-	pop bc
-	ret
-	
-SemiInvulnerableMoves:
-	dw FLY
-	dw BOUNCE
-	dw DIG
-	dw DIVE
-	dw -1
 
 ; hl -> user's weight
 ; clobbers a, bc, de

--- a/engine/battle/misc.asm
+++ b/engine/battle/misc.asm
@@ -156,3 +156,360 @@ CheckUserMove:
 	ld a, 1
 	and a
 	ret
+
+
+CheckAirborneAfterMoldBreaker:
+	push de
+	call SwitchTurn
+	call GetOpponentAbilityAfterMoldBreaker
+	ld b, a
+	call SwitchTurn
+	jr CheckAirborne_GotAbility
+
+CheckAirborne:
+	push de
+	call GetTrueUserAbility
+	ld b, a
+CheckAirborne_GotAbility:
+; d=1: Skip type checks (used for Inverse Battle Ground->Flying matchup)
+; Returns a=0 and z if grounded. Returns nz if not.
+; a contains ATKFAIL_MISSED for air balloon, ATKFAIL_IMMUNE for flying type,
+; ATKFAIL_ABILITY for Levitate.
+
+	; Check Gravity
+	ld a, [wFieldEffects]
+	and FIELD_GRAVITY
+	jr z, .no_gravity
+	; All pokemon are grounded during Gravity
+	pop de
+	xor a
+	ret
+.no_gravity
+	ld a, BATTLE_VARS_SUBSTATUS5
+	call GetBattleVar
+	bit SUBSTATUS_INGRAIN, a
+	jr z, .no_ingrain
+	xor a
+	ret
+.no_ingrain
+
+	; Check Iron Ball
+	push bc
+	predef GetUserItemAfterUnnerve
+	ld a, b
+	pop bc
+	pop de
+	ld c, a
+	sub HELD_IRON_BALL
+	ret z
+
+	; Check Magnet Rise
+	ldh a, [hBattleTurn]
+	and a
+	ld hl, wPlayerYawnMagnetRiseCount
+	jr z, .got_magnet_rise
+	ld hl, wEnemyYawnMagnetRiseCount
+.got_magnet_rise
+	ld a, [hl]
+	and $0F
+	jr nz, .airborne
+
+	; d=1 (inverse matchup checks/ring target) skips hardcoded immunity check
+	ld a, d
+	and a
+	jr nz, .typecheck_done
+	push bc
+	call CheckIfUserIsFlyingType
+	pop bc
+	ld a, ATKFAIL_IMMUNE
+	jr z, .airborne
+.typecheck_done
+	ld a, c
+	cp HELD_AIR_BALLOON
+	ld a, ATKFAIL_MISSED
+	jr z, .airborne
+	ld a, b
+	cp LEVITATE
+	ld a, ATKFAIL_ABILITY
+	jr z, .airborne
+	xor a
+.airborne
+	and a
+	ret
+
+
+BattleCheckTypeMatchup:
+	ldh a, [hBattleTurn]
+	and a
+	ld hl, wEnemyMonType1
+	jr z, CheckTypeMatchup
+	ld hl, wBattleMonType1
+	; fallthrough
+CheckTypeMatchup:
+; Wrapper that handles ability immunities, because type matchups take predecence,
+; this matters for Ground pokémon with Lightning Rod (and Trace edge-cases).
+; Yes, Lightning Rod is useless on ground types since GSC has no doubles.
+	push hl
+	push de
+	push bc
+	call _CheckTypeMatchup
+	; if the attack is ineffective, bypass ability checks
+	ld a, [wTypeMatchup]
+	and a
+	jr z, .end
+
+	; check Ground-type attacks
+	ld a, BATTLE_VARS_MOVE_TYPE
+	call GetBattleVar
+	cp GROUND
+	jr nz, .done_ground_type
+
+	call SwitchTurn
+
+	; Ring Target or Inverse battles bypass the type matchup check.
+	push bc
+	predef GetUserItemAfterUnnerve
+	ld a, b
+	pop bc
+	cp HELD_RING_TARGET
+	ld d, 1
+	jr z, .check_airborne
+	ld a, [wBattleType]
+	cp BATTLETYPE_INVERSE
+	jr z, .check_airborne
+	dec d
+.check_airborne
+	call CheckAirborneAfterMoldBreaker
+	push af
+	call SwitchTurn
+	pop af
+	jr z, .done_ground_type
+	cp ATKFAIL_ABILITY
+	jr nz, .no_levitate
+	ld [wAttackMissed], a
+
+.no_levitate
+	xor a
+	ld [wTypeMatchup], a
+
+.done_ground_type
+	farcall CheckNullificationAbilities
+.end
+	jmp PopBCDEHL
+
+_CheckTypeMatchup:
+	push hl
+; Handle powder moves
+	ld a, BATTLE_VARS_MOVE_ANIM
+	call GetBattleVar
+	call GetMoveIndexFromID
+	ld b, h
+	ld c, l
+	ld hl, PowderMoves
+	ld de, 2
+	call IsInWordArray
+	jr nc, .skip_powder
+	farcall GetOpponentItemAfterUnnerve
+	ld a, b
+	cp HELD_SAFETY_GOGGLES
+	jmp z, .Immune
+	pop hl
+	push hl
+	ld a, [hli]
+	cp GRASS
+	jmp z, .Immune
+	ld a, [hl]
+	cp GRASS
+	jmp z, .Immune
+	call GetOpponentAbilityAfterMoldBreaker
+	cp OVERCOAT
+	jr nz, .skip_powder
+	ld a, ATKFAIL_ABILITY
+	ld [wAttackMissed], a
+	jr .Immune
+
+.skip_powder
+	pop hl
+	push hl
+	ld a, BATTLE_VARS_MOVE_TYPE
+	call GetBattleVar
+	ld d, a
+	ld a, [hli]
+	ld c, [hl]
+	ld b, a
+	ld a, $10 ; 1.0
+	ld [wTypeMatchup], a
+	ld hl, InverseTypeMatchups
+	ld a, [wBattleType]
+	cp BATTLETYPE_INVERSE
+	jr z, .TypesLoop
+	ld hl, TypeMatchups
+.TypesLoop:
+	ld a, [hli]
+	; terminator
+	cp $ff
+	jr z, .end
+	cp $fe
+	jr nz, .Next
+	; stuff beyond this point is ignored if the foe is identified or we have Scrappy
+	ld a, BATTLE_VARS_SUBSTATUS1_OPP
+	call GetBattleVar
+	bit SUBSTATUS_IDENTIFIED, a
+	jr nz, .end
+	call GetTrueUserAbility
+	cp SCRAPPY
+	jr z, .end
+	cp MINDS_EYE
+	jr nz, .TypesLoop
+.end
+	pop hl
+	ret
+
+.Next:
+	; attacking type
+	cp d
+	jr nz, .Nope
+	ld a, [hli]
+	; defending types
+	cp b
+	jr z, .Yup
+	cp c
+	jr z, .Yup
+	jr .Nope2
+
+.Nope:
+	inc hl
+.Nope2:
+	inc hl
+	jr .TypesLoop
+
+.Yup:
+	; no need to continue if we encountered a 0x matchup
+	ld a, [hli]
+	and a
+	jr z, .RingTarget
+	cp SUPER_EFFECTIVE
+	jr z, .se
+	cp NOT_VERY_EFFECTIVE
+	jr z, .nve
+	jr .TypesLoop
+.se
+	ld a, [wTypeMatchup]
+	add a
+	ld [wTypeMatchup], a
+	jr .TypesLoop
+.nve
+	ld a, [wTypeMatchup]
+	srl a
+	ld [wTypeMatchup], a
+	jr .TypesLoop
+
+.RingTarget:
+	; if opponent is holding Ring Target, ignore type-based immunity
+	push hl
+	farcall GetOpponentItemAfterUnnerve
+	pop hl
+	ld a, b
+	cp HELD_RING_TARGET
+	jr z, .TypesLoop
+.Immune:
+	xor a
+	ld [wTypeMatchup], a
+	pop hl
+	ret
+
+INCLUDE "data/types/inverse_type_matchups.asm"
+INCLUDE "data/types/type_matchups.asm"
+
+
+TrueUserValidBattleItem:
+; Items (and Abilities) never apply to external Future Sight users.
+	farcall GetFutureSightUser
+	ret nz
+	; fallthrough
+UserValidBattleItem:
+; Checks if the user's held item applies to the species+form.
+; Used for items like Leek, Lucky Punch, Thick Club, etc.
+; Returns z if the item is valid.
+	push hl
+	push de
+	push bc
+
+	; Get item, species and form data.
+	ld hl, wBattleMonItem
+	call GetUserMonAttr
+	ld a, [hl]
+	ld de, wBattleMonSpecies - wBattleMonItem
+	add hl, de
+	ld c, [hl]
+	ld de, wBattleMonForm - wBattleMonSpecies
+	add hl, de
+	ld b, [hl]
+	ld d, a
+	ld hl, .ValidBattleItemTable
+
+.loop
+	; Check if we reached the end of the table.
+	ld a, [hli]
+	inc a
+	jr z, .failed
+
+	; Does the item match the held one?
+	dec a
+	cp d
+	ld a, [hli]
+	jr nz, .next
+
+	; Does the item apply to the species?
+	cp c
+	jr nz, .next
+
+	; Check exact species+form.
+	ld a, [hl]
+	call CompareSpeciesForm
+	jr z, .matched
+.next
+	inc hl
+	jr .loop
+.matched
+	xor a
+	jr .done
+.failed
+	or 1
+.done
+	jmp PopBCDEHL
+
+MACRO species_battle_item
+	db \1
+	shift
+	dp \#
+ENDM
+
+.ValidBattleItemTable:
+	species_battle_item LIGHT_BALL, PIKACHU
+	species_battle_item LEEK, FARFETCH_D
+	species_battle_item LEEK, SIRFETCH_D
+	species_battle_item LUCKY_PUNCH, CHANSEY
+	species_battle_item QUICK_POWDER, DITTO
+	species_battle_item THICK_CLUB, CUBONE
+	species_battle_item THICK_CLUB, MAROWAK
+	db -1
+
+
+CheckSheerForceNegation:
+; Check if a secondary effect was suppressed due to Sheer Force.
+; Most likely a bug introduced in Gen V, it is an established
+; mechanic at this point (VII) that if Sheer Force negates the
+; secondary effect of a move, various side effects don't trigger.
+; Returns z if an effect is negated.
+	call GetTrueUserAbility
+	cp SHEER_FORCE
+	ret nz
+	ld a, [wEffectFailed]
+	and a
+	jr z, .ret_nz
+	xor a
+	ret
+.ret_nz
+	or 1
+	ret

--- a/home/battle.asm
+++ b/home/battle.asm
@@ -940,3 +940,35 @@ PushLYOverrides::
 	ld a, (wLYOverridesEnd - wLYOverrides) / 16
 	ldh [hLYOverrideStackCopyAmount], a
 	ret
+
+CompareMove:
+; a = move ID
+; bc = move index
+; returns z if moves are the same
+	push hl
+	call GetMoveIndexFromID
+	ld a, h
+	cp b
+	ld a, l
+	pop hl
+	ret nz
+	cp c
+	ret
+
+CheckMoveInList:
+; a = move ID
+; hl = list of move indices
+; checks if the move ID in a belongs to a list of moves in hl
+; returns carry if found
+	push bc
+	push de
+	push hl
+	call GetMoveIndexFromID
+	ld b, h
+	ld c, l
+	pop hl
+	ld de, 2
+	call IsInWordArray
+	pop de
+	pop bc
+	ret

--- a/tools/bankends.c
+++ b/tools/bankends.c
@@ -4,7 +4,7 @@
 
 #include "parsemap.h"
 
-#define BANKS 128
+#define BANKS 256
 #define BANKSIZE 0x4000
 #define ROMSIZE (BANKS * BANKSIZE)
 


### PR DESCRIPTION
A recurring issue is running out of space in `effect_commands.asm` and there was a good chunk of routines that didn't need to exist there, so, I've moved them out to more appropriate places.

With sour's last commit and the changes in this one... we finally broke through and ran out of space in MBC3, so additionally this updates the build tools to use MBC3O.

The changes in this PR entirely moving around existing code and refactoring calls and farcalls where appropriate.