### PR TITLE
Fix Eusine's post-Ho-Oh quest progression

### DIFF
--- a/constants/event_flags.asm
+++ b/constants/event_flags.asm
@@ -2460,5 +2460,8 @@
 	const EVENT_GOT_OVAL_STONE_FROM_RUGGED_ROAD
 	const EVENT_CAN_RESURRECT_FOSSILS_IN_RUINS_OF_ALPH
 
+; Eusine quest state (use a spare flag without renumbering existing saves)
+	const EVENT_EUSINE_SAW_HO_OH
+
 	const_next $8ff
 DEF NUM_EVENTS EQU const_value ; 2303

--- a/engine/events/specials.asm
+++ b/engine/events/specials.asm
@@ -434,7 +434,6 @@ RespawnOneOffs:
 	jr nz, .CaughtHoOh
 	eventflagreset EVENT_TIN_TOWER_ROOF_HO_OH
 	eventflagreset EVENT_FOUGHT_HO_OH
-	eventflagreset EVENT_EUSINES_HOUSE_EUSINE
 .CaughtHoOh
 
 	ld de, ENGINE_PLAYER_CAUGHT_GALARIAN_ARTICUNO

--- a/maps/EusinesHouse.asm
+++ b/maps/EusinesHouse.asm
@@ -98,14 +98,12 @@ CeladonEusine:
 	step_end
 
 EusinesHouseGrampsScript:
+	checkevent EVENT_EUSINE_SAW_HO_OH
+	iftruefwd .EusineLeft
 	checkevent EVENT_EUSINES_HOUSE_EUSINE
 	iffalse_jumptextfaceplayer EusinesHouseGrampsGrandsonHomeText
 	checkevent EVENT_FOUGHT_SUICUNE
 	iffalse_jumptextfaceplayer EusinesHouseGrampsEusineSearchingForSuicuneText
-	checkevent EVENT_DECO_ABRA_DOLL
-	iftrue_jumptextfaceplayer EusinesHouseGrampsEusineTravelingWorldText
-	checkevent EVENT_FOUGHT_HO_OH
-	iftruefwd .AfterHoOhFight
 	jumpthistextfaceplayer
 
 	text "My grandson Eusine"
@@ -117,7 +115,9 @@ EusinesHouseGrampsScript:
 	cont "Ecruteak City."
 	done
 
-.AfterHoOhFight:
+.EusineLeft:
+	checkevent EVENT_DECO_ABRA_DOLL
+	iftrue_jumptextfaceplayer EusinesHouseGrampsEusineTravelingWorldText
 	faceplayer
 	opentext
 	writetext EusinesHouseGrampsThankYouGiftText

--- a/maps/TinTower1F.asm
+++ b/maps/TinTower1F.asm
@@ -42,18 +42,15 @@ TinTower1FSuicuneBattleScene:
 	end
 
 TinTower1FNPCsCallback:
+	; Ho-Oh's battle script places Eusine here until his farewell.
 	checkevent EVENT_GOT_RAINBOW_WING
-	iftruefwd .GotRainbowWing
+	iftruefwd .Done
 	checkevent EVENT_BEAT_ELITE_FOUR
 	iffalsefwd .FaceBeasts
 	special SpecialBeastsCheck
 	iffalsefwd .FaceBeasts
 	clearevent EVENT_TIN_TOWER_1F_WISE_TRIO_2
 	setevent EVENT_TIN_TOWER_1F_WISE_TRIO_1
-.GotRainbowWing:
-	checkevent EVENT_FOUGHT_HO_OH
-	iffalsefwd .Done
-	appear TINTOWER1F_EUSINE
 .Done:
 	endcallback
 
@@ -297,6 +294,7 @@ TinTower1FSage6Script:
 TinTower1FEusineAfterHoOhScript:
 	faceplayer
 	showtext TinTowerEusineHoOhText
+	setevent EVENT_EUSINE_SAW_HO_OH
 	readvar VAR_FACING
 	ifnotequal RIGHT, .PathClear
 	applymovement PLAYER, .PlayerStepsAsideMovement

--- a/maps/TinTowerRoof.asm
+++ b/maps/TinTowerRoof.asm
@@ -40,6 +40,12 @@ TinTowerHoOh:
 	pause 15
 	closetext
 	setevent EVENT_FOUGHT_HO_OH
+	; Arrange the farewell even if the player loses or later respawns Ho-Oh.
+	checkevent EVENT_EUSINE_SAW_HO_OH
+	iftruefwd .Battle
+	setevent EVENT_EUSINES_HOUSE_EUSINE
+	clearevent EVENT_TIN_TOWER_1F_EUSINE
+.Battle:
 	loadvar VAR_BATTLETYPE, BATTLETYPE_LEGENDARY
 	loadwildmon HO_OH, 75
 	startbattle


### PR DESCRIPTION
Closes #1282.

After meeting Ho-Oh before visiting Celadon, Eusine could still announce fresh rumors from his house, and Bell Tower recreated his farewell on every visit. Elite Four respawns could also send him home again. Eusine now progresses through the original story once, independently of Ho-Oh's respawn state.

This replaces the previous implementation on `master` at `d60d881025` (including the latest Wonder Trade fix). The phone contact and rematch additions are removed so the change addresses the quest inconsistency without extending the story.

### Quest flow

```mermaid
flowchart TD
    A[Battle Suicune] --> B[Eusine visits his Celadon home]
    B --> C{Talk to Eusine at home?}
    C -->|Missing a legendary beast| D[Research notes; Eusine stays home]
    D --> C
    C -->|All three beasts caught| E[Eusine leaves for Bell Tower]
    C -->|Skip Celadon| F[Encounter Ho-Oh]
    E --> F
    F --> G[Eusine leaves home and awaits you at Bell Tower]
    G --> H[Hear his farewell once]
    H --> I[Eusine leaves to travel the world]
    I --> J[Grandpa gives the Abra Doll once]
    R[Defeat the Elite Four again] -.-> S[Uncaught Ho-Oh respawns; Eusine keeps his progress]
```

- The Ho-Oh encounter schedules the farewell before battle, covering capture, defeat, fleeing, and whiteout.
- Bell Tower no longer recreates Eusine through its map callback. His pending farewell survives Elite Four respawns.
- A permanent farewell flag unlocks Grandpa's gift and traveling dialogue. Ho-Oh rematches cannot reset either.

### Save patcher handoff

`EVENT_EUSINE_SAW_HO_OH` (`$8ef`) is a new permanent flag in previously unused event space. Every existing event index and the save layout remain unchanged. There is no in-ROM save migration, no change to save loading or new-game initialization, and no save-version bump. Save conversion will be handled separately by the external patcher when the save version is officially upgraded.

The intended states for that conversion are:

| Quest state | House hidden | Bell Tower Eusine hidden | New farewell flag |
| --- | --- | --- | --- |
| Before Suicune | Yes | Yes | Clear |
| Visiting Celadon | No | Yes | Clear |
| Left Celadon, before Ho-Oh | Yes | Yes | Clear |
| Awaiting farewell after Ho-Oh | Yes | No | Clear |
| Farewell complete | Yes | Yes | Set |

Legacy saves did not record the farewell. `EVENT_FOUGHT_HO_OH`, the player's Ho-Oh caught flag, the Abra Doll, and Bell Tower Eusine's visibility provide partial evidence, but some histories are indistinguishable after an Elite Four respawn. The external patcher will need to choose how to map those ambiguous states; this PR makes no automatic conversion decision.

### Validation

- Standard and Faithful ROM builds, with all assembly objects rebuilt for each variant.
- 42 scenarios per variant in a local headless vibeEmu harness: new-game initialization, Suicune progression, all beast-capture combinations, skipped Celadon, Ho-Oh battle outcomes, repeated respawns, and the one-time gift.
- The harness executes the compiled respawn routine and script condition/event commands; presentation, object rendering/movement, and battle outcomes are simulated. This is not a full interactive playthrough.
- Headless standard-ROM startup smoke test (180 frames).
- All 2,267 existing event constant values unchanged; `git diff --check` clean.
- Reviewed the [assembly optimization guide](https://github.com/pret/pokecrystal/wiki/Optimizing-assembly-code) and ran `python3 utils/optimize.py` before and after the rework: zero findings.
