### PR TITLE
Port wBuffer labels from pokecrystal

### DIFF
--- a/engine/battle/abilities.asm
+++ b/engine/battle/abilities.asm
@@ -408,16 +408,16 @@ ForewarnAbility:
 	ld hl, wBattleMonMoves
 .got_move_ptr
 	ld a, NUM_MOVES + 1
-	ld [wBuffer1], a ; iterator
+	ld [wForewarnIterator], a ; iterator
 	xor a
-	ld [wBuffer2], a ; used when randomizing between equal-power moves
-	ld [wBuffer3], a ; highest power move index
-	ld [wBuffer4], a ; power of said move for comparing
+	ld [wForewarnEqualCount], a ; used when randomizing between equal-power moves
+	ld [wForewarnBestMove], a ; highest power move index
+	ld [wForewarnBestPower], a ; power of said move for comparing
 .loop
-	ld a, [wBuffer1]
+	ld a, [wForewarnIterator]
 	dec a
 	jr z, .done
-	ld [wBuffer1], a
+	ld [wForewarnIterator], a
 	; a mon can have less than 4 moves
 	ld a, [hli]
 	and a
@@ -443,35 +443,35 @@ ForewarnAbility:
 	jr z, .loop
 .compare_power
 	; b: current move ID, c: current move power
-	ld a, [wBuffer4]
+	ld a, [wForewarnBestPower]
 	cp c
 	jr z, .randomize
 	jr nc, .loop
 	; This move has higher BP, reset the random range
 	xor a
-	ld [wBuffer2], a
+	ld [wForewarnEqualCount], a
 	jr .replace
 .randomize
 	; Move power was equal: randomize. This is done as follows as to give even results:
 	; 2 moves share power: 2nd move replaces 1/2 of the time
 	; 3 moves share power: 3rd move replaces 1/3 of the time
 	; 4 moves share power: 4th move replaces 1/4 of the time
-	ld a, [wBuffer2]
+	ld a, [wForewarnEqualCount]
 	inc a ; no-optimize inefficient WRAM increment/decrement
-	ld [wBuffer2], a
+	ld [wForewarnEqualCount], a
 	inc a
 	call BattleRandomRange
 	and a
 	jr nz, .loop
 .replace
 	ld a, b
-	ld [wBuffer3], a
+	ld [wForewarnBestMove], a
 	ld a, c
-	ld [wBuffer4], a
+	ld [wForewarnBestPower], a
 	jr .loop
 .done
 	; Check if we have an attacking move in first place
-	ld a, [wBuffer3]
+	ld a, [wForewarnBestMove]
 	and a
 	ret z
 	push af

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -1852,9 +1852,9 @@ DoSubtractHPFromUser:
 _SubtractHPFromPlayer:
 	ld hl, wBattleMonMaxHP
 	ld a, [hli]
-	ld [wBuffer2], a
+	ld [wHPBuffer1 + 1], a
 	ld a, [hl]
-	ld [wBuffer1], a
+	ld [wHPBuffer1], a
 	ld hl, wBattleMonHP
 	ldh a, [hBattleTurn]
 	push af
@@ -1867,9 +1867,9 @@ _SubtractHPFromPlayer:
 _SubtractHPFromEnemy:
 	ld hl, wEnemyMonMaxHP
 	ld a, [hli]
-	ld [wBuffer2], a
+	ld [wHPBuffer1 + 1], a
 	ld a, [hl]
-	ld [wBuffer1], a
+	ld [wHPBuffer1], a
 	ld hl, wEnemyMonHP
 	ldh a, [hBattleTurn]
 	push af
@@ -1948,28 +1948,28 @@ _SubtractHP:
 .do_subtract
 	inc hl
 	ld a, [hl]
-	ld [wBuffer3], a
+	ld [wHPBuffer2], a
 	sub c
 	ld [hld], a
-	ld [wBuffer5], a
+	ld [wHPBuffer3], a
 	ld a, [hl]
-	ld [wBuffer4], a
+	ld [wHPBuffer2 + 1], a
 	sbc b
 	ld [hl], a
-	ld [wBuffer6], a
+	ld [wHPBuffer3 + 1], a
 	ret nc
 
-	ld a, [wBuffer3]
+	ld a, [wHPBuffer2]
 	ld [wCurDamage+1], a
 	ld c, a
-	ld a, [wBuffer4]
+	ld a, [wHPBuffer2 + 1]
 	ld [wCurDamage], a
 	ld b, a
 	xor a
 	ld [hli], a
 	ld [hld], a
-	ld [wBuffer5], a
-	ld [wBuffer6], a
+	ld [wHPBuffer3], a
+	ld [wHPBuffer3 + 1], a
 	ret
 
 RestoreHP:
@@ -1980,36 +1980,36 @@ RestoreHP:
 	ld hl, wEnemyMonMaxHP
 .ok
 	ld a, [hli]
-	ld [wBuffer2], a
+	ld [wHPBuffer1 + 1], a
 	ld a, [hld]
-	ld [wBuffer1], a
+	ld [wHPBuffer1], a
 	dec hl
 	ld a, [hl]
-	ld [wBuffer3], a
+	ld [wHPBuffer2], a
 	add c
 	ld [hld], a
-	ld [wBuffer5], a
+	ld [wHPBuffer3], a
 	ld a, [hl]
-	ld [wBuffer4], a
+	ld [wHPBuffer2 + 1], a
 	adc b
 	ld [hli], a
-	ld [wBuffer6], a
+	ld [wHPBuffer3 + 1], a
 
-	ld a, [wBuffer1]
+	ld a, [wHPBuffer1]
 	ld c, a
 	ld a, [hld]
 	sub c
-	ld a, [wBuffer2]
+	ld a, [wHPBuffer1 + 1]
 	ld b, a
 	ld a, [hl]
 	sbc b
 	jr c, UpdateHPBarBattleHuds
 	ld a, b
 	ld [hli], a
-	ld [wBuffer6], a
+	ld [wHPBuffer3 + 1], a
 	ld a, c
 	ld [hl], a
-	ld [wBuffer5], a
+	ld [wHPBuffer3], a
 	; fallthrough
 
 UpdateHPBarBattleHuds:
@@ -5039,7 +5039,7 @@ MoveSelectionScreen:
 	hlcoord 6, 17 - NUM_MOVES - 4
 .got_start_coord
 	ld a, SCREEN_WIDTH
-	ld [wBuffer1], a
+	ld [wListMovesLineSpacing], a
 	predef ListMoves
 
 	ld a, [wMoveSelectionMenuType]

--- a/engine/battle/trainer_huds.asm
+++ b/engine/battle/trainer_huds.asm
@@ -50,7 +50,7 @@ StageBallTilesData:
 	assert wPartyMon1Status - wPartyCount == wOTPartyMon1Status - wOTPartyCount
 	ld de, wPartyMon1Status - wPartyCount
 	add hl, de
-	ld de, wBuffer1
+	ld de, wBattleHUDTiles
 .loop
 	push bc
 	ld a, b
@@ -179,7 +179,7 @@ LinkBattle_TrainerHuds:
 	; fallthrough
 
 LoadTrainerHudOAM:
-	ld de, wBuffer1
+	ld de, wBattleHUDTiles
 	ld c, PARTY_LENGTH
 .loop
 	ld a, [wPlaceBallsY]

--- a/engine/battle_anims/anim_commands.asm
+++ b/engine/battle_anims/anim_commands.asm
@@ -817,8 +817,8 @@ BattleAnimCmd_CheckPokeball:
 	ret
 
 BattleAnimCmd_CheckCriticalCapture:
-	ld hl, wBuffer2
-	ld a, BANK(wBuffer2)
+	ld hl, wThrownBallWobbleCount
+	ld a, BANK(wThrownBallWobbleCount)
 	call GetFarWRAMByte
 	and $10
 	ld [wBattleAnimVar], a

--- a/engine/battle_anims/pokeball_wobble.asm
+++ b/engine/battle_anims/pokeball_wobble.asm
@@ -1,11 +1,11 @@
 GetPokeBallWobble:
 ; Returns whether a Poke Ball will wobble in the catch animation.
-	ld a, BANK(wBuffer2)
+	ld a, BANK(wThrownBallWobbleCount)
 	call StackCallInWRAMBankA
 .Function:
 ; Wobble up to 3 times.
 	; Check for critical capture flag
-	ld a, [wBuffer2]
+	ld a, [wThrownBallWobbleCount]
 	and $10
 	jr z, .no_critical
 
@@ -16,7 +16,7 @@ GetPokeBallWobble:
 
 .no_critical
 	ld hl, .WobbleProbabilities
-	ld a, [wBuffer1]
+	ld a, [wFinalCatchRate]
 
 	; If a is 255, always capture
 	inc a
@@ -46,10 +46,10 @@ GetPokeBallWobble:
 	; Check how many wobbles we've done so far. If this would've been our 4th,
 	; we've successfully caught the Pokémon.
 	ld c, 0 ; shake
-	ld a, [wBuffer2]
+	ld a, [wThrownBallWobbleCount]
 	inc a
 .critical_shake
-	ld [wBuffer2], a
+	ld [wThrownBallWobbleCount], a
 	cp 4
 	ret c
 

--- a/engine/events/heal_machine_anim.asm
+++ b/engine/events/heal_machine_anim.asm
@@ -8,18 +8,18 @@ HealMachineAnim:
 	; 1: Left (Elm's Lab)
 	; 2: Up (Hall of Fame)
 	ldh a, [hScriptVar]
-	ld [wBuffer1], a
+	ld [wHealMachineAnimType], a
 	ldh a, [rOBP1]
-	ld [wBuffer2], a
+	ld [wHealMachineTempOBP1], a
 	call .DoJumptableFunctions
-	ld a, [wBuffer2]
+	ld a, [wHealMachineTempOBP1]
 	jmp DmgToCgbObjPal1
 
 .DoJumptableFunctions:
 	xor a
-	ld [wBuffer3], a
+	ld [wHealMachineAnimState], a
 .jumptable_loop
-	ld a, [wBuffer1]
+	ld a, [wHealMachineAnimType]
 	ld e, a
 	ld d, 0
 	ld hl, .Pointers
@@ -28,10 +28,10 @@ HealMachineAnim:
 	ld a, [hli]
 	ld h, [hl]
 	ld l, a
-	ld a, [wBuffer3]
+	ld a, [wHealMachineAnimState]
 	ld e, a
 	inc a
-	ld [wBuffer3], a
+	ld [wHealMachineAnimState], a
 	add hl, de
 	ld a, [hl]
 	cp 5
@@ -162,7 +162,7 @@ HealMachineAnim:
 
 .PlaceHealingMachineTile:
 	push bc
-	ld a, [wBuffer1]
+	ld a, [wHealMachineAnimType]
 	bcpixel 2, 4
 	dec a ; ElmsLab = 1
 	jr z, .okay

--- a/engine/events/item_maniacs.asm
+++ b/engine/events/item_maniacs.asm
@@ -131,11 +131,11 @@ GetItemQuantity:
 	ld [wNamedObjectIndex], a
 	ld hl, wNumItems
 	call CountItem
-	; CountItem returns 16-bit value in wBuffer1 (high) and wBuffer2 (low)
-	ld a, [wBuffer1]
+	; CountItem returns 16-bit value in wItemCountHi (high) and wItemCountLo (low)
+	ld a, [wItemCountHi]
 	and a
 	jr nz, .max_quantity ; If high byte is non-zero, cap at 99
-	ld a, [wBuffer2]
+	ld a, [wItemCountLo]
 	cp 100
 	jr c, .store_quantity
 .max_quantity

--- a/engine/events/itemfinder.asm
+++ b/engine/events/itemfinder.asm
@@ -7,7 +7,7 @@ ItemFinder:
 	jr .resume
 
 .found_something
-	ld [wBuffer1], a
+	ld [wCurMapScriptBank], a
 	ld hl, .Script_FoundSomething
 
 .resume
@@ -17,7 +17,7 @@ ItemFinder:
 	ret
 
 .ItemfinderEffect:
-	ld a, [wBuffer1]
+	ld a, [wCurMapScriptBank]
 	and $f ; taxicab distance, 0-15
 	inc a ; 1-16
 	cp 9
@@ -38,10 +38,10 @@ ItemFinder:
 	dec c
 	jr nz, .sfx_loop
 	ld d, PLAYER
-	ld a, [wBuffer1]
+	ld a, [wCurMapScriptBank]
 	and $f
 	ldh [hScriptVar], a
-	ld a, [wBuffer1]
+	ld a, [wCurMapScriptBank]
 	rrca
 	rrca
 	ld e, a

--- a/engine/events/judge_machine.asm
+++ b/engine/events/judge_machine.asm
@@ -489,7 +489,7 @@ RenderEVChart:
 
 RenderIVChart:
 ; Read the IVs and scale them to 255 instead of 31
-	ld hl, wBuffer1
+	ld hl, wJudgeHyperTrainFlags
 	ld a, [wTempMonHyperTraining]
 	ld [hl], a
 ; HP

--- a/engine/events/kurt.asm
+++ b/engine/events/kurt.asm
@@ -86,7 +86,7 @@ Kurt_SelectApricorn:
 	db $10 ; flags
 	db 4, 7
 	db 1
-	dbw 0, wBuffer1
+	dbw 0, wKurtApricornCount
 	dba .Name
 	dba .Quantity
 	dba NULL
@@ -200,7 +200,7 @@ Kurt_GiveUpSelectedQuantityOfSelectedApricorn:
 
 Kurt_FindApricornsInBag:
 ; Checks the bag for Apricorns.
-	ld hl, wBuffer1
+	ld hl, wKurtApricornCount
 	xor a
 	ld [hli], a
 	dec a
@@ -217,7 +217,7 @@ Kurt_FindApricornsInBag:
 	ld a, b
 	cp NUM_APRICORNS + 1
 	jr c, .loop
-	ld a, [wBuffer1]
+	ld a, [wKurtApricornCount]
 	and a
 	ret nz
 	scf
@@ -225,7 +225,7 @@ Kurt_FindApricornsInBag:
 
 .addtobuffer
 	push hl
-	ld hl, wBuffer1
+	ld hl, wKurtApricornCount
 	inc [hl]
 	ld e, [hl]
 	ld d, 0

--- a/engine/events/lucky_number.asm
+++ b/engine/events/lucky_number.asm
@@ -26,11 +26,11 @@ Special_CheckForLuckyNumberWinners:
 	jr nz, .next
 	ld de, wTempMonID
 	push bc
-	ld hl, wBuffer1
+	ld hl, wMonIDDigitsBuffer
 	lb bc, PRINTNUM_LEADINGZEROS | 2, 5
 	call PrintNum
 	ld hl, wStringBuffer1 + 4
-	ld de, wBuffer1 + 4
+	ld de, wMonIDDigitsBuffer + 4
 	ld b, 0
 .compare_loop
 	ld a, [de]

--- a/engine/events/pokecenter_pc.asm
+++ b/engine/events/pokecenter_pc.asm
@@ -327,15 +327,15 @@ PlayerWithdrawItemMenu:
 	ret c
 
 	ld a, [wItemQuantityChangeBuffer]
-	ld [wBuffer1], a ; quantity
+	ld [wPCItemQuantityChange], a ; quantity
 	ld a, [wCurItemQuantity]
-	ld [wBuffer2], a
+	ld [wPCItemQuantity], a
 	ld hl, wNumItems
 	call ReceiveItem
 	jr nc, .PackFull
-	ld a, [wBuffer1]
+	ld a, [wPCItemQuantityChange]
 	ld [wItemQuantityChangeBuffer], a
-	ld a, [wBuffer2]
+	ld a, [wPCItemQuantity]
 	ld [wCurItemQuantity], a
 	ld hl, wNumPCItems
 	call TossItem
@@ -456,15 +456,15 @@ PlayerDepositItemMenu:
 	dw .tossable
 
 .tossable
-	ld a, [wBuffer1]
+	ld a, [wPCItemQuantityChange]
 	push af
-	ld a, [wBuffer2]
+	ld a, [wPCItemQuantity]
 	push af
 	call .DepositItem_
 	pop af
-	ld [wBuffer2], a
+	ld [wPCItemQuantity], a
 	pop af
-	ld [wBuffer1], a
+	ld [wPCItemQuantityChange], a
 	ret
 
 .DepositItem_:
@@ -478,15 +478,15 @@ PlayerDepositItemMenu:
 	jr c, .DeclinedToDeposit
 
 	ld a, [wItemQuantityChangeBuffer]
-	ld [wBuffer1], a
+	ld [wPCItemQuantityChange], a
 	ld a, [wCurItemQuantity]
-	ld [wBuffer2], a
+	ld [wPCItemQuantity], a
 	ld hl, wNumPCItems
 	call ReceiveItem
 	jr nc, .NoRoomInPC
-	ld a, [wBuffer1]
+	ld a, [wPCItemQuantityChange]
 	ld [wItemQuantityChangeBuffer], a
-	ld a, [wBuffer2]
+	ld a, [wPCItemQuantity]
 	ld [wCurItemQuantity], a
 	ld hl, wNumItems
 	call TossItem

--- a/engine/events/treemons.asm
+++ b/engine/events/treemons.asm
@@ -434,11 +434,11 @@ NoTreeMon:
 
 GetTreeScore:
 	call .CoordScore
-	ld [wBuffer1], a
+	ld [wTreeMonCoordScore], a
 	call .OTIDScore
-	ld [wBuffer2], a
+	ld [wTreeMonOTIDScore], a
 	ld c, a
-	ld a, [wBuffer1]
+	ld a, [wTreeMonCoordScore]
 	sub c
 	jr z, .rare
 	jr nc, .ok

--- a/engine/events/wonder_trade.asm
+++ b/engine/events/wonder_trade.asm
@@ -223,10 +223,10 @@ DoWonderTrade:
 	call CopyTradeName
 
 	call Random
-	ld [wBuffer1], a
+	ld [wWonderTradeScratch], a
 	call Random
-	ld [wBuffer1 + 1], a
-	ld hl, wBuffer1
+	ld [wWonderTradeScratch + 1], a
+	ld hl, wWonderTradeScratch
 	ld de, wOTTrademonID
 	call Trade_CopyTwoBytes
 
@@ -272,12 +272,12 @@ DoWonderTrade:
 
 	; Random DVs
 	call Random
-	ld [wBuffer1], a
+	ld [wWonderTradeScratch], a
 	call Random
-	ld [wBuffer1 + 1], a
+	ld [wWonderTradeScratch + 1], a
 	call Random
-	ld [wBuffer1 + 2], a
-	ld hl, wBuffer1
+	ld [wWonderTradeScratch + 2], a
+	ld hl, wWonderTradeScratch
 	ld de, wOTTrademonDVs
 	call Trade_CopyThreeBytes
 
@@ -312,7 +312,7 @@ endr
 	ld b, a
 .not_shiny
 	ld a, b
-	ld [wBuffer1], a
+	ld [wWonderTradeScratch], a
 	; Random gender (50-50)
 	call Random
 	and GENDER_MASK
@@ -337,8 +337,8 @@ endr
 	; Form
 	ld a, [wCurForm]
 	add b
-	ld [wBuffer1 + 1], a
-	ld hl, wBuffer1
+	ld [wWonderTradeScratch + 1], a
+	ld hl, wWonderTradeScratch
 	ld de, wOTTrademonPersonality
 	call Trade_CopyTwoBytes
 

--- a/engine/items/buy_sell_toss.asm
+++ b/engine/items/buy_sell_toss.asm
@@ -136,9 +136,9 @@ SelectQuantityToBuy:
 	farcall GetItemPrice
 RooftopSale_SelectQuantityToBuy:
 	ld a, d
-	ld [wBuffer1], a
+	ld [wBuySellPriceHi], a
 	ld a, e
-	ld [wBuffer2], a
+	ld [wBuySellPriceLo], a
 	call CalculateMaximumQuantity
 	ld hl, BuyItem_MenuDataHeader
 	call LoadMenuHeader
@@ -146,9 +146,9 @@ RooftopSale_SelectQuantityToBuy:
 
 BT_SelectQuantityToBuy:
 	xor a
-	ld [wBuffer1], a
+	ld [wBuySellPriceHi], a
 	ld a, c
-	ld [wBuffer2], a
+	ld [wBuySellPriceLo], a
 	call CalculateMaximumBTQuantity
 	ld hl, BTBuyItem_MenuDataHeader
 	call LoadMenuHeader
@@ -157,9 +157,9 @@ BT_SelectQuantityToBuy:
 SelectQuantityToSell:
 	farcall GetItemPrice
 	ld a, d
-	ld [wBuffer1], a
+	ld [wBuySellPriceHi], a
 	ld a, e
-	ld [wBuffer2], a
+	ld [wBuySellPriceLo], a
 	ld hl, SellItem_MenuDataHeader
 	call LoadMenuHeader
 	; fallthrough
@@ -312,9 +312,9 @@ BuySell_DisplaySubtotal:
 BuySell_MultiplyPrice:
 	xor a
 	ldh [hMultiplicand + 0], a
-	ld a, [wBuffer1]
+	ld a, [wBuySellPriceHi]
 	ldh [hMultiplicand + 1], a
-	ld a, [wBuffer2]
+	ld a, [wBuySellPriceLo]
 	ldh [hMultiplicand + 2], a
 	ld a, [wItemQuantityChangeBuffer]
 	ldh [hMultiplier], a

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -383,7 +383,7 @@ PokeBallEffect:
 	ld [wWildMon], a
 
 	farcall GetModifiedCaptureRate
-	ld [wBuffer1], a
+	ld [wFinalCatchRate], a
 	ld a, [wTempEnemyMonSpecies]
 	ld [wWildMon], a
 
@@ -391,7 +391,7 @@ PokeBallEffect:
 	farcall CheckCriticalCapture
 	sbc a   ; if c (critical) then $ff else 0
 	and $10 ; if c (critical) then $10 else 0
-	ld [wBuffer2], a
+	ld [wThrownBallWobbleCount], a
 
 	ld c, 20
 	call DelayFrames
@@ -409,7 +409,7 @@ PokeBallEffect:
 	ld [wNumHits], a
 	predef PlayBattleAnim
 
-	ld a, [wBuffer2] ; amount of shakes
+	ld a, [wThrownBallWobbleCount] ; amount of shakes
 	and a
 	ld hl, Text_NoShake
 	jmp z, .shake_and_break_free
@@ -1587,23 +1587,23 @@ IsMonAtFullHealth:
 LoadCurHPIntoBuffer5:
 	call UseItem_GetHPParameter
 	ld a, [hli]
-	ld [wBuffer6], a
+	ld [wHPBuffer3 + 1], a
 	ld a, [hl]
-	ld [wBuffer5], a
+	ld [wHPBuffer3], a
 	ret
 
 LoadCurHPToBuffer3:
 	call UseItem_GetHPParameter
 	ld a, [hli]
-	ld [wBuffer4], a
+	ld [wHPBuffer2 + 1], a
 	ld a, [hl]
-	ld [wBuffer3], a
+	ld [wHPBuffer2], a
 	ret
 
 LoadHPFromBuffer3:
-	ld a, [wBuffer4]
+	ld a, [wHPBuffer2 + 1]
 	ld d, a
-	ld a, [wBuffer3]
+	ld a, [wHPBuffer2]
 	ld e, a
 	ret
 
@@ -1611,16 +1611,16 @@ LoadMaxHPToBuffer1:
 	push hl
 	call UseItem_GetMaxHPParameter
 	ld a, [hli]
-	ld [wBuffer2], a
+	ld [wHPBuffer1 + 1], a
 	ld a, [hl]
-	ld [wBuffer1], a
+	ld [wHPBuffer1], a
 	pop hl
 	ret
 
 LoadHPFromBuffer1:
-	ld a, [wBuffer2]
+	ld a, [wHPBuffer1 + 1]
 	ld d, a
-	ld a, [wBuffer1]
+	ld a, [wHPBuffer1]
 	ld e, a
 	ret
 
@@ -3138,12 +3138,12 @@ ApplyPPUp:
 	ld a, MON_MOVES
 	call GetPartyParamLocationAndValue
 	push hl
-	ld de, wBuffer1
+	ld de, wPPUpPPBuffer
 	predef FillPP
 	pop hl
 	ld bc, MON_PP - MON_MOVES
 	add hl, bc
-	ld de, wBuffer1
+	ld de, wPPUpPPBuffer
 	ld b, 0
 .loop
 	inc b

--- a/engine/items/poke_balls.asm
+++ b/engine/items/poke_balls.asm
@@ -125,7 +125,7 @@ CheckCriticalCapture:
 	ld hl, hMultiplier
 	ld [hli], a
 	ld [hli], a
-	ld a, [wBuffer1]
+	ld a, [wFinalCatchRate]
 	ld [hl], a
 
 	farcall Pokedex_CountSeenOwn

--- a/engine/items/update_item_description.asm
+++ b/engine/items/update_item_description.asm
@@ -12,7 +12,7 @@ UpdateItemDescriptionAndBagQuantity:
 	call GetQuantityInBag
 	hlcoord 5, 1
 	push hl
-	ld de, wBuffer1
+	ld de, wItemCountHi
 	lb bc, 2, 4
 	call PrintNum
 	pop hl
@@ -53,7 +53,7 @@ UpdateExpCandyDescriptionAndBagQuantity:
 	call GetExpCandyQuantity
 	hlcoord 5, 1
 	push hl
-	ld de, wBuffer1
+	ld de, wItemCountHi
 	lb bc, 2, 4
 	call PrintNum
 	pop hl
@@ -136,7 +136,7 @@ GetExpCandyQuantity:
 	ld e, a
 	add hl, de
 	xor a
-	ld [wBuffer1], a
+	ld [wItemCountHi], a
 	ld a, [hl]
-	ld [wBuffer2], a
+	ld [wItemCountLo], a
 	ret

--- a/engine/overworld/decorations.asm
+++ b/engine/overworld/decorations.asm
@@ -11,16 +11,16 @@ _PlayerDecorationMenu:
 	ld hl, .MenuHeader
 	call LoadMenuHeader
 	xor a
-	ld [wBuffer5], a
+	ld [wChangedDecorations], a
 	ld a, $1
-	ld [wBuffer6], a
+	ld [wCurDecorationCategory], a
 .top_loop
-	ld a, [wBuffer6]
+	ld a, [wCurDecorationCategory]
 	ld [wMenuCursorBuffer], a
 	call .FindCategoriesWithOwnedDecos
 	call DoNthMenu
 	ld a, [wMenuCursorY]
-	ld [wBuffer6], a
+	ld [wCurDecorationCategory], a
 	jr c, .exit_menu
 	ld a, [wMenuSelection]
 	ld hl, .category_pointers
@@ -31,7 +31,7 @@ _PlayerDecorationMenu:
 	call ExitMenu
 	pop af
 	ld [wWhichIndexSet], a
-	ld a, [wBuffer5]
+	ld a, [wChangedDecorations]
 	ld c, a
 	ret
 
@@ -656,12 +656,12 @@ DecoAction_putawaybigdoll:
 
 DecoAction_TrySetItUp:
 	ld a, [hl]
-	ld [wBuffer1], a
+	ld [wCurDecoration], a
 	push hl
 	call DecoAction_SetItUp
 	jr c, .failed
 	ld a, 1
-	ld [wBuffer5], a
+	ld [wChangedDecorations], a
 	pop hl
 	ld a, [wMenuSelection]
 	ld [hl], a
@@ -675,7 +675,7 @@ DecoAction_TrySetItUp:
 
 DecoAction_SetItUp:
 ; See if there's anything of the same type already out
-	ld a, [wBuffer1]
+	ld a, [wCurDecoration]
 	and a
 	jr z, .nothingthere
 ; See if that item is already out
@@ -687,7 +687,7 @@ DecoAction_SetItUp:
 	ld a, [wMenuSelection]
 	ld hl, wStringBuffer4
 	call GetDecorationName
-	ld a, [wBuffer1]
+	ld a, [wCurDecoration]
 	ld hl, wStringBuffer3
 	call GetDecorationName
 	ld hl, DecoText_PutAwayAndSetUp
@@ -713,16 +713,16 @@ DecoAction_SetItUp:
 DecoAction_TryPutItAway:
 ; If there is no item of that type already set, there is nothing to put away.
 	ld a, [hl]
-	ld [wBuffer1], a
+	ld [wCurDecoration], a
 	xor a
 	ld [hl], a
-	ld a, [wBuffer1]
+	ld a, [wCurDecoration]
 	and a
 	jr z, .nothingthere
 ; Put it away.
 	ld a, $1
-	ld [wBuffer5], a
-	ld a, [wBuffer1]
+	ld [wChangedDecorations], a
+	ld a, [wCurDecoration]
 	ld [wMenuSelection], a
 	ld hl, wStringBuffer3
 	call GetDecorationName
@@ -744,7 +744,7 @@ DecoAction_setupornament:
 	call DecoAction_SetItUp_Ornament
 	jr c, .cancel
 	ld a, $1
-	ld [wBuffer5], a
+	ld [wChangedDecorations], a
 	jr DecoAction_FinishUp_Ornament
 
 .cancel
@@ -764,15 +764,15 @@ DecoAction_putawayornament:
 
 DecoAction_FinishUp_Ornament:
 	call QueryWhichSide
-	ld a, [wBuffer3]
+	ld a, [wSelectedDecoration]
 	ld [hl], a
-	ld a, [wBuffer4]
+	ld a, [wOtherDecoration]
 	ld [de], a
 	xor a
 	ret
 
 DecoAction_SetItUp_Ornament:
-	ld a, [wBuffer3]
+	ld a, [wSelectedDecoration]
 	and a
 	jr z, .nothingthere
 	ld b, a
@@ -786,7 +786,7 @@ DecoAction_SetItUp_Ornament:
 	ld hl, wStringBuffer4
 	call GetDecorationName
 	ld a, [wMenuSelection]
-	ld [wBuffer3], a
+	ld [wSelectedDecoration], a
 	call .getwhichside
 	ld hl, DecoText_PutAwayAndSetUp
 	call MenuTextboxBackup
@@ -795,7 +795,7 @@ DecoAction_SetItUp_Ornament:
 
 .nothingthere
 	ld a, [wMenuSelection]
-	ld [wBuffer3], a
+	ld [wSelectedDecoration], a
 	call .getwhichside
 	ld a, [wMenuSelection]
 	ld hl, wStringBuffer3
@@ -814,11 +814,11 @@ DecoAction_SetItUp_Ornament:
 .getwhichside
 	ld a, [wMenuSelection]
 	ld b, a
-	ld a, [wBuffer4]
+	ld a, [wOtherDecoration]
 	cp b
 	ret nz
 	xor a
-	ld [wBuffer4], a
+	ld [wOtherDecoration], a
 	ret
 
 WhichSidePutOnText:
@@ -826,15 +826,15 @@ WhichSidePutOnText:
 	text_end
 
 DecoAction_PutItAway_Ornament:
-	ld a, [wBuffer3]
+	ld a, [wSelectedDecoration]
 	and a
 	jr z, .nothingthere
 	ld hl, wStringBuffer3
 	call GetDecorationName
 	ld a, $1
-	ld [wBuffer5], a
+	ld [wChangedDecorations], a
 	xor a
-	ld [wBuffer3], a
+	ld [wSelectedDecoration], a
 	ld hl, DecoText_PutAwayTheDeco
 	call MenuTextboxBackup
 	xor a
@@ -860,12 +860,12 @@ DecoAction_AskWhichSide:
 	ld a, [wMenuCursorY]
 	cp 3
 	jr z, .nope
-	ld [wBuffer2], a
+	ld [wSelectedDecorationSide], a
 	call QueryWhichSide
 	ld a, [hl]
-	ld [wBuffer3], a
+	ld [wSelectedDecoration], a
 	ld a, [de]
-	ld [wBuffer4], a
+	ld [wOtherDecoration], a
 	xor a
 	ret
 
@@ -876,7 +876,7 @@ DecoAction_AskWhichSide:
 QueryWhichSide:
 	ld hl, wDecoRightOrnament
 	ld de, wDecoLeftOrnament
-	ld a, [wBuffer2]
+	ld a, [wSelectedDecorationSide]
 	dec a
 	ret z
 	jmp SwapHLDE

--- a/engine/pokemon/mon_menu.asm
+++ b/engine/pokemon/mon_menu.asm
@@ -1528,7 +1528,7 @@ MoveScreen_ListMoves:
 	ld bc, NUM_MOVES
 	rst CopyBytes
 	ld a, SCREEN_WIDTH * 2 ; move list spacing
-	ld [wBuffer1], a
+	ld [wListMovesLineSpacing], a
 	hlcoord 2, 3
 	predef ListMoves
 

--- a/engine/pokemon/mon_stats.asm
+++ b/engine/pokemon/mon_stats.asm
@@ -457,7 +457,7 @@ ListMovePP:
 	sub c
 	ld b, a
 	push hl
-	ld a, [wBuffer1]
+	ld a, [wListMovesLineSpacing]
 	ld e, a
 	ld d, 0
 .pp_loop
@@ -533,7 +533,7 @@ ListMovePP:
 	lb bc, 1, 2
 	call PrintNum
 	pop hl
-	ld a, [wBuffer1]
+	ld a, [wListMovesLineSpacing]
 	ld e, a
 	ld d, 0
 	add hl, de
@@ -1012,7 +1012,7 @@ FntString: rawchar "Fnt@"
 ToxString: rawchar "Tox@"
 
 ListMoves:
-; List moves at hl, spaced every [wBuffer1] tiles.
+; List moves at hl, spaced every [wListMovesLineSpacing] tiles.
 	ld de, wListMoves_MoveIndicesBuffer
 	ld b, $0
 .moves_loop
@@ -1032,7 +1032,7 @@ ListMoves:
 	inc b
 	pop hl
 	push bc
-	ld a, [wBuffer1]
+	ld a, [wListMovesLineSpacing]
 	ld c, a
 	ld b, 0
 	add hl, bc
@@ -1048,7 +1048,7 @@ ListMoves:
 .nonmove_loop
 	push af
 	ld [hl], '-'
-	ld a, [wBuffer1]
+	ld a, [wListMovesLineSpacing]
 	ld c, a
 	ld b, 0
 	add hl, bc

--- a/engine/pokemon/mon_submenu.asm
+++ b/engine/pokemon/mon_submenu.asm
@@ -25,7 +25,7 @@ MonSubmenu:
 
 .GetTopCoord:
 ; TopCoord = 1 + BottomCoord - 2 * (NumSubmenuItems + 1)
-	ld a, [wBuffer1]
+	ld a, [wMonSubmenuCount]
 	inc a
 	add a
 	ld b, a
@@ -39,7 +39,7 @@ MonMenuLoop:
 .loop
 	ld a, $a0 ; flags
 	ld [wMenuDataFlags], a
-	ld a, [wBuffer1] ; items
+	ld a, [wMonSubmenuCount] ; items
 	ld [wMenuDataItems], a
 	call InitVerticalMenuCursor
 	ld hl, w2DMenuFlags1
@@ -60,7 +60,7 @@ MonMenuLoop:
 	dec a
 	ld c, a
 	ld b, 0
-	ld hl, wBuffer2
+	ld hl, wMonSubmenuItems
 	add hl, bc
 	ld a, [hl]
 	ret
@@ -69,7 +69,7 @@ PopulateMonMenu:
 	call MenuBoxCoord2Tile
 	ld bc, $2a ; 42
 	add hl, bc
-	ld de, wBuffer2
+	ld de, wMonSubmenuItems
 .loop
 	ld a, [de]
 	inc de
@@ -160,7 +160,7 @@ GetMonSubmenuItems:
 	call AddMonMenuItem
 
 .skip2
-	ld a, [wBuffer1]
+	ld a, [wMonSubmenuCount]
 	cp NUM_MONMENU_ITEMS
 	jr z, TerminateMonSubmenu
 	ld a, MONMENUITEM_CANCEL
@@ -196,17 +196,17 @@ IsFieldMove:
 
 ResetMonSubmenu:
 	xor a
-	ld [wBuffer1], a
-	ld hl, wBuffer2
+	ld [wMonSubmenuCount], a
+	ld hl, wMonSubmenuItems
 	ld bc, NUM_MONMENU_ITEMS + 1
 	rst ByteFill
 	ret
 
 TerminateMonSubmenu:
-	ld a, [wBuffer1]
+	ld a, [wMonSubmenuCount]
 	ld e, a
 	ld d, $0
-	ld hl, wBuffer2
+	ld hl, wMonSubmenuItems
 	add hl, de
 	ld [hl], -1
 	ret
@@ -215,12 +215,12 @@ AddMonMenuItem:
 	push hl
 	push de
 	push af
-	ld a, [wBuffer1]
+	ld a, [wMonSubmenuCount]
 	ld e, a
 	inc a
-	ld [wBuffer1], a
+	ld [wMonSubmenuCount], a
 	ld d, $0
-	ld hl, wBuffer2
+	ld hl, wMonSubmenuItems
 	add hl, de
 	pop af
 	ld [hl], a

--- a/engine/pokemon/summary/green_page.asm
+++ b/engine/pokemon/summary/green_page.asm
@@ -114,11 +114,11 @@ INCLUDE "gfx/stats/green_page.pal"
 	rst CopyBytes
 	hlbgcoord 0, 0, wSummaryScreenWindowBuffer
 	ld a, TILEMAP_WIDTH * 2
-	ld [wBuffer1], a
+	ld [wListMovesLineSpacing], a
 	predef ListMoves
 	hlbgcoord 4, 1, wSummaryScreenWindowBuffer
 	ld a, TILEMAP_WIDTH * 2
-	ld [wBuffer1], a
+	ld [wListMovesLineSpacing], a
 	predef ListMovePP
 
 for n, NUM_MOVES

--- a/engine/pokemon/summary/orange_page.asm
+++ b/engine/pokemon/summary/orange_page.asm
@@ -89,13 +89,13 @@ INCLUDE "gfx/stats/orange_page.pal"
 	jr z, .hatched
 	dec a
 	jr z, .traded
-	ld [wBuffer2], a
+	ld [wSummaryCaughtLevel], a
 	ld de, .str_level
 	rst PlaceString
 	ld h, b
 	ld l, c
 ;	hlcoord = 15, 9
-	ld de, wBuffer2
+	ld de, wSummaryCaughtLevel
 	lb bc, PRINTNUM_LEFTALIGN | 1, 3
 	jmp PrintNum
 .hatched

--- a/engine/pokemon/summary/pink_page.asm
+++ b/engine/pokemon/summary/pink_page.asm
@@ -129,7 +129,7 @@ SummaryScreen_PinkPage:
 	call .CalcExpToNextLevel
 	hlcoord 12, 15
 	lb bc, 3, 7
-	ld de, wBuffer1
+	ld de, wExpToNextLevel
 	call PrintNum
 	ld de, .LevelUpStr
 	hlcoord 1, 15
@@ -194,18 +194,18 @@ SummaryScreen_PinkPage:
 	ldh a, [hQuotient + 2]
 	sub [hl]
 	dec hl
-	ld [wBuffer3], a
+	ld [wExpToNextLevel + 2], a
 	ldh a, [hQuotient + 1]
 	sbc [hl]
 	dec hl
-	ld [wBuffer2], a
+	ld [wExpToNextLevel + 1], a
 	ldh a, [hQuotient]
 	sbc [hl]
-	ld [wBuffer1], a
+	ld [wExpToNextLevel], a
 	ret
 
 .AlreadyAtMaxLevel:
-	ld hl, wBuffer1
+	ld hl, wExpToNextLevel
 	xor a
 	ld [hli], a
 	ld [hli], a

--- a/engine/pokemon/switchpartymons.asm
+++ b/engine/pokemon/switchpartymons.asm
@@ -1,17 +1,17 @@
 _SwitchPartyMons:
 	ld a, [wSwitchMon]
 	dec a
-	ld [wBuffer3], a
+	ld [wSwitchPartyMonTarget], a
 	ld b, a
 	ld a, [wMenuCursorY]
 	dec a
-	ld [wBuffer2], a
+	ld [wSwitchPartyMonSource], a
 	cp b
 	ret z
 	call SwapMonAndMail
-	ld a, [wBuffer3]
+	ld a, [wSwitchPartyMonTarget]
 	call .ClearSprite
-	ld a, [wBuffer2]
+	ld a, [wSwitchPartyMonSource]
 	; fallthrough
 
 .ClearSprite:
@@ -40,7 +40,7 @@ SwapMonAndMail:
 	push hl
 	push de
 	push bc
-	ld a, [wBuffer2]
+	ld a, [wSwitchPartyMonSource]
 	ld hl, wPartyMons
 	ld bc, PARTYMON_STRUCT_LENGTH
 	rst AddNTimes
@@ -48,7 +48,7 @@ SwapMonAndMail:
 	ld de, wSwitchMonBuffer
 	ld bc, PARTYMON_STRUCT_LENGTH
 	rst CopyBytes
-	ld a, [wBuffer3]
+	ld a, [wSwitchPartyMonTarget]
 	ld hl, wPartyMons
 	ld bc, PARTYMON_STRUCT_LENGTH
 	rst AddNTimes
@@ -60,12 +60,12 @@ SwapMonAndMail:
 	ld hl, wSwitchMonBuffer
 	ld bc, PARTYMON_STRUCT_LENGTH
 	rst CopyBytes
-	ld a, [wBuffer2]
+	ld a, [wSwitchPartyMonSource]
 	ld hl, wPartyMonOTs
 	call SkipNames
 	push hl
 	call .CopyNameTowSwitchMonBuffer
-	ld a, [wBuffer3]
+	ld a, [wSwitchPartyMonTarget]
 	ld hl, wPartyMonOTs
 	call SkipNames
 	pop de
@@ -75,12 +75,12 @@ SwapMonAndMail:
 	ld hl, wSwitchMonBuffer
 	call .CopyName
 	ld hl, wPartyMonNicknames
-	ld a, [wBuffer2]
+	ld a, [wSwitchPartyMonSource]
 	call SkipNames
 	push hl
 	call .CopyNameTowSwitchMonBuffer
 	ld hl, wPartyMonNicknames
-	ld a, [wBuffer3]
+	ld a, [wSwitchPartyMonTarget]
 	call SkipNames
 	pop de
 	push hl
@@ -89,7 +89,7 @@ SwapMonAndMail:
 	ld hl, wSwitchMonBuffer
 	call .CopyName
 	ld hl, sPartyMail
-	ld a, [wBuffer2]
+	ld a, [wSwitchPartyMonSource]
 	ld bc, MAIL_STRUCT_LENGTH
 	rst AddNTimes
 	push hl
@@ -99,7 +99,7 @@ SwapMonAndMail:
 	call GetSRAMBank
 	rst CopyBytes
 	ld hl, sPartyMail
-	ld a, [wBuffer3]
+	ld a, [wSwitchPartyMonTarget]
 	ld bc, MAIL_STRUCT_LENGTH
 	rst AddNTimes
 	pop de

--- a/engine/rtc/restart_clock.asm
+++ b/engine/rtc/restart_clock.asm
@@ -18,13 +18,13 @@ endr
 	ret
 
 .WrapAroundTimes:
-	dw wBuffer4
+	dw wRestartClockDay
 	db 7, 4
 
-	dw wBuffer5
+	dw wRestartClockHour
 	db 24, 12
 
-	dw wBuffer6
+	dw wRestartClockMin
 	db 60, 15
 
 RestartClock:
@@ -60,17 +60,17 @@ RestartClock:
 
 .SetClock:
 	ld a, 1
-	ld [wBuffer1], a ; which digit
-	ld [wBuffer2], a
+	ld [wRestartClockCurDivision], a ; which digit
+	ld [wRestartClockPrevDivision], a
 	ld a, 8
-	ld [wBuffer3], a
+	ld [wRestartClockUpArrowYCoord], a
 	call UpdateTime
 	call GetWeekday
-	ld [wBuffer4], a
+	ld [wRestartClockDay], a
 	ldh a, [hHours]
-	ld [wBuffer5], a
+	ld [wRestartClockHour], a
 	ldh a, [hMinutes]
-	ld [wBuffer6], a
+	ld [wRestartClockMin], a
 
 .loop
 	call .joy_loop
@@ -82,11 +82,11 @@ RestartClock:
 	call PrintText
 	call YesNoBox
 	jr c, .cancel
-	ld a, [wBuffer4]
+	ld a, [wRestartClockDay]
 	ld [wStringBuffer2], a
-	ld a, [wBuffer5]
+	ld a, [wRestartClockHour]
 	ld [wStringBuffer2 + 1], a
-	ld a, [wBuffer6]
+	ld a, [wRestartClockMin]
 	ld [wStringBuffer2 + 2], a
 	xor a
 	ld [wStringBuffer2 + 3], a
@@ -143,7 +143,7 @@ RestartClock:
 	ret
 
 .pressed_up
-	ld a, [wBuffer1]
+	ld a, [wRestartClockCurDivision]
 	call ResetClock_GetWraparoundTime
 	ld a, [de]
 	inc a
@@ -155,7 +155,7 @@ RestartClock:
 	jr .done_scroll
 
 .pressed_down
-	ld a, [wBuffer1]
+	ld a, [wRestartClockCurDivision]
 	call ResetClock_GetWraparoundTime
 	ld a, [de]
 	dec a
@@ -168,14 +168,14 @@ RestartClock:
 	jr .done_scroll
 
 .pressed_left
-	ld hl, wBuffer1
+	ld hl, wRestartClockCurDivision
 	dec [hl]
 	jr nz, .done_scroll
 	ld [hl], $3
 	jr .done_scroll
 
 .pressed_right
-	ld hl, wBuffer1
+	ld hl, wRestartClockCurDivision
 	inc [hl]
 	ld a, [hl]
 	cp $4
@@ -191,28 +191,28 @@ RestartClock:
 	lb bc, 5, 18
 	call Textbox
 	bccoord 1, 8
-	ld a, [wBuffer4]
+	ld a, [wRestartClockDay]
 	call PrintDayOfWeek
-	ld a, [wBuffer5]
+	ld a, [wRestartClockHour]
 	ld b, a
-	ld a, [wBuffer6]
+	ld a, [wRestartClockMin]
 	ld c, a
 	decoord 11, 8
 	farcall PrintHoursMins
-	ld a, [wBuffer2]
+	ld a, [wRestartClockPrevDivision]
 	lb de, ' ', ' '
 	call .PlaceChars
-	ld a, [wBuffer1]
+	ld a, [wRestartClockCurDivision]
 	lb de, '▲', '▼'
 	call .PlaceChars
-	ld a, [wBuffer1]
-	ld [wBuffer2], a
+	ld a, [wRestartClockCurDivision]
+	ld [wRestartClockPrevDivision], a
 	ret
 
 .PlaceChars:
 	push de
 	call ResetClock_GetWraparoundTime
-	ld a, [wBuffer3]
+	ld a, [wRestartClockUpArrowYCoord]
 	dec a
 	ld b, a
 	call Coord2Tile

--- a/home/battle.asm
+++ b/home/battle.asm
@@ -189,7 +189,7 @@ FloorBC::
 	ret
 
 GetMaxHP::
-; output: bc, wBuffer1-2
+; output: bc, wHPBuffer1-2
 	farcall GetFutureSightUser
 	jr z, .not_external
 	ld a, MON_MAXHP
@@ -200,11 +200,11 @@ GetMaxHP::
 	call GetUserMonAttr
 .got_maxhp
 	ld a, [hli]
-	ld [wBuffer2], a
+	ld [wHPBuffer1 + 1], a
 	ld b, a
 
 	ld a, [hl]
-	ld [wBuffer1], a
+	ld [wHPBuffer1], a
 	ld c, a
 	ret
 

--- a/home/item.asm
+++ b/home/item.asm
@@ -50,9 +50,9 @@ CountItem::
 	push de
 	farcall _CountItem
 	ld a, b
-	ld [wBuffer1], a
+	ld [wItemCountHi], a
 	ld a, c
-	ld [wBuffer2], a
+	ld [wItemCountLo], a
 	jmp PopBCDEHL
 
 ReceiveKeyItem::

--- a/ram/wramx.asm
+++ b/ram/wramx.asm
@@ -566,13 +566,10 @@ wEvolvableFlags:: flag_array PARTY_LENGTH
 wForceEvolution:: db
 
 UNION
-; general-purpose buffers
-wBuffer1:: db
-wBuffer2:: db
-wBuffer3:: db
-wBuffer4:: db
-wBuffer5:: db
-wBuffer6:: db
+; general-purpose HP buffers
+wHPBuffer1:: dw
+wHPBuffer2:: dw
+wHPBuffer3:: dw
 
 NEXTU
 ; HP bar animations
@@ -606,6 +603,136 @@ NEXTU
 wMintTeaPartyMon:: db
 wMintTeaLikedFlavor:: db
 wMintTeaDislikedFlavor:: db
+
+NEXTU
+; thrown ball data
+wFinalCatchRate:: db
+wThrownBallWobbleCount:: db
+
+NEXTU
+; experience
+wExpToNextLevel:: ds 3
+
+NEXTU
+; PP Up
+wPPUpPPBuffer:: ds NUM_MOVES
+
+NEXTU
+; lucky number show
+wMonIDDigitsBuffer:: ds 5
+
+NEXTU
+; mon submenu
+wMonSubmenuCount:: db
+wMonSubmenuItems:: ds NUM_MONMENU_ITEMS + 1
+
+NEXTU
+; move list formatting
+wListMovesLineSpacing:: db
+
+NEXTU
+; field move data
+wFieldMoveData::
+wFieldMoveJumptableIndex:: db
+wEscapeRopeOrDigType::
+wSurfingPlayerState::
+wFishingRodUsed:: db
+wCutWhirlpoolOverworldBlockAddr:: dw
+wCutWhirlpoolReplacementBlock:: db
+wCutWhirlpoolAnimationType::
+wFishingResult:: db
+	ds 1
+wFieldMoveDataEnd::
+
+NEXTU
+; hidden items
+wCurMapScriptBank:: db
+wRemainingBGEventCount:: db
+wBottomRightYCoord:: db
+wBottomRightXCoord:: db
+
+NEXTU
+; heal machine anim
+wHealMachineAnimType:: db
+wHealMachineTempOBP1:: db
+wHealMachineAnimState:: db
+
+NEXTU
+; decorations
+wCurDecoration:: db
+wSelectedDecorationSide:: db
+wSelectedDecoration:: db
+wOtherDecoration:: db
+wChangedDecorations:: db
+wCurDecorationCategory:: db
+
+NEXTU
+; withdraw/deposit items
+wPCItemQuantityChange:: db
+wPCItemQuantity:: db
+
+NEXTU
+; kurt
+wKurtApricornCount:: db
+wKurtApricornItems:: ds 10
+
+NEXTU
+; tree mons
+wTreeMonCoordScore:: db
+wTreeMonOTIDScore:: db
+
+NEXTU
+; restart clock
+wRestartClockCurDivision:: db
+wRestartClockPrevDivision:: db
+wRestartClockUpArrowYCoord:: db
+wRestartClockDay:: db
+wRestartClockHour:: db
+wRestartClockMin:: db
+
+NEXTU
+; move AI
+wEnemyAIMoveScores:: ds NUM_MOVES
+
+NEXTU
+; battle HUD
+wBattleHUDTiles:: ds PARTY_LENGTH
+
+NEXTU
+; forewarn ability
+wForewarnIterator:: db
+wForewarnEqualCount:: db
+wForewarnBestMove:: db
+wForewarnBestPower:: db
+
+NEXTU
+; item buy/sell price
+wBuySellPriceHi:: db
+wBuySellPriceLo:: db
+
+NEXTU
+; item count
+wItemCountHi:: db
+wItemCountLo:: db
+
+NEXTU
+; switch party mons
+	ds 1
+wSwitchPartyMonSource:: db
+wSwitchPartyMonTarget:: db
+
+NEXTU
+; wonder trade scratch
+wWonderTradeScratch:: ds 3
+
+NEXTU
+; judge machine
+wJudgeHyperTrainFlags:: db
+
+NEXTU
+; summary caught level
+	ds 1
+wSummaryCaughtLevel:: db
 
 NEXTU
 ; link data


### PR DESCRIPTION
Resolves #581 

* Verified this does not change the sha1sum of the rom.

- Replaced general-purpose buffer references with specific variable names across various files, including item management, Pokémon stats, and RTC functionalities.
- Updated item deposit/withdrawal logic to use dedicated PC item quantity variables.
- Enhanced tree mon scoring and wonder trade processes with specific score variables.
- Improved item buy/sell processes by utilizing dedicated price variables.
- Streamlined decoration management by replacing buffer references with specific decoration variables.
- Refined Pokémon menu and summary pages to use dedicated line spacing and caught level variables.
- Overall, these changes aim to improve code readability and reduce potential errors associated with using generic buffers.