### PR TITLE
Add bag full checks for throat spray and icy rock items

### DIFF
--- a/maps/IcePathB3F.asm
+++ b/maps/IcePathB3F.asm
@@ -49,6 +49,7 @@ LoreleiAfterIntroScript:
 	writetext LoreleiRewardText
 	promptbutton
 	verbosegiveitem ICY_ROCK
+	iffalsefwd LoreleiAfterScript
 	setevent EVENT_GOT_ICY_ROCK_FROM_LORELEI
 LoreleiAfterScript:
 	readvar VAR_BADGES
@@ -69,7 +70,12 @@ LoreleiAfterScript:
 
 LoreleiRematchScript:
 	checkevent EVENT_BEAT_LORELEI_AGAIN
+	iffalsefwd .DoRematch
+	checkevent EVENT_GOT_ICY_ROCK_FROM_LORELEI
 	iftrue_jumpopenedtext LoreleiRematchAfterText
+	opentext
+	sjumpfwd LoreleiGiveIcyRock
+.DoRematch:
 	checkevent EVENT_INTRODUCED_LORELEI
 	iftruefwd LoreleiReintroductionScript
 	writetext LoreleiIntroText
@@ -88,9 +94,11 @@ LoreleiAfterRematchIntroScript:
 	opentext
 	checkevent EVENT_GOT_ICY_ROCK_FROM_LORELEI
 	iftrue_jumpopenedtext LoreleiRematchAfterText
+LoreleiGiveIcyRock:
 	writetext LoreleiRewardText
 	promptbutton
 	verbosegiveitem ICY_ROCK
+	iffalse_jumpopenedtext LoreleiRematchAfterText
 	setevent EVENT_GOT_ICY_ROCK_FROM_LORELEI
 	jumpthisopenedtext
 

--- a/maps/WarehouseEntrance.asm
+++ b/maps/WarehouseEntrance.asm
@@ -460,6 +460,7 @@ PiersScript:
 	writetext PiersRewardText
 	promptbutton
 	verbosegiveitem THROAT_SPRAY
+	iffalse_jumpopenedtext PiersAfterText
 	setevent EVENT_GOT_THROAT_SPRAY_FROM_PIERS
 	jumpthisopenedtext
 
@@ -477,7 +478,12 @@ PiersAfterText:
 
 PiersRematchScript:
 	checkevent EVENT_BEAT_PIERS_AGAIN
+	iffalsefwd .DoRematch
+	checkevent EVENT_GOT_THROAT_SPRAY_FROM_PIERS
 	iftrue_jumpopenedtext PiersRematchAfterText
+	opentext
+	sjumpfwd .GiveThroatSpray
+.DoRematch:
 	checkevent EVENT_INTRODUCED_PIERS
 	iffalsefwd .Intro
 	writetext PiersRematchIntroAgainText
@@ -499,9 +505,11 @@ PiersRematchScript:
 	opentext
 	checkevent EVENT_GOT_THROAT_SPRAY_FROM_PIERS
 	iftrue_jumpopenedtext PiersRematchAfterText
+.GiveThroatSpray:
 	writetext PiersRewardText
 	promptbutton
 	verbosegiveitem THROAT_SPRAY
+	iffalse_jumpopenedtext PiersRematchAfterText
 	setevent EVENT_GOT_THROAT_SPRAY_FROM_PIERS
 	jumpthisopenedtext
 


### PR DESCRIPTION
Enhance the scripts for Piers and Lorelei to include bag full checks when giving throat spray and icy rock items. This change addresses the issue of missing bag full checks for these items, ensuring proper handling during item distribution.

Fixes #1296