### PR TITLE
Minimal fix for Youngster Joey Soft Lock

### DIFF
--- a/engine/overworld/wildmons.asm
+++ b/engine/overworld/wildmons.asm
@@ -1098,8 +1098,8 @@ RandomPhoneMon:
 	; bc == size of mon sub-struct
 	ld b, 0
 
-	; b currently holds party size in bytes
-	ld a, b
+	; c currently holds party size in bytes
+	ld a, c
 	add l
 	ld e, 0
 	push hl


### PR DESCRIPTION
Resolves #1218, #1197
Supersedes #1244

This PR contains the minimal fix to resolve the issues described in the above issues. The other PR appears to be excessive in it's attempt to resolve the problem.