### PR TITLE
Fix text in Ilex Forest trainer tip

### DIFF
--- a/maps/IlexForest.asm
+++ b/maps/IlexForest.asm
@@ -1014,17 +1014,16 @@ IlexForestTrainerTips:
 
 	para "As long as you"
 	line "have an HM in"
-	cont "your bag,"
+	cont "your Bag,"
 
-	para "and #mon in"
-	line "your party that"
+	para "and a #mon in"
+	line "your party that's"
 
-	para "are compatible"
-	line "with it,"
+	para "compatible with"
+	line "it, you can use"
 
-	para "you can use the"
-	line "move outside of" 
-	cont "battle."
+	para "the move outside"
+	line "of battle."
 
 	para "You don't even"
 	line "have to teach it!"


### PR DESCRIPTION
The sentence of the new Trainer Tip in Ilex Forest seems incomplete. 
It seems that during the completion of pull request #1055 something went missing.

I tried to correct the text this way, feel free to further improve upon if if necessary.

P.S. I also removed the exclamation mark after `Trainer Tips` since other trainer tips also don't use exclamation marks.