### PR TITLE
Implement changes to Bug Contest encounters

### DIFF
--- a/data/wild/bug_contest_mons.asm
+++ b/data/wild/bug_contest_mons.asm
@@ -39,7 +39,7 @@ ContestMonsEnd:
 
 ; Bug Catching Contest after E4
 E4_ContestMons:
-	;           Time, Weight, min,                   max,                   species
+	;           Time, Weight, min,                    max,                   species
 	contest_mon    7,     10, LEVEL_FROM_BADGES + 0,  LEVEL_FROM_BADGES + 4, BUTTERFREE
 	contest_mon    7,     10, LEVEL_FROM_BADGES + 0,  LEVEL_FROM_BADGES + 4, BEEDRILL
 	contest_mon    7,     10, LEVEL_FROM_BADGES + 0,  LEVEL_FROM_BADGES + 4, PARAS
@@ -60,7 +60,7 @@ E4_ContestMonsEnd:
 
 ; Bug Catching Contest after Blue
 Blue_ContestMons:
-	;           Time, Weight, min,                   max,                   species
+	;           Time, Weight, min,                    max,                   species
 	contest_mon    7,     10, LEVEL_FROM_BADGES + 0,  LEVEL_FROM_BADGES + 4, BUTTERFREE
 	contest_mon    7,     10, LEVEL_FROM_BADGES + 0,  LEVEL_FROM_BADGES + 4, BEEDRILL
 	contest_mon    7,      7, LEVEL_FROM_BADGES - 1,  LEVEL_FROM_BADGES + 2, PARASECT

--- a/data/wild/bug_contest_mons.asm
+++ b/data/wild/bug_contest_mons.asm
@@ -1,21 +1,80 @@
 MACRO contest_mon
-	db \1
-	dp \2
-	db \3, \4
+	db \1     ; Time of Day
+	db \2     ; Encounter Weight
+	db \3, \4 ; Min-Max Levels
+	if _NARG == 6
+		dp \5, \6 ; Species & Form
+		shift
+	else
+		dp \5 ; Species
+	endc
 ENDM
 
+; Times of Day Masks
+; 1 = Morning Only
+; 2 = Day Only
+; 3 = Morning and Day
+; 4 = Night Only
+; 5 = Morning and Night
+; 6 = Day and Night
+; 7 = All Times of Day
+
+; Base Bug Catching Contest
 ContestMons:
-	;            %, species,   min, max
-	contest_mon 15, CATERPIE,    7, 18
-	contest_mon 15, WEEDLE,      7, 18
-	contest_mon 10, METAPOD,     9, 18
-	contest_mon 10, KAKUNA,      9, 18
-	contest_mon  5, BUTTERFREE, 12, 15
-	contest_mon  5, BEEDRILL,   12, 15
-	contest_mon 10, VENONAT,    10, 16
-	contest_mon 10, PARAS,      10, 17
-	contest_mon  5, VENOMOTH,   12, 15
-	contest_mon  5, YANMA,      13, 14
-	contest_mon  5, SCYTHER,    13, 14
-	contest_mon  5, PINSIR,     13, 14
+	;           Time, Weight, min,                   max,                   species
+	contest_mon    7,     15, LEVEL_FROM_BADGES - 5, LEVEL_FROM_BADGES + 6, CATERPIE
+	contest_mon    7,     15, LEVEL_FROM_BADGES - 5, LEVEL_FROM_BADGES + 6, WEEDLE
+	contest_mon    7,     10, LEVEL_FROM_BADGES - 3, LEVEL_FROM_BADGES + 6, METAPOD
+	contest_mon    7,     10, LEVEL_FROM_BADGES - 3, LEVEL_FROM_BADGES + 6, KAKUNA
+	contest_mon    7,      5, LEVEL_FROM_BADGES + 0, LEVEL_FROM_BADGES + 3, BUTTERFREE
+	contest_mon    7,      5, LEVEL_FROM_BADGES + 0, LEVEL_FROM_BADGES + 3, BEEDRILL
+	contest_mon    7,     10, LEVEL_FROM_BADGES - 2, LEVEL_FROM_BADGES + 4, VENONAT
+	contest_mon    7,     10, LEVEL_FROM_BADGES - 2, LEVEL_FROM_BADGES + 5, PARAS
+	contest_mon    7,      5, LEVEL_FROM_BADGES + 0, LEVEL_FROM_BADGES + 3, VENOMOTH
+	contest_mon    7,      5, LEVEL_FROM_BADGES + 1, LEVEL_FROM_BADGES + 2, YANMA
+	contest_mon    7,      5, LEVEL_FROM_BADGES + 1, LEVEL_FROM_BADGES + 2, SCYTHER
+	contest_mon    7,      5, LEVEL_FROM_BADGES + 1, LEVEL_FROM_BADGES + 2, PINSIR
+	dp -1
 ContestMonsEnd:
+
+; Bug Catching Contest after E4
+E4_ContestMons:
+	;           Time, Weight, min,                   max,                   species
+	contest_mon    7,     10, LEVEL_FROM_BADGES + 0,  LEVEL_FROM_BADGES + 4, BUTTERFREE
+	contest_mon    7,     10, LEVEL_FROM_BADGES + 0,  LEVEL_FROM_BADGES + 4, BEEDRILL
+	contest_mon    7,     10, LEVEL_FROM_BADGES + 0,  LEVEL_FROM_BADGES + 4, PARAS
+	contest_mon    7,      5, LEVEL_FROM_BADGES - 1,  LEVEL_FROM_BADGES + 2, PARASECT
+	contest_mon    7,     10, LEVEL_FROM_BADGES + 0,  LEVEL_FROM_BADGES + 4, VENONAT
+	contest_mon    7,      5, LEVEL_FROM_BADGES - 1,  LEVEL_FROM_BADGES + 2, VENOMOTH
+	contest_mon    7,      5, LEVEL_FROM_BADGES - 2,  LEVEL_FROM_BADGES + 1, SCYTHER
+	contest_mon    7,      5, LEVEL_FROM_BADGES - 2,  LEVEL_FROM_BADGES + 1, PINSIR
+	contest_mon    7,     10, LEVEL_FROM_BADGES + 0,  LEVEL_FROM_BADGES + 4, LEDIAN
+	contest_mon    7,      5, LEVEL_FROM_BADGES - 1,  LEVEL_FROM_BADGES + 2, ARIADOS
+	contest_mon    7,      5, LEVEL_FROM_BADGES - 2,  LEVEL_FROM_BADGES + 1, YANMA
+	contest_mon    7,      5, LEVEL_FROM_BADGES - 2,  LEVEL_FROM_BADGES + 1, HERACROSS
+	contest_mon    7,      5, LEVEL_FROM_BADGES + 0,  LEVEL_FROM_BADGES + 4, PINECO
+	contest_mon    7,      5, LEVEL_FROM_BADGES - 2,  LEVEL_FROM_BADGES + 1, FORRETRESS
+	contest_mon    7,      5, LEVEL_FROM_BADGES + 0,  LEVEL_FROM_BADGES + 4, SHUCKLE
+	dp -1
+E4_ContestMonsEnd:
+
+; Bug Catching Contest after Blue
+Blue_ContestMons:
+	;           Time, Weight, min,                   max,                   species
+	contest_mon    7,     10, LEVEL_FROM_BADGES + 0,  LEVEL_FROM_BADGES + 4, BUTTERFREE
+	contest_mon    7,     10, LEVEL_FROM_BADGES + 0,  LEVEL_FROM_BADGES + 4, BEEDRILL
+	contest_mon    7,      7, LEVEL_FROM_BADGES - 1,  LEVEL_FROM_BADGES + 2, PARASECT
+	contest_mon    7,      7, LEVEL_FROM_BADGES - 1,  LEVEL_FROM_BADGES + 2, VENOMOTH
+	contest_mon    7,      7, LEVEL_FROM_BADGES - 2,  LEVEL_FROM_BADGES + 1, SCYTHER
+	contest_mon    7,      7, LEVEL_FROM_BADGES - 2,  LEVEL_FROM_BADGES + 1, PINSIR
+	contest_mon    7,     10, LEVEL_FROM_BADGES + 0,  LEVEL_FROM_BADGES + 4, LEDIAN
+	contest_mon    7,      8, LEVEL_FROM_BADGES - 1,  LEVEL_FROM_BADGES + 2, ARIADOS
+	contest_mon    7,      8, LEVEL_FROM_BADGES - 2,  LEVEL_FROM_BADGES + 1, YANMA
+	contest_mon    7,      7, LEVEL_FROM_BADGES - 2,  LEVEL_FROM_BADGES + 1, HERACROSS
+	contest_mon    7,      7, LEVEL_FROM_BADGES - 2,  LEVEL_FROM_BADGES + 1, FORRETRESS
+	contest_mon    7,      7, LEVEL_FROM_BADGES + 0,  LEVEL_FROM_BADGES + 4, SHUCKLE
+	contest_mon    7,      2, LEVEL_FROM_BADGES - 2,  LEVEL_FROM_BADGES + 1, SCIZOR
+	contest_mon    7,      2, LEVEL_FROM_BADGES - 2,  LEVEL_FROM_BADGES + 1, YANMEGA
+	contest_mon    7,      1, LEVEL_FROM_BADGES - 2,  LEVEL_FROM_BADGES + 1, KLEAVOR
+	dp -1
+Blue_ContestMonsEnd:

--- a/engine/overworld/events.asm
+++ b/engine/overworld/events.asm
@@ -1330,15 +1330,15 @@ GetContestLocations:
 	scf
 	ret nz
 
-	ld hl, ContestMons + 1
-	ld e, (ContestMonsEnd - ContestMons) / 5
+	call FetchBugTables
 .loop
-	ld a, [hli]
+	inc hl ; skip time of day
+	ld a, [hli] ; encounter weight
 	cp c
-	ld a, [hli]
 	inc hl ; skip level min
 	inc hl ; skip level max
-	inc hl ; skip (next mon's) encounter rate
+	ld a, [hli] ; Species
+	inc hl ; skip form
 	jr nz, .next
 	call DexCompareWildForm
 	jr z, .found_mon
@@ -1355,39 +1355,85 @@ GetContestLocations:
 _TryWildEncounter_BugContest:
 	call TryWildEncounter_BugContest
 	ret nc
-; Pick a random mon out of ContestMons.
-.loop
-	call Random
-	cp 100 << 1
-	jr nc, .loop
-	srl a
-	ld hl, ContestMons
-	ld de, 5
+
+; Initialize badge level scaling.
+	farcall SetBadgeBaseLevel ; Set wBadgeBaseLevel
+; Load the correct bug contest table
+	call LoadContestMonTable  ; Set hl
+	ld b, 0  ;  b = RandomRange maximum
+; Get time of day
+; Morning 0 -> 1
+; Day     1 -> 2
+; Night   2 -> 4
+	farcall GetTimeOfDayNotEve ; Set a
+	ld c, 1  ;  c = Time of Day Mask
+	ld de, 5 ; de = Table Increment value
+.time_of_day_mask
+	cp 0
+	jr z, .accumulate
+	sla c
+	sub 1
+	jr .time_of_day_mask
+; Accumulate weight of valid table entries for time of day
+.accumulate
+	; Load time of day mask into a
+	ld a, [hli]
+	; Time of Day BITAND Time of Day Mask
+	and c
+	; If the result is zero, the Mon cannot be found at the current time of day
+	; jump to next_row operation
+	jr z, .next_row
+	; Set a to b (accumulate)
+	ld a, b
+	add [hl]
+	ld b, a
+.next_row
+	; Increment hl to next row
+	add hl, de
+	; Set a to [hl]
+	ld a, [hl]
+	; If [hl] is -1, continue, otherwise keep accumulating.
+	cp -1
+	jr nz, .accumulate
+; Load the correct bug contest table once more
+	call LoadContestMonTable
+; Pick a random value from 0 to RandomMax
+	ld a, b
+	call RandomRange
+	ld b, a
 .CheckMon:
+	; Load time of day mask into a
+	ld a, [hli]
+	; Time of Day BITAND Time of Day Mask
+	and c
+	; If the result is zero, skip
+	jr z, .SkipMon
+	; Otherwise, the next hl value is the encounter weight
+	; subtract that weight from the RandomRange result
+	; Load RandomResult to a
+	ld a, b
 	sub [hl]
+	; if the subtraction forced a carry, then skip to GotMon
+	; otherwise we go to the next row and CheckMon again
 	jr c, .GotMon
+	; Update b with the result of a - hl
+	ld b, a
+.SkipMon
+	; Increment hl to next row
 	add hl, de
 	jr .CheckMon
 .GotMon:
 	inc hl
-; Species
-	ld a, [hli]
-	ld [wTempWildMonSpecies], a
-; Form
-	ld a, [hli]
-	ld [wCurForm], a
-	ld [wWildMonForm], a
 ; Min level
 	ld a, [hli]
 	ld d, a
 ; Max level
-	ld a, [hl]
+	ld a, [hli]
 	sub d
 	jr nz, .RandomLevel
 ; If min and max are the same.
 	ld a, d
 	jr .GotLevel
-
 .RandomLevel:
 ; Get a random level between the min and max.
 	ld c, a
@@ -1397,9 +1443,61 @@ _TryWildEncounter_BugContest:
 	call SimpleDivide
 	add d
 .GotLevel:
+	ld b, a
+; Species
+	ld a, [hli]
+	ld [wTempWildMonSpecies], a
+; Form
+	ld a, [hl]
+	ld [wCurForm], a
+	ld [wWildMonForm], a
+	ld a, b
+; Adjust level scaling.
+	farcall AdjustLevelForBadges
 	ld [wCurPartyLevel], a
 	xor a
 	farjp CheckRepelEffect
+
+FetchBugTables:
+; Postgame Bugcontest
+	; If the player has beaten Blue, load Blue Contest Table
+	eventflagcheck EVENT_BEAT_BLUE
+	jr z, .e4_bugs
+	ld hl, Blue_ContestMons + 1
+	ld e, (Blue_ContestMonsEnd - Blue_ContestMons) / 6
+	ret
+.e4_bugs
+	; If the player has beaten the E4, but not Blue, then load the
+	; E4 contest table. Otherwise skip to the regular table.
+	eventflagcheck EVENT_BEAT_ELITE_FOUR
+	jr z, .base_bugs
+	ld hl, E4_ContestMons + 1
+	ld e, (E4_ContestMonsEnd - E4_ContestMons) / 6
+	ret
+; end postgame bugcontest
+.base_bugs
+	ld hl, ContestMons + 1
+	ld e, (ContestMonsEnd - ContestMons) / 6
+	ret
+
+LoadContestMonTable:
+; Postgame Bugcontest
+	; If the player has beaten Blue, check against the Blue table
+	eventflagcheck EVENT_BEAT_BLUE
+	jr z, .e4_load
+	ld hl, Blue_ContestMons
+	ret
+	; If the player has beaten the E4, but not Blue, then load the
+	; E4 contest table. Otherwise skip to the regular table.
+.e4_load
+	eventflagcheck EVENT_BEAT_ELITE_FOUR
+	jr z, .base_load
+	ld hl, E4_ContestMons
+	ret
+; end postgame bugcontest
+.base_load
+	ld hl, ContestMons
+	ret
 
 TryWildEncounter_BugContest:
 	ld a, [wPlayerTileCollision]


### PR DESCRIPTION
An effort towards #1382

Implement multiple bug contest encounter tables such that the contest has some level scaling as well as better catchable mons in postgame.

The encounter function has an accumulator step which determines a RandomRange maximum based on valid encounters for a given time of day. Then the function iterates through the table once more to determine the encounter to have based on the result of RandomRange and the time of day.

This change also could accomplish the long term goal of consolidating encounter tables to use both a level range and time of day bitmask instead of relying on 3x the amount of entries per route and multiple slots for hardcoded level values, in lieu of implementing a mechanic similar to surfing encounters for level variance to walking encounters.