### PR TITLE
Fixed two bugs with how the high bits of 10 bit moves were handled during PC storage.

### DIFF
--- a/engine/pc/bills_pc.asm
+++ b/engine/pc/bills_pc.asm
@@ -782,8 +782,12 @@ EncodeTempMon:
 	; Convert Move IDs to Move Indexes.
 	ld hl, wTempMonMoves
 	ld de, wEncodedTempMonMovesLow
-	lb bc, NUM_MOVES, 0
+	ld b, NUM_MOVES
+	xor a
 .moves_loop
+	rla
+	rla
+	ld c, a
 	ld a, [hli]
 	push hl
 	call GetMoveIndexFromID
@@ -794,13 +798,9 @@ EncodeTempMon:
 	pop hl
 	and %11 ; clamp to 2 bits (just in case)
 	or c
-	rla
-	rla
-	ld c, a
 	dec b
 	jr nz, .moves_loop
 	ld de, wEncodedTempMonMovesHigh
-	ld a, c
 	ld [de], a
 
 	; Move Extra bytes.
@@ -930,7 +930,6 @@ DecodeTempMon:
 	and %11
 	ld h, a
 	ld a, c
-	and %00111111
 	rra
 	rra
 	ld c, a


### PR DESCRIPTION
- On encoding, the byte containing the high bits of the moves was rotated an extra time, which gave each move the high bits of the move after it (and killed the high bits of the last move).
- On decoding, an unnecessary mask was performed with an incorrect bitmask (%00111111 instead of %11111100), killing the high bits of the first move. This mask has been removed, as it seems to serve no discernible purpose.