### PR TITLE
Trick/Switcheroo fix.

### DIFF
--- a/engine/battle/move_effects/trick.asm
+++ b/engine/battle/move_effects/trick.asm
@@ -39,10 +39,6 @@ BattleCommand_trick:
 	ld a, b
 	ld [de], a
 
-	ld [hl], c
-	ld a, b
-	ld [de], a
-
 	ld hl, SwappedItemsText
 	call StdBattleTextbox
 


### PR DESCRIPTION
Previously, the check for if both items were empty was performed after the swapping to avoid clobbering a; the issue is that the swap itself also involves clobbering a. This caused Switcheroo to partially fail whenever the opponent lacked an item, even if the user happened to hold one, since you were effectively or-ing b with itself.

Since both parts clobber a anyway, I felt I might as well swap the order, in addition to fixing the bug.