### PR TITLE
Load missing partymon palette for name rater

### DIFF
--- a/engine/gfx/mon_icons.asm
+++ b/engine/gfx/mon_icons.asm
@@ -395,7 +395,17 @@ _LoadMonMini:
 
 	; for move menu, mon minis use palette 1
 	ld de, wOBPals1 palette 1 + 2
+
+	ld a, [wMonType]
+	cp TEMPMON
+	jr z, .use_temp
+	; not temp -> use party palette
+	farcall LoadPartyMonPalette
+	jr .palette_done
+.use_temp
 	farcall LoadTempMonPalette
+
+.palette_done
 	ld a, 1
 	ld hl, wShadowOAMSprite00Attributes
 	ld de, OBJ_SIZE


### PR DESCRIPTION
Closes #1481 

I investigated this for a while, I'm still learning assembly so please let me know if I've made some glaring mistakes.

`_LoadMonMini` always loaded mini palettes via `LoadTempMonPalette`, which reads from `wTempMon`.  
In nickname flows like Name Rater, the selected mon is a party mon (`wMonType = PARTYMON`), so palette data could be read from stale `wTempMon` state instead of the current party mon.

I think this explains the inconsistent mini colors, including incorrect shiny coloring and occasionally completely wrong palettes.

### Fix
Choose palette source by `wMonType` in `_LoadMonMini`:
- `TEMPMON` -> `LoadTempMonPalette`
- otherwise -> `LoadPartyMonPalette`

<img width="521" height="494" alt="Screenshot 2026-03-11 at 23 17 27" src="https://github.com/user-attachments/assets/a5f07a1d-ed7a-4f51-851a-24ef25922b94" />
