### PR TITLE
Optional level caps

### DIFF
--- a/constants/ram_constants.asm
+++ b/constants/ram_constants.asm
@@ -118,7 +118,8 @@ DEF LINK_OPTMASK EQU (1 << NATURES_OPT) | (1 << ABILITIES_OPT) | (1 << PERFECT_I
 	const NO_EXP_OPT           ; 2
 	const RTC_OPT              ; 3
 	const EVOLVE_IN_BATTLE_OPT ; 4
-	const_skip 2
+	const LEVEL_CAP_OPT        ; 5
+	const_skip 1
 	const RESET_INIT_OPTS      ; 7
 
 	const_def

--- a/data/options/initial_option_names.asm
+++ b/data/options/initial_option_names.asm
@@ -11,6 +11,7 @@ InitialOptionNames:
 	dw .TradedMon
 	dw .EvolveInBattle
 	dw .ColorVariation
+	dw .LevelCap
 	assert_table_length NUM_INITIAL_MENU_OPTIONS
 
 .Natures:
@@ -35,3 +36,5 @@ InitialOptionNames:
 	db "Evolve in battle@"
 .ColorVariation:
 	db "Color variation@"
+.LevelCap:
+	db "Level cap@"

--- a/data/options/initial_options_descriptions.asm
+++ b/data/options/initial_options_descriptions.asm
@@ -13,6 +13,7 @@ InitialOptionDescriptions:
 	dw .TradedMon
 	dw .EvolveInBattle
 	dw .ColorVariation
+	dw .LevelCap
 	assert_table_length NUM_INITIAL_MENU_OPTIONS
 
 .Natures:
@@ -162,6 +163,22 @@ InitialOptionDescriptions:
 
 	para "variation based"
 	line "on nicknames."
+	prompt
+
+.LevelCap:
+	text "Your #mon stop"
+	line "gaining Exp. once"
+	cont "they reach the"
+
+	para "level of the next"
+	line "Gym Leader's or"
+	cont "Champion's ace."
+
+	para "The cap rises as"
+	line "you earn Badges."
+
+	para "Exp.Candy and Rare"
+	line "Candy obey it too."
 	prompt
 
 InitialOptionsDoneDescription:

--- a/data/wild/level_caps.asm
+++ b/data/wild/level_caps.asm
@@ -1,0 +1,23 @@
+; LevelCaps[CountSetBits(wBadges)] is the highest level a Pokémon can reach
+; until the next major battle. Each entry is the next boss's ace level, per
+; https://github.com/Rangi42/polishedcrystal/wiki/Nuzlocke#list-of-highest-levels
+; Post-game caps (Red, ???) are handled by event flags in GetLevelCap.
+
+LevelCaps:
+	db 13 ; 0 badges
+	db 17 ; 1 badge (falkner)
+	db 21 ; 2 badges (bugsy)
+	db 26 ; 3 badges (whitney)
+	db 31 ; 4 badges (morty)
+	db 37 ; 5 badges (chuck)
+	db 42 ; 6 badges (jasmine)
+	db 47 ; 7 badges (pryce)
+	db 60 ; 8 badges (clair / johto elite four & champion)
+	db 62 ; 9 badges (lt.surge)
+	db 64 ; 10 badges (sabrina)
+	db 65 ; 11 badges (misty)
+	db 65 ; 12 badges (erika)
+	db 66 ; 13 badges (janine)
+	db 69 ; 14 badges (brock)
+	db 70 ; 15 badges (blaine)
+	db 80 ; 16 badges (blue / kanto elite four & champion)

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -6487,6 +6487,10 @@ GiveExperiencePoints:
 	and a
 	ret nz
 
+	; Compute the level cap once; it's the same for every party mon.
+	farcall GetLevelCap
+	ld [wLevelCap], a
+
 	xor a
 	ld [wCurPartyMon], a
 	ld bc, wPartyMon1Species
@@ -6517,12 +6521,13 @@ GiveExperiencePoints:
 	bit NO_EXP_OPT, a
 	jmp nz, .next_mon
 
-	; No experience at level 100
+	; No experience at or above the level cap
 	ld hl, MON_LEVEL
 	add hl, bc
 	ld a, [hl]
-	cp MAX_LEVEL
-	jmp z, .next_mon
+	ld hl, wLevelCap
+	cp [hl]
+	jmp nc, .next_mon
 
 	push bc
 	xor a
@@ -6642,7 +6647,8 @@ GiveExperiencePoints:
 	ld [wCurForm], a
 	call GetBaseData
 	push bc
-	ld d, MAX_LEVEL
+	ld a, [wLevelCap]
+	ld d, a
 	farcall CalcExpAtLevel
 	pop bc
 	ld hl, MON_EXP + 2

--- a/engine/items/item_effects.asm
+++ b/engine/items/item_effects.asm
@@ -788,14 +788,22 @@ RareCandy:
 
 	call UseItem_GetBaseDataAndNickParameters
 
+	farcall GetLevelCap
+	ld [wLevelCap], a
+
 	ld a, MON_LEVEL
 	call GetPartyParamLocationAndValue
-	cp MAX_LEVEL
+	push hl
+	ld hl, wLevelCap
+	cp [hl] ; level - cap; carry set if below the cap
+	pop hl
 	jr c, .not_max_level
 
 	; This evolution check isn't limited to level-based evolution, but covers
 	; everything that can be induced by a level up. And we want to force the
-	; evolution!
+	; evolution! At or above the level cap (which includes level 100) we behave
+	; like vanilla does at level 100: force a level-up evolution if possible,
+	; else the candy has no effect and is not consumed.
 	ld a, EVOLVE_LEVEL
 	jmp InduceEvolutionWithItem
 
@@ -1865,11 +1873,17 @@ INCLUDE "data/items/wing_names.asm"
 CandyJar_MonSelected:
 ; Runs when a mon has been selected.
 
-	; if mon is level 100, no effect.
+	farcall GetLevelCap
+	ld [wLevelCap], a
+
+	; if mon is at or above the level cap (which includes level 100), no effect.
 	ld a, MON_LEVEL
 	call GetPartyParamLocationAndValue
-	cp MAX_LEVEL
-	jmp z, .no_effect
+	push hl
+	ld hl, wLevelCap
+	cp [hl] ; level - cap; carry set if below the cap
+	pop hl
+	jmp nc, .no_effect
 
 	; What candy does the player want to choose?
 	ldh a, [hBGMapMode]
@@ -1934,7 +1948,8 @@ CandyJar_MonSelected:
 
 	; load max_exp into wCandyMaxLevelExp
 	call UseItem_GetBaseDataAndNickParameters
-	ld d, MAX_LEVEL
+	ld a, [wLevelCap]
+	ld d, a
 	farcall CalcExpAtLevel
 	ldh a, [hProduct + 1]
 	ld [wCandyMaxLevelExp + 0], a

--- a/engine/menus/initial_options_menu.asm
+++ b/engine/menus/initial_options_menu.asm
@@ -62,7 +62,7 @@ SetInitialOptions:
 .BGPalettes:
 INCLUDE "gfx/options/initial_options_bg.pal"
 
-DEF NUM_INITIAL_MENU_OPTIONS EQU 11
+DEF NUM_INITIAL_MENU_OPTIONS EQU 12
 
 InitialOptions_CallOptionRoutine:
 	ld a, [wMenuSelection]
@@ -82,6 +82,7 @@ InitialOptions_CallOptionRoutine:
 	dw InitialOptions_TradedMon
 	dw InitialOptions_EvolveInBattle
 	dw InitialOptions_ColorVariation
+	dw InitialOptions_LevelCap
 	assert_table_length NUM_INITIAL_MENU_OPTIONS
 
 MenuDataHeader_InitialOptions:
@@ -384,6 +385,26 @@ InitialOptions_ColorVariation:
 	jmp OptionsShared_PlaceStringAtValueCoord
 .SetYes:
 	set COLOR_VARY_OPT, [hl]
+	ld de, YesString
+	jmp OptionsShared_PlaceStringAtValueCoord
+
+InitialOptions_LevelCap:
+	ld hl, wInitialOptions2
+	ldh a, [hJoyPressed]
+	and PAD_LEFT | PAD_RIGHT
+	jr nz, .Toggle
+	bit LEVEL_CAP_OPT, [hl]
+	jr z, .SetNo
+	jr .SetYes
+.Toggle:
+	bit LEVEL_CAP_OPT, [hl]
+	jr z, .SetYes
+.SetNo:
+	res LEVEL_CAP_OPT, [hl]
+	ld de, NoString
+	jmp OptionsShared_PlaceStringAtValueCoord
+.SetYes:
+	set LEVEL_CAP_OPT, [hl]
 	ld de, YesString
 	jmp OptionsShared_PlaceStringAtValueCoord
 

--- a/engine/overworld/wildmons.asm
+++ b/engine/overworld/wildmons.asm
@@ -1180,7 +1180,53 @@ SetBadgeBaseLevel:
 	ld [wBadgeBaseLevel], a
 	ret
 
+GetLevelCap::
+; Returns the current level cap in a.
+; If the level cap option is off, returns MAX_LEVEL (i.e. vanilla behavior).
+; Otherwise the cap rises with progress (each cap is the next boss's ace level):
+;   beat Red                 -> 100
+;   beat the Kanto Elite 4   ->  90
+;   otherwise LevelCaps[number of badges owned]
+; Clobbers a, bc, de, hl. Requires WRAM bank 1 (for wBadges/wEventFlags), which
+; is always active in the battle and menu contexts that call this.
+	ld a, [wInitialOptions2]
+	bit LEVEL_CAP_OPT, a
+	jr nz, .enabled
+	ld a, MAX_LEVEL
+	ret
+
+.enabled
+	ld de, EVENT_BEAT_RED
+	ld b, CHECK_FLAG
+	call EventFlagAction
+	ld a, c
+	and a
+	jr z, .check_kanto_elite_four
+	ld a, 100
+	ret
+
+.check_kanto_elite_four
+	ld de, EVENT_BEAT_ELITE_FOUR_AGAIN
+	ld b, CHECK_FLAG
+	call EventFlagAction
+	ld a, c
+	and a
+	jr z, .by_badges
+	ld a, 90
+	ret
+
+.by_badges
+	ld hl, wBadges
+	ld b, wBadgesEnd - wBadges
+	call CountSetBits
+	ld hl, LevelCaps
+	ld b, 0
+	add hl, bc
+	ld a, [hl]
+	ret
+
 INCLUDE "data/wild/badge_base_levels.asm"
+INCLUDE "data/wild/level_caps.asm"
 
 AdjustLevelForBadges:
 	cp MAX_LEVEL + 1

--- a/ram/wram0.asm
+++ b/ram/wram0.asm
@@ -1411,7 +1411,8 @@ wColoredMaleFemaleShinyTiles:: ds 3 tiles
 
 SECTION "Unused", WRAM0
 
-	ds 318 ; it's free real estate
+wLevelCap:: db ; highest level a Pokémon can reach this battle/item use; see GetLevelCap
+	ds 317 ; it's free real estate
 
 
 SECTION "Options", WRAM0
@@ -1478,7 +1479,8 @@ wInitialOptions2::
 ; bit 2: no exp on/off (cannot be set together with scaled exp)
 ; bit 3: use RTC
 ; bit 4: evolve in battle
-; bits 5-6: unused
+; bit 5: level cap on/off
+; bit 6: unused
 ; bit 7: ask to reset at start
 	db
 wOptionsEnd::


### PR DESCRIPTION
## Add optional level cap

Adds a new toggle to the initial options menu — **Level cap: Yes / No** (Default: No)— that enforces an experience cap. When enabled, Pokémon stop gaining Exp once they reach the level of the next Gym Leader's or Champion's ace. The cap rises automatically as badges are earned.

### How the cap is determined

The cap is computed by `GetLevelCap` (added to `engine/overworld/wildmons.asm`) using the following priority:

| Condition | Cap |
|---|---|
| Beaten Red | 100 |
| Beaten Kanto Elite Four | 90 |
| Otherwise | `LevelCaps[badge_count]` |

The `LevelCaps` table (added as `data/wild/level_caps.asm`) maps badge count to the next major boss's ace level:

| Badges | Cap | Next boss |
|---|---|---|
| 0 | 13 | Falkner |
| 1 | 17 | Bugsy |
| 2 | 21 | Whitney |
| 3 | 26 | Morty |
| 4 | 31 | Chuck |
| 5 | 37 | Jasmine |
| 6 | 42 | Pryce |
| 7 | 47 | Clair / Johto E4 |
| 8 | 60 | Lt. Surge |
| 9 | 62 | Sabrina |
| 10 | 64 | Misty |
| 11 | 65 | Erika |
| 12 | 65 | Janine |
| 13 | 66 | Brock |
| 14 | 69 | Blaine |
| 15 | 70 | Blue / Kanto E4 |
| 16 | 80 | (post-game) |

This logic has been based on the nuzlock-style caps defined [here](https://github.com/Rangi42/polishedcrystal/wiki/Nuzlocke#list-of-highest-levels)

### Files changed

- **`constants/ram_constants.asm`** — adds `LEVEL_CAP_OPT` constant (bit 5 of `wInitialOptions2`)
- **`ram/wram0.asm`** — adds `wLevelCap` scratch variable in WRAM0; documents `LEVEL_CAP_OPT` in the `wInitialOptions2` bit layout
- **`data/wild/level_caps.asm`** *(new)* — the badge-indexed level cap table
- **`engine/overworld/wildmons.asm`** — adds `GetLevelCap` function; includes new table
- **`engine/battle/core.asm`** — `GiveExperiencePoints` calls `GetLevelCap` once per battle and skips Exp for any Pokémon at or above the cap
- **`engine/items/item_effects.asm`** — Rare Candy and Exp. Candy both respect the cap; at or above the cap, Rare Candy still triggers level-up evolutions (matching vanilla level 100 behaviour) but the candy is not consumed
- **`engine/menus/initial_options_menu.asm`** — adds `InitialOptions_LevelCap` routine and wires it into the option dispatch table; bumps `NUM_INITIAL_MENU_OPTIONS` to 12
- **`data/options/initial_option_names.asm`** — adds "Level cap" entry
- **`data/options/initial_options_descriptions.asm`** — adds full in-game description for the option

### Design notes

- When the option is **off**, `GetLevelCap` returns `MAX_LEVEL` (100), preserving vanilla behaviour exactly — no other code path is affected.
- The cap is cached in `wLevelCap` at the start of each Exp distribution loop and each candy use, avoiding repeated `farcall`s per party member.
- The cap uses `>= cap` (not `== 100`) so Pokémon already over-levelled from a previous session are also blocked from gaining further Exp.

### Considerations

I am aware of the [history with nuzlock modes](https://github.com/Rangi42/polishedcrystal/blob/master/FAQ.md#what-happened-to-nuzlocke-mode) this romhack has and therefore the potential pushback this PR might have, however I believe level caps are a feature more related to enhancing the difficulty, level curve and overall experience of the romhack than they are to nuzlocking. Plus, this is something the game can easily handle that removes a lot of headaches and manual work from the player, cause even if the player wants to self-impose level caps they have to be constantly juggling pokemon to play the "do not exceed the level" roulette game rather than enjoying the rom for what it is. The option is also disabled by default and the player can choose to enable it when starting a new game.

I will also add that the changes in this PR have been mostly written by Claude and steered by a human - I want to make that very clear as I am aware a lot of GH repo owners do not appreciate AI-written contributions, not sure if that is the case here.