### PR TITLE
Define routine documentation format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Routine Documentation
+
+When commenting routines be sure to follow this style guide for consistency.
+Many different styles of comments exist from various points of time but, this is considered up to date.
+
+* All register names, labels, and math expressions should be surrounded with backticks in comments.
+
+```x86asm
+; Fills `bc` bytes with the value of `a`, starting at `hl`.
+```
+
+* All registers and significant memory address inputs should be described with ``@input [reg] = [description]``. The order of registers and addresses should be "logical" with the function of the routine, rather than determined by which registers are used.
+
+```x86asm
+; @input `wFoo` = First value to multiply
+; @input `a` = Second value to multiply
+```
+
+* All registers and significant memory address outputs should be described with ``@output [reg] -> [description]``. The order of registers and addresses should be "logical" with the function of the routine, rather than determined by which registers are used.
+
+```x86asm
+; @output `wFoo` -> Size of data read
+; @output `hl` -> Start of data
+```
+
+* Routines which set flags as return values should document them as ``@flag [reg] -> [description]``.
+
+```x86asm
+; @flag `c` -> Set if found
+```
+
+* **Every** routine documented with comments **must** include an `@clobbers [reg] [, regN...]`. 
+The list should include every register that is modified by the routine, even registers marked as outputs. When listing clobbered registers, use the order `a`, `hl`, `bc`, `de`.
+
+```x86asm
+; @clobbers `a`, `hl`, `c`
+```
+
+* Register joining should be used contextually based on use.
+Use `bc` if the two registers are used as a single 16-bit number, but `b`, and `c` if the registers represent different values.
+
+```x86asm
+; @input `b` = Height to fill
+; @input `c` = Width to fill
+; @output `bc` -> Number of tiles filled
+```
+
+## Examples
+
+```x86asm
+; Fills `bc` bytes with the value of `a`, starting at `hl`.
+; @input `hl` = Address to start filling from
+; @input `bc` = How many bytes to fill
+; @input `a` = Value to fill with
+; @clobbers `hl`, `bc`
+ByteFill::
+```
+
+## Reasoning
+
+By far the most time consuming part of learning an assembly codebase and continuing to use it is understanding what registers are stable and clobbered by routines.
+Understanding undocumented input and output behavior is also time consuming.
+As such, it's most important to be able to trust that a routine properly documents this behavior, particularly clobbered registers.
+
+Syntactically, `@input` is used as IDEs are prone to merge lines together most of the time.
+A line that starts with `@` generally causes them to be shown on separate lines, which is highly desired for inputs and outputs.
+`=` and `->` are used to more easily determine inputs and outputs at a glance.
+Using backtick code blocks for registers helps notably for readability and scanning, particularly for registers like `a` which are a word in English.

--- a/home/array.asm
+++ b/home/array.asm
@@ -1,14 +1,36 @@
-FarIsInByteArray:
+; Finds value `c` in array `a:hl` of width `1`
+; @input `c` = Value to search for
+; @input `a` = ROM bank of array
+; @input `hl` = Array to search
+; @output `b` -> Index of the found value
+; @output `hl` -> Address of found value
+; @flag `c` -> Set if found
+; @clobbers `a`, `hl`, `bc`, `de`
+FarIsInByteArray::
 ; Find value c in array a:hl.
 	call StackCallInBankA
 .Function:
 	ld a, c
-	; fallthrough
+	fallthrough IsInByteArray
+; Finds value `a` in array `hl` of width `1`
+; @input `a` = Value to search for
+; @input `hl` = Array to search
+; @output `b` -> Index of the found value
+; @output `hl` -> Address of found value
+; @flag `c` -> Set if found
+; @clobbers `a`, `hl`, `bc`, `de`
 IsInByteArray::
 	ld de, 1
+	fallthrough IsInArray
+; Finds value `a` in array `hl` of width `de`
+; @input `a` = Value to search for
+; @input `hl` = Array to search
+; @input `de` = Width of array
+; @output `b` -> Index of the found value
+; @output `hl` -> Address of found value
+; @flag `c` -> Set if found
+; @clobbers `a`, `hl`, `bc`
 IsInArray::
-; Find value a for every de bytes in array hl.
-; Return index in b, and carry if found.
 	ld b, 0
 	ld c, a
 .loop
@@ -22,16 +44,30 @@ IsInArray::
 	add hl, de
 	jr .loop
 
+; Finds value `bc` in array `a:hl` of width `de`
+; @input `bc` = Value to search for
+; @input `a` = ROM bank of array
+; @input `hl` = Array to search
+; @input `de` = Width of array
+; @output `hl` -> Address of found value
+; @flag `c` -> Set if found
+; @clobbers `a`, `hl`, `bc`
 FarIsInWordArray::
-; Find value bc in array a:hl.
 	call StackCallInBankA
 .Function:
 	jr IsInWordArray
 
 IsInWordArray_NextItem:
 	add hl, de
+	fallthrough IsInWordArray
+; Finds value `bc` in array `hl` of width `de`
+; @input `bc` = Value to search for
+; @input `hl` = Array to search
+; @input `de` = Width of array
+; @output `hl` -> Address of found value
+; @flag `c` -> Set if found
+; @clobbers `a`, `hl`, `bc`
 IsInWordArray::
-; Same as IsInArray, but for word values. The value is input in bc; index not returned.
 	ld a, [hli]
 	and [hl]
 	inc a
@@ -48,7 +84,7 @@ IsInWordArray::
 SkipNames::
 ; Skip a names.
 	ld bc, NAME_LENGTH
-	; fallthrough
+	fallthrough _AddNTimes
 _AddNTimes::
 ; Add bc * a to hl. Don't optimize this for space.
 	and a

--- a/home/battle_vars.asm
+++ b/home/battle_vars.asm
@@ -1,12 +1,19 @@
+; Gets the variable from `BATTLE_VARS_*` constant in `a`, depending on current turn.
+; @input `a` = `BATTLE_VARS_*` constant to get value for
+; @output `a` -> Requested variable
+; @clobbers `a`
 GetBattleVar::
 	push hl
 	call GetBattleVarAddr
 	pop hl
 	ret
 
+; Gets the variable from `BATTLE_VARS_*` constant in `a`, depending on current turn.
+; @input `a` = `BATTLE_VARS_*` constant to get value for
+; @output `a` -> Requested variable
+; @output `hl` -> Requested variable's address
+; @clobbers `a`, `hl`
 GetBattleVarAddr::
-; Get variable from pair a, depending on whose turn it is.
-; There are 22 variable pairs.
 	push bc
 
 	ld hl, BattleVarPairs

--- a/home/farcall.asm
+++ b/home/farcall.asm
@@ -192,11 +192,17 @@ AnonBankPush::
 	pop af
 	ret
 
+; Calls the following code in ROM bank `b`.
+; Previous ROM bank is restored on `ret`
+; @input `a` = ROM bank to switch to
+; @clobbers `a`
 StackCallInBankB:
-; Call the following function in bank b. Clobbers a.
 	ld a, b
+; Calls the following code in ROM bank `a`.
+; Previous ROM bank is restored on `ret`
+; @input `a` = ROM bank to switch to
+; @clobbers `a`
 StackCallInBankA:
-; Call the following function in bank a. Clobbers a.
 	add sp, -3
 	push de
 	push hl
@@ -236,11 +242,16 @@ StackCallInBankA:
 	pop de
 	jmp Bankswitch
 
+; Calls the following code in `wDecompressScratch`'s WRAM bank.
+; Previous WRAM bank is restored on `ret`
+; @clobbers `a`
 RunFunctionInWRA6::
-; Call the following function in wDecompressScratch's WRAM bank. Clobbers a.
 	ld a, BANK(wDecompressScratch)
+; Calls the following code in WRAM bank `a`.
+; Previous WRAM bank is restored on `ret`
+; @input `a` = WRAM bank to switch to
+; @clobbers `a`
 StackCallInWRAMBankA::
-; Call the following function in WRAM bank a. Clobbers a.
 	add sp, -3
 	push de
 	push hl

--- a/home/header.asm
+++ b/home/header.asm
@@ -15,6 +15,8 @@ SwitchToMapScriptsBank::
 	; fallthrough
 
 SECTION "rst08 Bankswitch", ROM0[$0008]
+; Switches to the ROM bank in `a`
+; @input `a` = ROM bank to switch to
 Bankswitch::
 	ldh [hROMBank], a
 	ld [MBC3RomBank], a
@@ -44,6 +46,12 @@ FarCall::
 
 
 SECTION "rst18 AddNTimes", ROM0[$0018]
+; Adds `bc * a` to `hl`
+; @input `hl` = Base value
+; @input `bc` = Increment to add
+; @input `a` = Amount of increment to add
+; @output `hl` -> `hl + (bc * a)`
+; @clobbers: `a`, `hl`
 AddNTimes::
 	jmp _AddNTimes
 
@@ -57,11 +65,20 @@ FarCopyWRAM::
 	; fallthrough
 
 SECTION "rst20 CopyBytes", ROM0[$0020]
+; Copies `bc` bytes from `hl` to `de`
+; @input `hl` = Source
+; @input `de` = Destination
+; @input `bc` = Amount to copy
+; @clobbers `a`, `hl`, `bc`, `de`
 CopyBytes::
 	jmp _CopyBytes
 
+; Retrieves a single byte from `a:hl`, and returns it in `a`
+; @input `a` = ROM Bank
+; @input `hl` = Address
+; @output `a` -> The value at `a:hl`
+; @clobbers `a`
 GetFarByte::
-; retrieve a single byte from a:hl, and return it in a.
 	call StackCallInBankA
 
 .Function:
@@ -70,9 +87,19 @@ GetFarByte::
 
 
 SECTION "rst28 ByteFill", ROM0[$0028]
+; Fills `bc` bytes with the value of `a`, starting at `hl`.
+; @input `hl` = Address to start filling from
+; @input `bc` = How many bytes to fill
+; @input `a` = Value to fill with
+; @clobbers `hl`, `bc`
 ByteFill::
 	jmp _ByteFill
 
+; Retrieves a single byte from `a:hl`, and returns it in `a`
+; @input `a` = WRAM Bank
+; @input `hl` = Address
+; @output `a` -> The value at `a:hl`
+; @clobbers `a`
 GetFarWRAMByte::
 	call StackCallInWRAMBankA
 
@@ -85,6 +112,12 @@ SECTION "rst30 PlaceString", ROM0[$0030]
 PlaceString::
 	jmp _PlaceString
 
+; Swaps the contents of `hl` and `de`
+; @input `hl` = Value to put in `de`
+; @input `de` = Value to put in `hl`
+; @output `hl` -> Input `de`
+; @output `de` -> Input `hl`
+; @clobbers `hl`, `de`
 SwapHLDE::
 	push de
 	ld d, h
@@ -137,8 +170,23 @@ SECTION "timer", ROM0[$0050]
 
 	reti ; just in case
 
+; Pops, in order, `af`, `bc`, `de`, and `hl` from the stack.
+; This should not be `call`ed, only jumped to.
+; Calling will push the return address to the stack.
+; @output `af` -> First item on the stack
+; @output `bc` -> Second item on the stack
+; @output `de` -> Third item on the stack
+; @output `hl` -> Fourth item on the stack
+; @clobbers `af`, `hl`, `bc`, `de`
 PopAFBCDEHL::
 	pop af
+; Pops, in order, `bc`, `de`, and `hl` from the stack.
+; This should not be `call`ed, only jumped to.
+; Calling will push the return address to the stack.
+; @output `bc` -> First item on the stack
+; @output `de` -> Second item on the stack
+; @output `hl` -> Third item on the stack
+; @clobbers `hl`, `bc`, `de`
 PopBCDEHL::
 	pop bc
 	pop de

--- a/home/math.asm
+++ b/home/math.asm
@@ -1,5 +1,9 @@
+; Returns `a * c` in `a`
+; @input `a` = First value
+; @input `c` = Second value
+; @output `a` -> `a * c` 
+; @clobbers `a`
 SimpleMultiply::
-; Return a * c.
 	and a
 	ret z
 
@@ -13,8 +17,14 @@ SimpleMultiply::
 	pop bc
 	ret
 
+; Returns `a / c` in `b` and `a`.
+; If `c` is `0`, the game will crash.
+; @input `a` = First value
+; @input `c` = Second value
+; @output `a` -> `a % c`
+; @output `b` -> `a / c`
+; @clobbers `a`, `b`, `c`
 SimpleDivide::
-; Divide a by c. Return quotient b and remainder a.
 	inc c
 	dec c
 	jr z, .div0
@@ -30,9 +40,13 @@ SimpleDivide::
 	ld a, ERR_DIV_ZERO
 	jmp Crash
 
+; Multiplies and divides `hMultiplicand` by the nybbles in `a`
+; @input `hMultiplicand` = Value to modify
+; @input `a` = $xy multiply by x, divide by y
+; @output `hMultiplicand`/`hQuotient` -> Quotient
+; @output `hRemainder` -> Remainder
+; @clobbers `a`
 MultiplyAndDivide::
-; a = $xy: multiply multiplicands by x, then divide by y
-; Used for damage modifiers, catch rate modifiers, etc.
 	push bc
 	ld b, a
 

--- a/macros/asserts.asm
+++ b/macros/asserts.asm
@@ -111,3 +111,7 @@ MACRO jmp
 		assert warn, (\<_NARG>) - @ > 127 || (\<_NARG>) - @ < -129, "jp can be jr"
 	endc
 ENDM
+
+MACRO fallthrough
+	assert BANK(@) == BANK(\1) && @ == \1, "Address does not fallthrough to \1"
+ENDM


### PR DESCRIPTION
This PR proposes a format for rigorous routine documentation and applies it to a bunch of high traffic routines. Let me know any thoughts you have on the formatting, it's not set in stone.

Additionally, a `fallthrough` macro has been added. All it does is validate that the fallthrough hasn't had code inserted, slightly more reasonable than a fallthrough comment.

Once this has been discussed and merged, I'll be applying more documentation across high traffic routines in the codebase, particularly around 10bit move expansion. If it ends up being useful, we can think about porting it upstream to pokecrystal.