### PR TITLE
Make palette swaps fade-aware

### DIFF
--- a/constants/gfx_constants.asm
+++ b/constants/gfx_constants.asm
@@ -63,6 +63,15 @@ DEF DEXTILE_FROM_DEXMAP EQU 1 << DEXTILE_FROM_DEXMAP_F
 DEF NUM_FLYFROM_ANIM_OAMS EQU 4 + 9 ; 4 for flymon, 9 for leaves
 DEF NUM_FLYTO_ANIM_OAMS   EQU 4 + 8 ; 4 for flymon, 8 for leaves
 
+; wPaletteSwapFlag uses one nibble each for current and initialized states.
+DEF NUM_PALETTE_SWAP_STATES EQU 4
+DEF PALETTE_SWAP_STATE_MASK EQU (1 << NUM_PALETTE_SWAP_STATES) - 1
+
+; Temporary flags used while processing one palette swap entry.
+DEF PALETTE_SWAP_INSIDE_F  EQU 0
+DEF PALETTE_SWAP_CHANGED_F EQU 7
+DEF PALETTE_SWAP_INSIDE    EQU 1 << PALETTE_SWAP_INSIDE_F
+
 ; wPalState types (see engine/gfx/sprite_palettes.asm)
 	const_def
 	const PREV_PALSTATE ; 0

--- a/constants/gfx_constants.asm
+++ b/constants/gfx_constants.asm
@@ -63,10 +63,6 @@ DEF DEXTILE_FROM_DEXMAP EQU 1 << DEXTILE_FROM_DEXMAP_F
 DEF NUM_FLYFROM_ANIM_OAMS EQU 4 + 9 ; 4 for flymon, 9 for leaves
 DEF NUM_FLYTO_ANIM_OAMS   EQU 4 + 8 ; 4 for flymon, 8 for leaves
 
-; wPaletteSwapFlag uses one nibble each for current and initialized states.
-DEF NUM_PALETTE_SWAP_STATES EQU 4
-DEF PALETTE_SWAP_STATE_MASK EQU (1 << NUM_PALETTE_SWAP_STATES) - 1
-
 ; Temporary flags used while processing one palette swap entry.
 DEF PALETTE_SWAP_INSIDE_F  EQU 0
 DEF PALETTE_SWAP_CHANGED_F EQU 7

--- a/engine/gfx/color.asm
+++ b/engine/gfx/color.asm
@@ -1059,20 +1059,25 @@ SwapColorPalette::
 	add hl, de
 
 	; Previous-state palettes become active; current-state palettes are the target.
-	push hl
-	ld hl, wBGPals2
+	; d = [wPalState] == PREV_PALSTATE ? LOW(wBGPals2) : LOW(wBGPals1)
 	ld a, [wPalState]
 	assert PREV_PALSTATE == 0
 	and a
+	ld d, LOW(wBGPals2)
 	jr z, .got_target
-	ld hl, wBGPals1
+	ld d, LOW(wBGPals1)
 .got_target
+	; Set `de` to the `b`th palette of `wBGPals1` or `wBGPals2`.
 	ld a, b
-	ld bc, 1 palettes
-	rst AddNTimes
-	ld d, h
-	ld e, l
-	pop hl
+	add a
+	add a
+	add a
+	add d ; LOW(wBGPals1) or LOW(wBGPals2)
+	ld e, a
+	assert HIGH(wBGPals1) == HIGH(wBGPals2)
+	adc HIGH(wBGPals1)
+	sub e
+	ld d, a
 
 	; Skip past the regular palettes to the overcast ones if applicable.
 	ld a, PALSTATE_OVERCAST_INDEX
@@ -1088,20 +1093,16 @@ SwapColorPalette::
 	jmp FarCopyColorWRAM
 
 UpdatePaletteSwapState::
-; wPaletteSwapFlag's low nibble stores the current state of each entry;
-; its high nibble records which entries have been initialized.
+; wPaletteSwapStates stores the current state of each entry.
+; wPaletteSwapInits records which entries have been initialized.
 ; Input: `c` PALETTE_SWAP_INSIDE_F set inside the rectangle,
 ;        `e` = this entry's state bit.
 ; Output: `c` PALETTE_SWAP_CHANGED_F set on first check or a state change.
-	ld a, [wPaletteSwapFlag]
-	ld b, a
-	; Mark this entry initialized, and build its new state in `a`.
-	ld a, e
-	swap a
-	or b
+	ld a, [wPaletteSwapStates]
+	ld d, a
+	; Build this entry's new state in `a`.
 	bit PALETTE_SWAP_INSIDE_F, c
 	jr nz, .inside
-	ld d, a
 	ld a, e
 	cpl
 	and d
@@ -1109,12 +1110,19 @@ UpdatePaletteSwapState::
 .inside
 	or e
 
-	; Store only if the initialized or current state changed.
+	; Store only on first check or if the current state changed.
 .compare
-	xor b
-	ret z
-	xor b
-	ld [wPaletteSwapFlag], a
+	cp d
+	jr nz, .changed
+	ld a, [wPaletteSwapInits]
+	and e
+	ret nz
+	ld a, d
+.changed
+	ld [wPaletteSwapStates], a
+	ld a, [wPaletteSwapInits]
+	or e
+	ld [wPaletteSwapInits], a
 	set PALETTE_SWAP_CHANGED_F, c
 	ret
 

--- a/engine/gfx/color.asm
+++ b/engine/gfx/color.asm
@@ -1117,9 +1117,10 @@ UpdatePaletteSwapState::
 	ld a, [wPaletteSwapInits]
 	and e
 	ret nz
-	ld a, d
+	jr .finish
 .changed
 	ld [wPaletteSwapStates], a
+.finish
 	ld a, [wPaletteSwapInits]
 	or e
 	ld [wPaletteSwapInits], a
@@ -1134,12 +1135,18 @@ CatchUpPaletteSwapFade::
 	ld a, [wPalWhiteState]
 	and a
 	jr z, .swap_previous
-	ld hl, wBGPals2
+
+	; de = wBGPals2 palette b
 	ld a, b
-	ld bc, 1 palettes
-	rst AddNTimes
-	ld d, h
-	ld e, l
+	add a
+	add a
+	add a
+	add LOW(wBGPals2)
+	ld e, a
+	adc HIGH(wBGPals2)
+	sub e
+	ld d, a
+
 	farcall CopyWhitePal
 	jr .got_previous
 
@@ -1147,14 +1154,14 @@ CatchUpPaletteSwapFade::
 	xor a
 	assert PREV_PALSTATE == 0
 	ld [wPalState], a
+	push bc
 	call SwapColorPalette
+	pop bc
 
 .got_previous
 	pop de
-	pop bc
 	ld a, CURR_PALSTATE
 	ld [wPalState], a
-	push bc
 	call SwapColorPalette
 	pop bc
 	ld a, b

--- a/engine/gfx/color.asm
+++ b/engine/gfx/color.asm
@@ -1086,6 +1086,46 @@ SwapColorPalette::
 	ld bc, 1 palettes
 	jmp FarCopyColorWRAM
 
+UpdatePaletteSwapState::
+; Input: `c` bit 0 set inside the rectangle, `e` = this entry's state bit.
+; Output: `c` bit 7 set on first check or a state change.
+	ld a, e
+	swap a
+	ld d, a
+	ld a, [wPaletteSwapFlag]
+	and d
+	jr z, .changed
+	ld a, [wPaletteSwapFlag]
+	and e
+	jr z, .was_outside
+	bit 0, c
+	ret nz
+	jr .changed
+.was_outside
+	bit 0, c
+	ret z
+
+.changed
+	set 7, c
+	ld a, [wPaletteSwapFlag]
+	or d
+	ld [wPaletteSwapFlag], a
+	bit 0, c
+	jr z, .clear_state
+	ld a, [wPaletteSwapFlag]
+	or e
+	ld [wPaletteSwapFlag], a
+	ret
+
+.clear_state
+	ld a, e
+	cpl
+	ld d, a
+	ld a, [wPaletteSwapFlag]
+	and d
+	ld [wPaletteSwapFlag], a
+	ret
+
 INCLUDE "data/tileset_palettes.asm"
 
 INCLUDE "data/maps/environment_colors.asm"

--- a/engine/gfx/color.asm
+++ b/engine/gfx/color.asm
@@ -1087,43 +1087,34 @@ SwapColorPalette::
 	jmp FarCopyColorWRAM
 
 UpdatePaletteSwapState::
-; Input: `c` bit 0 set inside the rectangle, `e` = this entry's state bit.
-; Output: `c` bit 7 set on first check or a state change.
+; wPaletteSwapFlag's low nibble stores the current state of each entry;
+; its high nibble records which entries have been initialized.
+; Input: `c` PALETTE_SWAP_INSIDE_F set inside the rectangle,
+;        `e` = this entry's state bit.
+; Output: `c` PALETTE_SWAP_CHANGED_F set on first check or a state change.
+	ld a, [wPaletteSwapFlag]
+	ld b, a
+	; Mark this entry initialized, and build its new state in `a`.
 	ld a, e
 	swap a
+	or b
+	bit PALETTE_SWAP_INSIDE_F, c
+	jr nz, .inside
 	ld d, a
-	ld a, [wPaletteSwapFlag]
-	and d
-	jr z, .changed
-	ld a, [wPaletteSwapFlag]
-	and e
-	jr z, .was_outside
-	bit 0, c
-	ret nz
-	jr .changed
-.was_outside
-	bit 0, c
-	ret z
-
-.changed
-	set 7, c
-	ld a, [wPaletteSwapFlag]
-	or d
-	ld [wPaletteSwapFlag], a
-	bit 0, c
-	jr z, .clear_state
-	ld a, [wPaletteSwapFlag]
-	or e
-	ld [wPaletteSwapFlag], a
-	ret
-
-.clear_state
 	ld a, e
 	cpl
-	ld d, a
-	ld a, [wPaletteSwapFlag]
 	and d
+	jr .compare
+.inside
+	or e
+
+	; Store only if the initialized or current state changed.
+.compare
+	xor b
+	ret z
+	xor b
 	ld [wPaletteSwapFlag], a
+	set PALETTE_SWAP_CHANGED_F, c
 	ret
 
 INCLUDE "data/tileset_palettes.asm"

--- a/engine/gfx/color.asm
+++ b/engine/gfx/color.asm
@@ -1062,7 +1062,8 @@ SwapColorPalette::
 	push hl
 	ld hl, wBGPals2
 	ld a, [wPalState]
-	and a ; PREV_PALSTATE == 0
+	assert PREV_PALSTATE == 0
+	and a
 	jr z, .got_target
 	ld hl, wBGPals1
 .got_target

--- a/engine/gfx/color.asm
+++ b/engine/gfx/color.asm
@@ -1047,8 +1047,9 @@ SwapColorPalette::
 	or e
 	ret z
 
-	; Set `hl` to the `[wTimeOfDayPal]`th palette in the table at `de`.
-	ld a, [wTimeOfDayPal]
+	; Set `hl` to the selected state's time-of-day palette in the table at `de`.
+	ld a, PALSTATE_TIME_OF_DAY
+	farcall GetPalState
 	and 3
 	add a
 	add a
@@ -1057,23 +1058,24 @@ SwapColorPalette::
 	ld h, 0
 	add hl, de
 
-	; Set `de` to the `b`th palette of `wBGPals1`.
+	; Previous-state palettes become active; current-state palettes are the target.
+	push hl
+	ld hl, wBGPals2
+	ld a, [wPalState]
+	and a ; PREV_PALSTATE == 0
+	jr z, .got_target
+	ld hl, wBGPals1
+.got_target
 	ld a, b
-	add a
-	add a
-	add a
-	add LOW(wBGPals1)
-	ld e, a
-	adc HIGH(wBGPals1)
-	sub e
-	ld d, a
+	ld bc, 1 palettes
+	rst AddNTimes
+	ld d, h
+	ld e, l
+	pop hl
 
 	; Skip past the regular palettes to the overcast ones if applicable.
-	push hl
-	push de
-	farcall GetOvercastIndex
-	pop de
-	pop hl
+	ld a, PALSTATE_OVERCAST_INDEX
+	farcall GetPalState
 	and a
 	jr z, .not_overcast
 	ld bc, 4 palettes

--- a/engine/gfx/color.asm
+++ b/engine/gfx/color.asm
@@ -1118,6 +1118,40 @@ UpdatePaletteSwapState::
 	set PALETTE_SWAP_CHANGED_F, c
 	ret
 
+CatchUpPaletteSwapFade::
+; Rebuild BG palette `b` from palette list `de` under the fade's previous and
+; current conditions, then catch its active palette up to the current step.
+	push bc
+	push de
+	ld a, [wPalWhiteState]
+	and a
+	jr z, .swap_previous
+	ld hl, wBGPals2
+	ld a, b
+	ld bc, 1 palettes
+	rst AddNTimes
+	ld d, h
+	ld e, l
+	farcall CopyWhitePal
+	jr .got_previous
+
+.swap_previous
+	xor a
+	assert PREV_PALSTATE == 0
+	ld [wPalState], a
+	call SwapColorPalette
+
+.got_previous
+	pop de
+	pop bc
+	ld a, CURR_PALSTATE
+	ld [wPalState], a
+	push bc
+	call SwapColorPalette
+	pop bc
+	ld a, b
+	farjp CatchUpBGPaletteFade
+
 INCLUDE "data/tileset_palettes.asm"
 
 INCLUDE "data/maps/environment_colors.asm"

--- a/engine/gfx/dma_transfer.asm
+++ b/engine/gfx/dma_transfer.asm
@@ -277,4 +277,8 @@ DI_DelayFrame:
 	jr nc, .loop
 .done
 	pop bc
+	; Don't service the VBlank that elapsed while interrupts were disabled.
+	ldh a, [rIF]
+	res B_IF_VBLANK, a
+	ldh [rIF], a
 	ret

--- a/engine/gfx/fade.asm
+++ b/engine/gfx/fade.asm
@@ -27,7 +27,8 @@ OWFadePalettesInit::
 	ldh [rWBK], a
 	ret
 
-ApplyPalsIfNotFading::
+CheckPaletteFading::
+	push bc
 	ldh a, [rWBK]
 	push af
 	ld a, BANK(wPalFadeDelayFrames)
@@ -37,7 +38,12 @@ ApplyPalsIfNotFading::
 	pop af
 	ldh [rWBK], a
 	ld a, b
+	pop bc
 	and a
+	ret
+
+ApplyPalsIfNotFading::
+	call CheckPaletteFading
 	ret nz
 	farcall ApplyPals
 	ld a, TRUE
@@ -398,7 +404,23 @@ FadeColorStep:
 CatchUpObjPaletteFade::
 ; Input: a = OBJ palette index (0-7)
 ; Ensures a newly loaded palette matches the current fade progress.
+	ld hl, wOBPals2
+	jr CatchUpPaletteFade
+
+CatchUpBGPaletteFade::
+; Input: a = BG palette index (0-7)
+	ld hl, wBGPals2
+	call CatchUpPaletteFade
+	ld a, TRUE
+	ldh [hCGBPalUpdate], a
+	ret
+
+CatchUpPaletteFade:
 	ld b, a
+	push bc
+	ld bc, 1 palettes
+	rst AddNTimes
+	pop bc
 	ldh a, [rWBK]
 	push af
 	ld a, BANK(wPalFadeDelayFrames)
@@ -429,10 +451,6 @@ CatchUpObjPaletteFade::
 	push bc
 	push de
 	push hl
-	ld hl, wOBPals2
-	ld a, b
-	ld bc, 1 palettes
-	rst AddNTimes
 	ld a, d
 	ld [wPalFadeStepValue], a
 	call FadeSinglePaletteStep

--- a/engine/gfx/fade.asm
+++ b/engine/gfx/fade.asm
@@ -27,6 +27,23 @@ OWFadePalettesInit::
 	ldh [rWBK], a
 	ret
 
+ApplyPalsIfNotFading::
+	ldh a, [rWBK]
+	push af
+	ld a, BANK(wPalFadeDelayFrames)
+	ldh [rWBK], a
+	ld a, [wPalFadeDelayFrames]
+	ld b, a
+	pop af
+	ldh [rWBK], a
+	ld a, b
+	and a
+	ret nz
+	farcall ApplyPals
+	ld a, TRUE
+	ldh [hCGBPalUpdate], a
+	ret
+
 CancelOWFadePalettes::
 	ldh a, [rWBK]
 	push af

--- a/engine/gfx/fade.asm
+++ b/engine/gfx/fade.asm
@@ -452,7 +452,6 @@ CatchUpPaletteFade:
 	ld a, d
 	cp e
 	jr z, .done
-	push bc
 	push de
 	push hl
 	ld a, d
@@ -460,7 +459,6 @@ CatchUpPaletteFade:
 	call FadeSinglePaletteStep
 	pop hl
 	pop de
-	pop bc
 	dec d
 	jr .catch_loop
 
@@ -476,82 +474,5 @@ CatchUpPaletteFade:
 	ret
 
 FadeSinglePaletteStep:
-	ld de, 0
-	ld d, PAL_COLORS
-
-.single_loop
-	push de
-	ld a, [hli]
-	ld e, a
-	ld d, [hl]
-	ld a, [wPalFadeMode]
-	bit PALFADE_FLASH_F, a
-	jr z, .single_no_flash
-	ld bc, 0
-	dec hl
-	jr .single_got_destination
-
-.single_no_flash
-	ld bc, wBGPals1 - wBGPals2
-	add hl, bc
-	ld a, [hld]
-	ld b, a
-	ld c, [hl]
-	push bc
-	ld bc, wBGPals2 - wBGPals1
-	add hl, bc
-	pop bc
-
-.single_got_destination
-	push hl
-	ld a, c
-	and COLOR_RED
-	ld l, a
-	ld a, e
-	and COLOR_RED
-	call FadeColorStep
-	ld a, e
-	and ~COLOR_RED
-	or l
-	ld e, a
-	push bc
-	call FadeColorGetGreen
-	ld l, a
-	ld b, d
-	ld c, e
-	call FadeColorGetGreen
-	pop bc
-	call FadeColorStep
-	sla l
-	swap l
-	ld a, l
-	xor e
-	and COLOR_GREEN_LOW
-	xor e
-	ld e, a
-	ld a, l
-	xor d
-	and COLOR_GREEN_HIGH
-	xor d
-	ld d, a
-	ld a, b
-	call FadeColorGetBlue
-	ld l, a
-	ld a, d
-	call FadeColorGetBlue
-	call FadeColorStep
-	sla l
-	sla l
-	ld a, d
-	and COLOR_GREEN_HIGH ; essentially ~COLOR_BLUE
-	or l
-	ld d, a
-	pop hl
-	ld a, e
-	ld [hli], a
-	ld a, d
-	ld [hli], a
-	pop de
-	dec d
-	jr nz, .single_loop
-	ret
+	lb de, PAL_COLORS, 0
+	jp FadePalettesStep.inner_loop

--- a/engine/gfx/fade.asm
+++ b/engine/gfx/fade.asm
@@ -228,16 +228,17 @@ FadePalettesStep:
 	ld hl, wOBPals2
 .got_count
 	ld a, [wPalFadeMode]
-
 	and PALFADE_SKIP_FIRST
-	jr z, .inner_loop
+	jr z, FadePalettesStepLoop
+
 	ld bc, 1 palettes
 	add hl, bc
 	ld a, d
 	sub PAL_COLORS
 	ld d, a
+	; fallthrough
 
-.inner_loop
+FadePalettesStepLoop:
 	push de
 	ld a, [hli]
 	ld e, a
@@ -319,7 +320,7 @@ FadePalettesStep:
 	ld [hli], a
 	pop de
 	dec d
-	jr nz, .inner_loop
+	jr nz, FadePalettesStepLoop
 	ret
 
 FadeColorGetGreen:
@@ -456,7 +457,8 @@ CatchUpPaletteFade:
 	push hl
 	ld a, d
 	ld [wPalFadeStepValue], a
-	call FadeSinglePaletteStep
+	lb de, PAL_COLORS, 0
+	call FadePalettesStepLoop
 	pop hl
 	pop de
 	dec d
@@ -472,7 +474,3 @@ CatchUpPaletteFade:
 	ld a, TRUE
 	ldh [hCGBPalUpdate], a
 	ret
-
-FadeSinglePaletteStep:
-	lb de, PAL_COLORS, 0
-	jp FadePalettesStep.inner_loop

--- a/engine/gfx/fade.asm
+++ b/engine/gfx/fade.asm
@@ -28,6 +28,8 @@ OWFadePalettesInit::
 	ret
 
 CheckPaletteFading::
+	; This runs every frame on palette-swap maps; switching banks directly is
+	; much faster than GetFarWRAMByte's stack-call setup.
 	push bc
 	ldh a, [rWBK]
 	push af
@@ -410,17 +412,19 @@ CatchUpObjPaletteFade::
 CatchUpBGPaletteFade::
 ; Input: a = BG palette index (0-7)
 	ld hl, wBGPals2
-	call CatchUpPaletteFade
-	ld a, TRUE
-	ldh [hCGBPalUpdate], a
-	ret
+	; fallthrough
 
 CatchUpPaletteFade:
 	ld b, a
-	push bc
-	ld bc, 1 palettes
-	rst AddNTimes
-	pop bc
+	; hl += `a` palettes
+	add a
+	add a
+	add a
+	add l
+	ld l, a
+	adc h
+	sub l
+	ld h, a
 	ldh a, [rWBK]
 	push af
 	ld a, BANK(wPalFadeDelayFrames)
@@ -463,12 +467,12 @@ CatchUpPaletteFade:
 .done
 	ld a, e
 	ld [wPalFadeStepValue], a
-	ld a, 1
-	ldh [hCGBPalUpdate], a
 
 .restore_bank
 	pop af
 	ldh [rWBK], a
+	ld a, TRUE
+	ldh [hCGBPalUpdate], a
 	ret
 
 FadeSinglePaletteStep:

--- a/engine/gfx/sprite_palettes.asm
+++ b/engine/gfx/sprite_palettes.asm
@@ -79,7 +79,7 @@ CopyLeafGreenToOBPal7:
 ; other colors like purple. (We can assume that if PAL_BG_GREEN is *not* swapped,
 ; then it's still appropriate for use as a leaf/tree color.)
 	ld a, [wPaletteSwapFlag]
-	and $f ; upper bits track which palette swap entries are initialized
+	and PALETTE_SWAP_STATE_MASK
 	ld a, PAL_OW_LEAF_GREEN
 	jr nz, CopySpritePalToOBPal7
 	; fallthrough

--- a/engine/gfx/sprite_palettes.asm
+++ b/engine/gfx/sprite_palettes.asm
@@ -139,14 +139,17 @@ CopySpritePalHandler::
 	ld [wPalState], a
 	call CalculateStates
 	call CopySpritePal
-	; A copy-BG palette sourced its active color from the matching, already
-	; partially faded BG palette. Replaying the elapsed fade steps would put it
-	; ahead of the BG palette it is meant to match. Fades from white still need
-	; the normal catch-up path because their active palette started as white.
+	; An ordinary copy-BG palette sourced its active color from the matching,
+	; already partially faded BG palette. Replaying the elapsed fade steps would
+	; put it ahead of the BG palette it is meant to match. Fades from white still
+	; need the normal catch-up path because their active palette started as white;
+	; PAL_OW_COPY_BG_WHITE also needs it because it is built from target colors.
 	ld a, [wPalWhiteState]
 	and a
 	jr nz, .catch_up
 	ld a, [wNeededPalIndex]
+	cp PAL_OW_COPY_BG_WHITE
+	jr z, .catch_up
 	cp FIRST_COPY_BG_PAL
 	jr nc, .caught_up
 .catch_up

--- a/engine/gfx/sprite_palettes.asm
+++ b/engine/gfx/sprite_palettes.asm
@@ -78,8 +78,8 @@ CopyLeafGreenToOBPal7:
 ; Fly leaves should use standard green if PAL_BG_GREEN has been "swapped" to
 ; other colors like purple. (We can assume that if PAL_BG_GREEN is *not* swapped,
 ; then it's still appropriate for use as a leaf/tree color.)
-	ld a, [wPaletteSwapFlag]
-	and PALETTE_SWAP_STATE_MASK
+	ld a, [wPaletteSwapStates]
+	and a
 	ld a, PAL_OW_LEAF_GREEN
 	jr nz, CopySpritePalToOBPal7
 	; fallthrough

--- a/engine/gfx/sprite_palettes.asm
+++ b/engine/gfx/sprite_palettes.asm
@@ -139,6 +139,17 @@ CopySpritePalHandler::
 	ld [wPalState], a
 	call CalculateStates
 	call CopySpritePal
+	; A copy-BG palette sourced its active color from the matching, already
+	; partially faded BG palette. Replaying the elapsed fade steps would put it
+	; ahead of the BG palette it is meant to match. Fades from white still need
+	; the normal catch-up path because their active palette started as white.
+	ld a, [wPalWhiteState]
+	and a
+	jr nz, .catch_up
+	ld a, [wNeededPalIndex]
+	cp FIRST_COPY_BG_PAL
+	jr nc, .caught_up
+.catch_up
 	push de
 	push bc
 	ld c, 1 palettes
@@ -151,6 +162,7 @@ CopySpritePalHandler::
 	pop hl
 	pop bc
 	pop de
+.caught_up
 	pop af
 	ld [wPalFlags], a
 	ret
@@ -175,7 +187,18 @@ CopySpritePal::
 	jr z, .copy_white
 
 .copy_bg
+	; Copy-BG palettes use the corresponding buffer for the requested state.
+	; wBGPals2 is the active, possibly partially faded palette; wBGPals1 is the
+	; destination palette.
+	push af
+	ld a, [wPalState]
+	assert PREV_PALSTATE == 0
+	and a
+	ld hl, wBGPals2
+	jr z, .got_copy_bg_source
 	ld hl, wBGPals1
+.got_copy_bg_source
+	pop af
 	ld bc, 1 palettes
 	rst AddNTimes
 	jr .got_pal

--- a/engine/gfx/sprite_palettes.asm
+++ b/engine/gfx/sprite_palettes.asm
@@ -79,7 +79,7 @@ CopyLeafGreenToOBPal7:
 ; other colors like purple. (We can assume that if PAL_BG_GREEN is *not* swapped,
 ; then it's still appropriate for use as a leaf/tree color.)
 	ld a, [wPaletteSwapFlag]
-	and a
+	and $f ; upper bits track which palette swap entries are initialized
 	ld a, PAL_OW_LEAF_GREEN
 	jr nz, CopySpritePalToOBPal7
 	; fallthrough

--- a/engine/gfx/sprite_palettes.asm
+++ b/engine/gfx/sprite_palettes.asm
@@ -199,7 +199,8 @@ CopySpritePal::
 	and a
 	ld hl, wBGPals2
 	jr z, .got_copy_bg_source
-	ld hl, wBGPals1
+	assert HIGH(wBGPals2) == HIGH(wBGPals1)
+	ld l, LOW(wBGPals1)
 .got_copy_bg_source
 	pop af
 	ld bc, 1 palettes

--- a/engine/overworld/warp_connection.asm
+++ b/engine/overworld/warp_connection.asm
@@ -11,8 +11,9 @@ HandleContinueMap:
 	ld hl, wPaletteSwapAddress
 	ld [hli], a
 	ld [hli], a
-	assert wPaletteSwapAddress + 2 == wPaletteSwapFlag
+	assert wPaletteSwapAddress + 2 == wPaletteSwapStates
 	ld [hl], a
+	ld [wPaletteSwapInits], a
 	ld a, MAPCALLBACK_CMDQUEUE
 	call RunMapCallback
 	call GetMapTimeOfDay

--- a/engine/overworld/warp_connection.asm
+++ b/engine/overworld/warp_connection.asm
@@ -12,8 +12,9 @@ HandleContinueMap:
 	ld [hli], a
 	ld [hli], a
 	assert wPaletteSwapAddress + 2 == wPaletteSwapStates
+	ld [hli], a
+	assert wPaletteSwapStates + 1 == wPaletteSwapInits
 	ld [hl], a
-	ld [wPaletteSwapInits], a
 	ld a, MAPCALLBACK_CMDQUEUE
 	call RunMapCallback
 	call GetMapTimeOfDay

--- a/home/palette_swap.asm
+++ b/home/palette_swap.asm
@@ -24,6 +24,7 @@ InitializeSwappedPalette::
 	ld a, CURR_PALSTATE
 	ld [wPalState], a
 	farcall CalculateStates
+	ld c, 1 ; one state bit per palette swap entry (up to four)
 	jr .loop
 
 .no_palette_swaps
@@ -33,38 +34,28 @@ InitializeSwappedPalette::
 	ret
 
 .loop
+	push bc
 	; If there are no more palette swap rectangles, just return.
 	call CheckPaletteSwapRectangle
-	jr z, .done
+	jr z, .done_loop
+	ld c, 0
+	jr nc, .got_current_state
+	inc c
+.got_current_state
 
-	; If the current state in the carry flag differs from the previous state
-	; in [wPaletteSwapFlag], then toggle the value of [wPaletteSwapFlag].
-	; Both are 0/unset (outside) or 1/set (inside), so their sum is 0 or 2 if they match, and
-	; 1 if they don't. So after summing them, `dec a` will yield `nz` if they match.
-	ld de, wPaletteSwapFlag
-	ld a, [de]
-	adc 0
-	dec a
-	; Swap the palette even if we don't toggle, because CloseSubmenu
-	; (e.g. from the Start menu) does not restore the non-default palette.
-	; TODO: look into a more targeted fix for this.
-	jr nz, .skip_toggle
+	; Preserve this entry's state bit across palette loading. `c` returns bit 0
+	; set inside the rectangle and bit 7 set if this entry changed.
+	pop de
+	farcall UpdatePaletteSwapState
+	push de
 
-	; Toggle the current [wPaletteSwapFlag] state.
-	ld a, [de]
-	xor 1
-	ld [de], a
-
-.skip_toggle
 	; Get the BG palette ID in `b`.
 	ld a, [hli]
 	ld b, a
 
 	; Get the palette list in `de`.
 	; Advance `hl` past the two palettes.
-	ld a, [de]
-	ld c, a
-	and a
+	bit 0, c
 	jr z, .get_palette
 	; Skip the regular palette to get the swapped one.
 	inc hl
@@ -74,8 +65,7 @@ InitializeSwappedPalette::
 	ld e, a
 	ld a, [hli]
 	ld d, a
-	ld a, c
-	and a
+	bit 0, c
 	jr nz, .got_palette
 	; Skip the swapped palette if we already got the regular one.
 	inc hl
@@ -88,6 +78,8 @@ InitializeSwappedPalette::
 	jr z, .swapped
 
 	farcall CheckPaletteFading
+	jr z, .swap_current
+	bit 7, c
 	jr z, .swap_current
 
 	; Rebuild this palette under the fade's previous conditions, then catch it
@@ -138,8 +130,12 @@ InitializeSwappedPalette::
 
 	; Continue processing more than one `paletteswap` rectangle.
 	call SwitchToMapScriptsBank
+	pop bc
+	sla c
 	jr .loop
 
+.done_loop
+	pop bc
 .done
 	; Return carry when there were some `paletteswap` rectangles.
 	pop af

--- a/home/palette_swap.asm
+++ b/home/palette_swap.asm
@@ -30,7 +30,7 @@ InitializeSwappedPalette::
 	ld a, CURR_PALSTATE
 	ld [wPalState], a
 	farcall CalculateStates
-	ld c, 1 ; one state bit per palette swap entry (up to four)
+	ld c, PALETTE_SWAP_INSIDE ; one state bit per palette swap entry
 	jr .loop
 
 .no_palette_swaps
@@ -44,13 +44,13 @@ InitializeSwappedPalette::
 	; If there are no more palette swap rectangles, just return.
 	call CheckPaletteSwapRectangle
 	jr z, .done_loop
-	ld c, 0
-	jr nc, .got_current_state
-	inc c
-.got_current_state
+	sbc a
+	and PALETTE_SWAP_INSIDE
+	ld c, a
 
-	; Preserve this entry's state bit across palette loading. `c` returns bit 0
-	; set inside the rectangle and bit 7 set if this entry changed.
+	; Preserve this entry's state bit across palette loading. `c` returns
+	; PALETTE_SWAP_INSIDE_F set inside the rectangle and
+	; PALETTE_SWAP_CHANGED_F set if this entry changed.
 	pop de
 	farcall UpdatePaletteSwapState
 	push de
@@ -61,7 +61,7 @@ InitializeSwappedPalette::
 
 	; Get the palette list in `de`.
 	; Advance `hl` past the two palettes.
-	bit 0, c
+	bit PALETTE_SWAP_INSIDE_F, c
 	jr z, .get_palette
 	; Skip the regular palette to get the swapped one.
 	inc hl
@@ -71,7 +71,7 @@ InitializeSwappedPalette::
 	ld e, a
 	ld a, [hli]
 	ld d, a
-	bit 0, c
+	bit PALETTE_SWAP_INSIDE_F, c
 	jr nz, .got_palette
 	; Skip the swapped palette if we already got the regular one.
 	inc hl
@@ -85,7 +85,7 @@ InitializeSwappedPalette::
 
 	farcall CheckPaletteFading
 	jr z, .swap_current
-	bit 7, c
+	bit PALETTE_SWAP_CHANGED_F, c
 	jr z, .swap_current
 
 	; Rebuild this palette under the fade's previous conditions, then catch it
@@ -127,6 +127,9 @@ InitializeSwappedPalette::
 	jr .swapped
 
 .swap_current
+	; Always reload the selected palette: CloseSubmenu does not restore
+	; non-default palettes, even when this entry's state has not changed.
+	; TODO: look into a more targeted fix for this.
 	ld a, BANK(SwapColorPalette)
 	rst Bankswitch
 	call SwapColorPalette

--- a/home/palette_swap.asm
+++ b/home/palette_swap.asm
@@ -36,7 +36,7 @@ InitializeSwappedPalette::
 	ld a, CURR_PALSTATE
 	ld [wPalState], a
 	farcall CalculateStates
-	ld de, PALETTE_SWAP_INSIDE ; d: changed BG palettes, e: entry state bit
+	lb de, 0, PALETTE_SWAP_INSIDE ; d: changed BG palettes, e: entry state bit
 
 .state_loop
 	; First update every entry's state and collect its destination palette.
@@ -59,7 +59,7 @@ InitializeSwappedPalette::
 	ld b, a
 	bit PALETTE_SWAP_CHANGED_F, c
 	jr z, .state_updated
-	call .get_palette_mask
+	call GetPaletteMask
 	or d
 	ld d, a
 
@@ -96,7 +96,7 @@ InitializeSwappedPalette::
 	ld a, d
 	and a
 	jr z, .got_changed_state
-	call .get_palette_mask
+	call GetPaletteMask
 	and d
 	jr z, .got_changed_state
 	set PALETTE_SWAP_CHANGED_F, c
@@ -151,7 +151,14 @@ InitializeSwappedPalette::
 	call SwitchToMapScriptsBank
 	jr .palette_loop
 
-.get_palette_mask
+.done
+	; Return carry when there were some `paletteswap` rectangles.
+	pop af
+	rst Bankswitch
+	scf
+	ret
+
+GetPaletteMask:
 ; Return `a` = 1 << `b` given BG palette ID `b`, preserving `bc`.
 	push bc
 	ld a, $80
@@ -161,13 +168,6 @@ InitializeSwappedPalette::
 	dec b
 	jr nz, .mask_loop
 	pop bc
-	ret
-
-.done
-	; Return carry when there were some `paletteswap` rectangles.
-	pop af
-	rst Bankswitch
-	scf
 	ret
 
 CheckPaletteSwapRectangle:

--- a/home/palette_swap.asm
+++ b/home/palette_swap.asm
@@ -1,7 +1,9 @@
 HandlePaletteSwap::
 	call InitializeSwappedPalette
 	ret nc
-	homecall _CGB_ForceUpdateLayout
+	; Keep an in-progress fade's active palettes intact. The newly swapped
+	; palettes in wBGPals1 will remain the fade destination.
+	homecall ApplyPalsIfNotFading
 	ret
 
 InitializeSwappedPalette::

--- a/home/palette_swap.asm
+++ b/home/palette_swap.asm
@@ -152,7 +152,7 @@ InitializeSwappedPalette::
 	jr .palette_loop
 
 .get_palette_mask
-; Return a one-hot mask for BG palette ID `b`, preserving `bc`.
+; Return `a` = 1 << `b` given BG palette ID `b`, preserving `bc`.
 	push bc
 	ld a, $80
 	inc b

--- a/home/palette_swap.asm
+++ b/home/palette_swap.asm
@@ -130,8 +130,6 @@ InitializeSwappedPalette::
 	bit PALETTE_SWAP_CHANGED_F, c
 	jr z, .swap_current
 
-	; Rebuild this palette under the fade's previous conditions, then catch it
-	; up to the current fade step toward the same palette's current conditions.
 	farcall CatchUpPaletteSwapFade
 	jr .swapped
 

--- a/home/palette_swap.asm
+++ b/home/palette_swap.asm
@@ -25,39 +25,83 @@ InitializeSwappedPalette::
 	ld h, [hl]
 	ld l, a
 	or h
-	jr z, .no_palette_swaps
-
-	ld a, CURR_PALSTATE
-	ld [wPalState], a
-	farcall CalculateStates
-	ld c, PALETTE_SWAP_INSIDE ; one state bit per palette swap entry
-	jr .loop
-
-.no_palette_swaps
+	jr nz, .has_palette_swaps
 	pop af
 	rst Bankswitch
 	and a
 	ret
 
-.loop
-	push bc
-	; If there are no more palette swap rectangles, just return.
+.has_palette_swaps
+	push hl
+	ld a, CURR_PALSTATE
+	ld [wPalState], a
+	farcall CalculateStates
+	ld de, PALETTE_SWAP_INSIDE ; d: changed BG palettes, e: entry state bit
+
+.state_loop
+	; First update every entry's state and collect its destination palette.
+	; This must finish before loading palettes: a later NULL entry can leave an
+	; earlier entry for the same slot as the final effective palette.
 	call CheckPaletteSwapRectangle
-	jr z, .done_loop
+	jr z, .states_done
 	sbc a
 	and PALETTE_SWAP_INSIDE
 	ld c, a
 
-	; Preserve this entry's state bit across palette loading. `c` returns
+	; Preserve the accumulated palette mask around the farcall. `c` returns
 	; PALETTE_SWAP_INSIDE_F set inside the rectangle and
 	; PALETTE_SWAP_CHANGED_F set if this entry changed.
-	pop de
-	farcall UpdatePaletteSwapState
 	push de
+	farcall UpdatePaletteSwapState
+	pop de
 
-	; Get the BG palette ID in `b`.
 	ld a, [hli]
 	ld b, a
+	bit PALETTE_SWAP_CHANGED_F, c
+	jr z, .state_updated
+	call .get_palette_mask
+	or d
+	ld d, a
+
+.state_updated
+	; Skip the outside and inside palette pointers.
+	ld bc, 4
+	add hl, bc
+	sla e
+	jr .state_loop
+
+.states_done
+	; A changed palette only needs catch-up during an active fade.
+	ld a, d
+	and a
+	jr z, .load_palettes
+	farcall CheckPaletteFading
+	jr nz, .load_palettes
+	ld d, a ; a == 0
+
+.load_palettes
+	pop hl
+
+.palette_loop
+	call CheckPaletteSwapRectangle
+	jr z, .done
+	sbc a
+	and PALETTE_SWAP_INSIDE
+	ld c, a
+
+	; Get the BG palette ID in `b`, and mark the slot if any entry targeting it
+	; changed. This makes chained swaps resolve to their final effective palette.
+	ld a, [hli]
+	ld b, a
+	ld a, d
+	and a
+	jr z, .got_changed_state
+	call .get_palette_mask
+	and d
+	jr z, .got_changed_state
+	set PALETTE_SWAP_CHANGED_F, c
+.got_changed_state
+	push de
 
 	; Get the palette list in `de`.
 	; Advance `hl` past the two palettes.
@@ -83,47 +127,12 @@ InitializeSwappedPalette::
 	or e
 	jr z, .swapped
 
-	farcall CheckPaletteFading
-	jr z, .swap_current
 	bit PALETTE_SWAP_CHANGED_F, c
 	jr z, .swap_current
 
 	; Rebuild this palette under the fade's previous conditions, then catch it
 	; up to the current fade step toward the same palette's current conditions.
-	push bc
-	push de
-	ld a, [wPalWhiteState]
-	and a
-	jr z, .swap_previous
-	ld hl, wBGPals2
-	ld a, b
-	ld bc, 1 palettes
-	rst AddNTimes
-	ld d, h
-	ld e, l
-	farcall CopyWhitePal
-	jr .got_previous
-
-.swap_previous
-	xor a
-	assert PREV_PALSTATE == 0
-	ld [wPalState], a
-	ld a, BANK(SwapColorPalette)
-	rst Bankswitch
-	call SwapColorPalette
-
-.got_previous
-	pop de
-	pop bc
-	ld a, CURR_PALSTATE
-	ld [wPalState], a
-	ld a, BANK(SwapColorPalette)
-	rst Bankswitch
-	push bc
-	call SwapColorPalette
-	pop bc
-	ld a, b
-	farcall CatchUpBGPaletteFade
+	farcall CatchUpPaletteSwapFade
 	jr .swapped
 
 .swap_current
@@ -136,15 +145,24 @@ InitializeSwappedPalette::
 
 .swapped
 	pop hl
+	pop de
 
 	; Continue processing more than one `paletteswap` rectangle.
 	call SwitchToMapScriptsBank
-	pop bc
-	sla c
-	jr .loop
+	jr .palette_loop
 
-.done_loop
+.get_palette_mask
+; Return a one-hot mask for BG palette ID `b`, preserving `bc`.
+	push bc
+	ld a, $80
+	inc b
+.mask_loop
+	rlca
+	dec b
+	jr nz, .mask_loop
 	pop bc
+	ret
+
 .done
 	; Return carry when there were some `paletteswap` rectangles.
 	pop af

--- a/home/palette_swap.asm
+++ b/home/palette_swap.asm
@@ -1,4 +1,10 @@
 HandlePaletteSwap::
+	ld a, [wPlayerStepFlags]
+	bit PLAYERSTEP_STOP_F, a
+	jr nz, .update
+	farcall CheckPaletteFading
+	ret nz
+.update
 	call InitializeSwappedPalette
 	ret nc
 	; A fading swap has already caught up its own slot, so do not overwrite all

--- a/home/palette_swap.asm
+++ b/home/palette_swap.asm
@@ -1,8 +1,8 @@
 HandlePaletteSwap::
 	call InitializeSwappedPalette
 	ret nc
-	; Keep an in-progress fade's active palettes intact. The newly swapped
-	; palettes in wBGPals1 will remain the fade destination.
+	; A fading swap has already caught up its own slot, so do not overwrite all
+	; active palettes with their destinations.
 	homecall ApplyPalsIfNotFading
 	ret
 
@@ -19,8 +19,14 @@ InitializeSwappedPalette::
 	ld h, [hl]
 	ld l, a
 	or h
-	jr nz, .loop
+	jr z, .no_palette_swaps
 
+	ld a, CURR_PALSTATE
+	ld [wPalState], a
+	farcall CalculateStates
+	jr .loop
+
+.no_palette_swaps
 	pop af
 	rst Bankswitch
 	and a
@@ -75,12 +81,59 @@ InitializeSwappedPalette::
 	inc hl
 	inc hl
 .got_palette
-
-	; Swap the palette in VRAM.
 	push hl
+	; A NULL palette leaves an earlier swap for the same slot intact.
+	ld a, d
+	or e
+	jr z, .swapped
+
+	farcall CheckPaletteFading
+	jr z, .swap_current
+
+	; Rebuild this palette under the fade's previous conditions, then catch it
+	; up to the current fade step toward the same palette's current conditions.
+	push bc
+	push de
+	ld a, [wPalWhiteState]
+	and a
+	jr z, .swap_previous
+	ld hl, wBGPals2
+	ld a, b
+	ld bc, 1 palettes
+	rst AddNTimes
+	ld d, h
+	ld e, l
+	farcall CopyWhitePal
+	jr .got_previous
+
+.swap_previous
+	xor a
+	assert PREV_PALSTATE == 0
+	ld [wPalState], a
 	ld a, BANK(SwapColorPalette)
 	rst Bankswitch
 	call SwapColorPalette
+
+.got_previous
+	pop de
+	pop bc
+	ld a, CURR_PALSTATE
+	ld [wPalState], a
+	ld a, BANK(SwapColorPalette)
+	rst Bankswitch
+	push bc
+	call SwapColorPalette
+	pop bc
+	ld a, b
+	farcall CatchUpBGPaletteFade
+	jr .swapped
+
+.swap_current
+	ld a, BANK(SwapColorPalette)
+	rst Bankswitch
+	call SwapColorPalette
+
+.swapped
 	pop hl
 
 	; Continue processing more than one `paletteswap` rectangle.

--- a/macros/scripts/events.asm
+++ b/macros/scripts/events.asm
@@ -1427,6 +1427,7 @@ ENDM
 
 	const usepaletteswap_command
 MACRO usepaletteswap
+	redef _NUM_PALETTE_SWAPS = 0
 	db usepaletteswap_command
 	dw \1 ; paletteswap_pointer
 ENDM

--- a/macros/scripts/events.asm
+++ b/macros/scripts/events.asm
@@ -1427,7 +1427,7 @@ ENDM
 
 	const usepaletteswap_command
 MACRO usepaletteswap
-	redef _NUM_PALETTE_SWAPS = 0
+	def _NUM_PALETTE_SWAPS = 0
 	db usepaletteswap_command
 	dw \1 ; paletteswap_pointer
 ENDM

--- a/macros/scripts/maps.asm
+++ b/macros/scripts/maps.asm
@@ -225,7 +225,12 @@ MACRO stonetable
 	dw \3 ; script pointer
 ENDM
 
+DEF _NUM_PALETTE_SWAPS = 0
+
 MACRO paletteswap
+	assert _NUM_PALETTE_SWAPS < NUM_PALETTE_SWAP_STATES, \
+		"A palette swap list may have at most {d:NUM_PALETTE_SWAP_STATES} entries"
+	redef _NUM_PALETTE_SWAPS += 1
 	db \1, \2 ; X range
 	db \3, \4 ; Y range
 	db \5 ; palette ID

--- a/macros/scripts/maps.asm
+++ b/macros/scripts/maps.asm
@@ -228,9 +228,6 @@ ENDM
 DEF _NUM_PALETTE_SWAPS = 0
 
 MACRO paletteswap
-	assert _NUM_PALETTE_SWAPS < NUM_PALETTE_SWAP_STATES, \
-		"A palette swap list may have at most {d:NUM_PALETTE_SWAP_STATES} entries"
-	redef _NUM_PALETTE_SWAPS += 1
 	db \1, \2 ; X range
 	db \3, \4 ; Y range
 	db \5 ; palette ID
@@ -240,6 +237,10 @@ MACRO paletteswap
 		"\6 is not accessible in the color ROMX bank!"
 	assert BANK(\7) == BANK(SwapColorPalette) || BANK(\6) == 0, \
 		"\7 is not accessible in the color ROMX bank!"
+	; wPaletteSwapStates and wPaletteSwapInits use one bit per entry,
+	; so max 8 paletteswaps for the 8 bits.
+	assert _NUM_PALETTE_SWAPS < 8, "A palette swap list may have at most 8 entries"
+	redef _NUM_PALETTE_SWAPS += 1
 ENDM
 
 ; Connections go in order: north, south, west, east

--- a/macros/scripts/maps.asm
+++ b/macros/scripts/maps.asm
@@ -225,8 +225,6 @@ MACRO stonetable
 	dw \3 ; script pointer
 ENDM
 
-DEF _NUM_PALETTE_SWAPS = 0
-
 MACRO paletteswap
 	db \1, \2 ; X range
 	db \3, \4 ; Y range

--- a/ram/wramx.asm
+++ b/ram/wramx.asm
@@ -1088,7 +1088,7 @@ wTimeOfDayPal:: db
 wFollowInSync:: db
 
 wPaletteSwapAddress:: dw
-wPaletteSwapFlag:: db
+wPaletteSwapFlag:: db ; low nibble: current states; high nibble: initialized
 
 wTimeOfDayPalFlags:: db
 wTimeOfDayPalset:: db

--- a/ram/wramx.asm
+++ b/ram/wramx.asm
@@ -1085,10 +1085,9 @@ wEnteredMapFromContinue:: db
 
 wTimeOfDayPal:: db
 
-wFollowInSync:: db
-
 wPaletteSwapAddress:: dw
 wPaletteSwapStates:: db
+wPaletteSwapInits:: db
 
 wTimeOfDayPalFlags:: db
 wTimeOfDayPalset:: db
@@ -1183,7 +1182,7 @@ wTradeFlags:: flag_array PARTY_LENGTH
 
 wMooMooBerries:: db
 
-wPaletteSwapInits:: db
+wFollowInSync:: db
 
 wFarfetchdPosition:: db
 

--- a/ram/wramx.asm
+++ b/ram/wramx.asm
@@ -1088,7 +1088,7 @@ wTimeOfDayPal:: db
 wFollowInSync:: db
 
 wPaletteSwapAddress:: dw
-wPaletteSwapFlag:: db ; low nibble: current states; high nibble: initialized
+wPaletteSwapStates:: db
 
 wTimeOfDayPalFlags:: db
 wTimeOfDayPalset:: db
@@ -1183,7 +1183,7 @@ wTradeFlags:: flag_array PARTY_LENGTH
 
 wMooMooBerries:: db
 
-	ds 1 ; unused
+wPaletteSwapInits:: db
 
 wFarfetchdPosition:: db
 


### PR DESCRIPTION
## Summary

Make map `paletteswap` entries integrate with the overworld fade system instead of forcing an immediate full palette application.

This prevents swapped BG palettes from snapping during weather, time-of-day, map-connection, lightning, and similar fades. It also makes a palette that changes or first appears partway through a fade start from the correct previous-state colors and catch up to the current fade step immediately.

## Palette state handling

- Make `SwapColorPalette` use the fade system's selected `wPalState` rather than reading the live time-of-day and overcast values directly.
- Write previous-state palettes to `wBGPals2`, the active/fading buffer, and current-state palettes to `wBGPals1`, the destination buffer.
- Track each palette-swap rectangle's current inside/outside state and whether that entry has ever been initialized. `wPaletteSwapFlag` uses:
  - low nibble: current inside/outside state for entries 1-4;
  - high nibble: initialization state for entries 1-4.
- Add named constants for the temporary inside/changed processing flags instead of relying on numeric bit positions.
- Add a build-time assertion limiting a palette-swap list to four entries, matching the capacity that already exists in `wPaletteSwapFlag`.

## Fade-aware updates and catch-up

- Avoid the old forced full-palette update while an overworld fade is active.
- During an active fade, process palette swaps on the movement frame where the player's rectangle state can change, while skipping unnecessary work on idle fade frames.
- Catch up only destination BG palette slots affected by an initialized or changed entry.
- Rebuild a changed slot under the fade's previous conditions, load its destination under the current conditions, and replay the elapsed fade steps for that one BG palette.
- Support fades whose previous state is white by initializing the changed active BG palette to white before catch-up.

Palette-swap lists are resolved in two passes. The first pass updates all rectangle states and records which BG palette slots were affected. The second pass applies entries in list order. This is required for chained entries such as Goldenrod City's two `PAL_BG_WATER` swaps, where a later `NULL` palette means “leave the earlier entry for this slot intact.” The final effective palette now receives catch-up even when the entry whose rectangle changed selects `NULL`.

No additional WRAM or persistent palette-swap state is introduced for this resolution; the affected BG slots are held in a transient register mask.

## Shared fade helpers and copied OBJ palettes

- Generalize palette fade catch-up so it can target either an OBJ or BG palette.
- Set `hCGBPalUpdate` after catching up a BG palette so its active colors are uploaded normally.
- Make copy-BG OBJ palettes select the active or destination BG buffer according to `wPalState`.
- Do not replay fade steps for ordinary copy-BG OBJ palettes that already copied an in-progress active BG palette; this avoids advancing them ahead of the BG palette they mirror.
- Preserve normal catch-up for white-origin fades and `PAL_OW_COPY_BG_WHITE`, which are constructed from destination colors.
- Mask `wPaletteSwapFlag` to its current-state nibble when choosing the Fly/Cut leaf palette, so initialization bits are not mistaken for active swaps.

## VBlank safety

`DI_DelayFrame` can wait through VBlank with interrupts disabled during HBlank DMA. Clear the stale VBlank request before returning so it is not serviced later in the visible frame, where a deferred CGB palette upload could write inaccessible palette VRAM.

## Performance and size

- Skip catch-up unless a palette-swap entry actually changed.
- Skip the added fade-state query and destination-mask calculation on the common no-change path.
- Move the larger palette rebuild/catch-up helper into the banked color engine to keep the ROM0 `Home` section within capacity.
- Use a tail `farjp` for the final BG catch-up call.
- `python3 utils/optimize.py` reports zero findings across all assembly files changed by this branch.

## Validation

- `make clean && make -j6`
- `make clean && make -j6 debug`
- Intentional five-entry palette-swap list fails assembly with: `A palette swap list may have at most 4 entries`.
- Reviewed chained same-slot swaps, selected `NULL` entries, first-time initialization, ordinary and white-origin fades, copy-BG OBJ palettes, ROM/WRAM bank restoration, and stack balance on every exit path.
