### PR TITLE
Give Sirfetch'd Inner Focus in Nonfaithful

### DIFF
--- a/data/pokemon/base_stats/sirfetch_d.asm
+++ b/data/pokemon/base_stats/sirfetch_d.asm
@@ -7,7 +7,11 @@
 	db NO_ITEM, LEEK ; held items
 	dn GENDER_F50, HATCH_MEDIUM_FAST ; gender ratio, step cycles to hatch
 
+if DEF(FAITHFUL)
 	abilities_for SIRFETCH_D, STEADFAST, STEADFAST, SCRAPPY
+else
+	abilities_for SIRFETCH_D, STEADFAST, INNER_FOCUS, SCRAPPY
+endc
 	db GROWTH_MEDIUM_FAST ; growth rate
 	dn EGG_FLYING, EGG_GROUND ; egg groups
 


### PR DESCRIPTION
Fixes #1553 

Sirfetch'd's ability slots 1 and 2 are both Steadfast, so slot 2 is unused.  This gives it Inner Focus there in Nonfaithful builds.  