### PR TITLE
Clean up BG map-related functions

### DIFF
--- a/constants/ram_constants.asm
+++ b/constants/ram_constants.asm
@@ -547,10 +547,8 @@ DEF LCDC_DEFAULT EQU LCDC_ON | LCDC_WIN_9C00 | LCDC_WIN_ON | LCDC_BLOCK21 | LCDC
 
 ; hBGMapMode::
 	const_def
-	const NO_BG_MAP_TRANSFER   ; 0
-	const TRANSFER_TILEMAP     ; 1: from wTilemap to 0:[hBGMapAddress]
-	const TRANSFER_ATTRMAP     ; 2: from wAttrmap to 1:[hBGMapAddress]
-	const TRANSFER_TILEMAP1    ; 3: from wTilemap to vBGMap1
-	const TRANSFER_ATTRMAP1    ; 4: from wAttrmap to vBGMap3
-	const TRANSFER_TILEMAP_OFS ; 5: like TRANSFER_TILEMAP, but starts on the [hBGMapHalf]th row
-	const TRANSFER_ATTRMAP_OFS ; 6: like TRANSFER_ATTRMAP, but starts on the [hBGMapHalf]th row
+	const NO_BG_MAP_TRANSFER ; 0
+	const TRANSFER_TILEMAP   ; 1: from wTilemap to 0:[hBGMapAddress]
+	const TRANSFER_ATTRMAP   ; 2: from wAttrmap to 1:[hBGMapAddress]
+	const TRANSFER_TILEMAP1  ; 3: from wTilemap to vBGMap1
+	const TRANSFER_ATTRMAP1  ; 4: from wAttrmap to vBGMap3

--- a/engine/gfx/copy_tilemap_at_once.asm
+++ b/engine/gfx/copy_tilemap_at_once.asm
@@ -58,33 +58,6 @@ _SafeCopyTilemapAtOnce::
 	ldh [hMapAnims], a
 	ret
 
-_CopyTilemapAtOnce::
-	ldh a, [hBGMapMode]
-	push af
-	ldh a, [hMapAnims]
-	push af
-
-	xor a
-	assert NO_BG_MAP_TRANSFER == 0
-	ldh [hBGMapMode], a
-	ldh [hMapAnims], a
-
-	di
-	hlcoord 0, 0, wAttrmap
-	ld a, 1 ; BANK(vStandingFrameTiles)
-	call CopyFullTilemapInHBlank
-	hlcoord 0, 0
-	xor a ; BANK(vObjTiles)
-	call CopyFullTilemapInHBlank
-
-	ei ; in case we've passed vblank
-
-	pop af
-	ldh [hMapAnims], a
-	pop af
-	ldh [hBGMapMode], a
-	ret
-
 VBlankSafeCopyTilemapAtOnce::
 	ldh a, [hSCX]
 	ldh [rSCX], a
@@ -266,4 +239,31 @@ CopyTilemapInHBlank:
 	ld sp, wSPBuffer
 	pop hl
 	ld sp, hl
+	ret
+
+_CopyTilemapAtOnce::
+	ldh a, [hBGMapMode]
+	push af
+	ldh a, [hMapAnims]
+	push af
+
+	xor a
+	assert NO_BG_MAP_TRANSFER == 0
+	ldh [hBGMapMode], a
+	ldh [hMapAnims], a
+
+	di
+	hlcoord 0, 0, wAttrmap
+	ld a, 1 ; BANK(vStandingFrameTiles)
+	call CopyFullTilemapInHBlank
+	hlcoord 0, 0
+	xor a ; BANK(vObjTiles)
+	call CopyFullTilemapInHBlank
+
+	ei ; in case we've passed vblank
+
+	pop af
+	ldh [hMapAnims], a
+	pop af
+	ldh [hBGMapMode], a
 	ret

--- a/engine/gfx/copy_tilemap_at_once.asm
+++ b/engine/gfx/copy_tilemap_at_once.asm
@@ -48,9 +48,14 @@ _SafeCopyTilemapAtOnce::
 	ldh [hOAMUpdate], a
 .noForceOAMUpdate
 	bit 3, b
-	ld a, 3
+def NB_ROWS_TILEMAP_ONLY equ 9
+; If we're copying both maps, we won't have enough time to copy as many rows.
+; Thus, the remainder gets copied outside of VBlank, in chunks of 5 rows; this leaves a remainder of 3,
+; which is suitable to be transferred during VBlank (twice: once for each of the two maps).
+def NB_ROWS_BOTH_MAPS equ 3
+	ld a, NB_ROWS_BOTH_MAPS
 	jr z, .gotRowCount
-	ld a, 9
+	ld a, NB_ROWS_TILEMAP_ONLY
 .gotRowCount
 	ldh [hBGMapCopyNRows], a
 	ld a, b
@@ -128,25 +133,18 @@ VBlankSafeCopyTilemapAtOnce::
 	ld de, TILEMAP_WIDTH * 9
 	ld b, 9
 	jr CopyTilemapInHBlank
+
 .attrAndBGCopy
-; now copy both tile and attr map, of alternating groups of 5/5/4
-	hlcoord 0, 3, wAttrmap
-	ld de, TILEMAP_WIDTH * 3
+FOR row_idx, NB_ROWS_BOTH_MAPS, SCREEN_HEIGHT, 5
+	hlcoord 0, row_idx, wAttrmap
+	ld de, TILEMAP_WIDTH * row_idx
 	call Copy5RowsOfTilemapInHBlank_VBK1
-	hlcoord 0, 3
-	ld de, TILEMAP_WIDTH * 3
+	hlcoord 0, row_idx
+	ld de, TILEMAP_WIDTH * row_idx
+	IF row_idx != SCREEN_HEIGHT - 5 ; Replace the last call with a fallthrough.
 	call Copy5RowsOfTilemapInHBlank_VBK0
-	hlcoord 0, 8, wAttrmap
-	ld de, TILEMAP_WIDTH * 8
-	call Copy5RowsOfTilemapInHBlank_VBK1
-	hlcoord 0, 8
-	ld de, TILEMAP_WIDTH * 8
-	call Copy5RowsOfTilemapInHBlank_VBK0
-	hlcoord 0, 13, wAttrmap
-	ld de, TILEMAP_WIDTH * 13
-	call Copy5RowsOfTilemapInHBlank_VBK1
-	hlcoord 0, 13
-	ld de, TILEMAP_WIDTH * 13
+	ENDC
+ENDR
 
 ; fallthrough
 Copy5RowsOfTilemapInHBlank_VBK0:

--- a/engine/gfx/copy_tilemap_at_once.asm
+++ b/engine/gfx/copy_tilemap_at_once.asm
@@ -74,7 +74,8 @@ VBlankSafeCopyTilemapAtOnce::
 	jr z, .copyAttrmapAndTilemap
 	; Copy only the tilemap.
 	; First, reuse the same code as `UpdateBGMap` to copy the top half during VBlank...
-	call UpdateBGMap.DoTiles
+	xor a
+	call _UpdateBGMap
 
 	call PushOAM ; This is still the VBlank handler!
 
@@ -97,8 +98,7 @@ VBlankSafeCopyTilemapAtOnce::
 	ldh [rVBK], a
 	ld hl, wAttrmap
 	call CopyTop3MapRows
-	; xor a (a == 0 at this point)
-	ldh [rVBK], a
+	; The previous function returns with VRA0 loaded.
 	ld hl, wTilemap
 	call CopyTop3MapRows
 

--- a/engine/gfx/copy_tilemap_at_once.asm
+++ b/engine/gfx/copy_tilemap_at_once.asm
@@ -1,16 +1,13 @@
 _SafeCopyTilemapAtOnce::
-	ldh a, [hBGMapMode]
-	push af
 	ldh a, [hMapAnims]
 	push af
 	ldh a, [hVBlank]
 	push af
 	xor a
-	assert NO_BG_MAP_TRANSFER == 0
-	ldh [hBGMapMode], a
 	ldh [hMapAnims], a
 
 	ld a, b
+	ldh [hTilemapAtomicCopyFlags], a ; Some of these flags must be passed to the VBlank handler.
 	and %11
 	jr nz, .notZero
 	ldh a, [hCGBPalUpdate]
@@ -36,45 +33,29 @@ _SafeCopyTilemapAtOnce::
 	call nc, DelayFrame ; not enough time to update music, so wait a frame
 	ld a, e
 	ldh [hCGBPalUpdate], a
+
 .waitLYAndUpdateMusic
 	ldh a, [rLY]
 	cp $70
 	jr nz, .waitLYAndUpdateMusic
-	xor a
-	ldh [hBGMapHalf], a
 	bit 2, b
 	jr z, .noForceOAMUpdate
 	xor a
 	ldh [hOAMUpdate], a
 .noForceOAMUpdate
-	bit 3, b
-def NB_ROWS_TILEMAP_ONLY equ 9
-; If we're copying both maps, we won't have enough time to copy as many rows.
-; Thus, the remainder gets copied outside of VBlank, in chunks of 5 rows; this leaves a remainder of 3,
-; which is suitable to be transferred during VBlank (twice: once for each of the two maps).
-def NB_ROWS_BOTH_MAPS equ 3
-	ld a, NB_ROWS_BOTH_MAPS
-	jr z, .gotRowCount
-	ld a, NB_ROWS_TILEMAP_ONLY
-.gotRowCount
-	ldh [hBGMapCopyNRows], a
-	ld a, b
-	and %1000
-	swap a
-	or TRANSFER_TILEMAP_OFS
-	ldh [hBGMapMode], a ; bit 7 = skip attr map
-	ld a, 1 << 7 | 7 ; execute actual VBlank7
+
+	ld a, 1 << 7 | 7 ; execute actual VBlank7, which leads to `VBlankSafeCopyTilemapAtOnce` below.
 	ldh [hVBlank], a
 	call UpdateSound
 	call DelayFrame
+
+	; Restore all regs.
 	ld a, d
 	ldh [hCGBPalUpdate], a
 	pop af
 	ldh [hVBlank], a
 	pop af
 	ldh [hMapAnims], a
-	pop af
-	ldh [hBGMapMode], a
 	ret
 
 _CopyTilemapAtOnce::
@@ -114,28 +95,44 @@ VBlankSafeCopyTilemapAtOnce::
 	ldh a, [hWX]
 	ldh [rWX], a
 	call UpdateCGBPals
-; values for the bg map update part should already be loaded
-	call UpdateBGMap
-; specify the values for attr map update
-	ldh a, [hBGMapMode]
-	bit 7, a
-	jr nz, .skipAttr
-	ld a, TRANSFER_ATTRMAP_OFS
-	ldh [hBGMapMode], a
-	call UpdateBGMap
-.skipAttr
-	call PushOAM
-	ldh a, [hBGMapMode]
-	bit 7, a
-	jr z, .attrAndBGCopy
-; if we only need to update tiles, copy the remaining half in hblank
-	hlcoord 0, 9
-	ld de, TILEMAP_WIDTH * 9
-	ld b, 9
+
+	ldh a, [hTilemapAtomicCopyFlags]
+	and 1 << 3
+	jr z, .copyAttrmapAndTilemap
+	; Copy only the tilemap.
+	; First, reuse the same code as `UpdateBGMap` to copy the top half during VBlank...
+	call UpdateBGMap.DoTiles
+
+	call PushOAM ; This is still the VBlank handler!
+
+	; ...and then, copy the bottom half during HBlank.
+	hlcoord 0, SCREEN_HEIGHT / 2 ; HALF_HEIGHT from `video.asm`.
+	ld de, TILEMAP_WIDTH * (SCREEN_HEIGHT / 2)
+	ld b, SCREEN_HEIGHT / 2
 	jr CopyTilemapInHBlank
 
-.attrAndBGCopy
-FOR row_idx, NB_ROWS_BOTH_MAPS, SCREEN_HEIGHT, 5
+.copyAttrmapAndTilemap
+	; We do not have enough time to copy one half of each map; instead, the strategy is to copy some
+	; during VBlank, and then copy the rest during rendering.
+	; To avoid tearing, we must stay ahead of the rendering, which requires alternating between updating
+	; the tilemap and attrmap. However, it is more efficient to copy in bulk from the same one, since
+	; switching between the two carries some overhead.
+	; 5 rows turns out to be an appreciable compromise; this means we can split the 18 {tile,attr}map rows
+	; into three chunks of 5, leaving a remainder of 3.
+	; Those 3 rows are thus what we will copy here during VBlank.  (Whew!)
+	inc a ; ld a, 1
+	ldh [rVBK], a
+	ld hl, wAttrmap
+	call CopyTop3MapRows
+	; xor a (a == 0 at this point)
+	ldh [rVBK], a
+	ld hl, wTilemap
+	call CopyTop3MapRows
+
+	call PushOAM ; This is still a VBlank handler, after all :)
+
+	; Perform the rest of the copies in HBlank.
+FOR row_idx, 3 /* rows already copied during VBlank */, SCREEN_HEIGHT, 5
 	hlcoord 0, row_idx, wAttrmap
 	ld de, TILEMAP_WIDTH * row_idx
 	call Copy5RowsOfTilemapInHBlank_VBK1

--- a/engine/pc/bills_pc_ui.asm
+++ b/engine/pc/bills_pc_ui.asm
@@ -2348,7 +2348,7 @@ BillsPC_MoveItem:
 
 	ld a, 1
 	ldh [rVBK], a
-	dec a
+	xor a
 	assert NO_BG_MAP_TRANSFER == 0
 	ldh [hBGMapMode], a
 

--- a/engine/pokegear/pokegear.asm
+++ b/engine/pokegear/pokegear.asm
@@ -1815,12 +1815,7 @@ TownMapBGUpdate:
 	ldh [hBGMapAddress], a
 	ld a, h
 	ldh [hBGMapAddress + 1], a
-	ld a, TRANSFER_ATTRMAP
-	ldh [hBGMapMode], a
-	; wait to update the whole screen's palettes.
-	ld c, 3
-	call DelayFrames
-	call ApplyTilemapInVBlank
+	call ApplyAttrAndTilemapInVBlank
 	xor a
 	assert NO_BG_MAP_TRANSFER == 0
 	ldh [hBGMapMode], a

--- a/home/gfx.asm
+++ b/home/gfx.asm
@@ -359,37 +359,6 @@ WriteVCopyRegistersToHRAM:
 	ldh [hNbTilesToCopy], a
 	ret
 
-VRAMToVRAMCopy:
-	lb bc, STAT_MODE, LOW(rSTAT) ; predefine for speed and size
-	jr .waitNoHBlank2
-.outerLoop2
-	ldh a, [rLY]
-	cp $88
-	jr nc, ContinueHBlankCopy
-.waitNoHBlank2
-	ldh a, [c]
-	and b
-	jr z, .waitNoHBlank2
-.waitHBlank2
-	ldh a, [c]
-	and b
-	jr nz, .waitHBlank2
-rept 8
-	pop de
-	ld a, e
-	ld [hli], a
-	ld a, d
-	ld [hli], a
-endr
-	ld a, l
-	and $f
-	jr nz, .waitNoHBlank2
-	ldh a, [hNbTilesToCopy]
-	dec a
-	ldh [hNbTilesToCopy], a
-	jr nz, .outerLoop2
-	jr DoneHBlankCopy
-
 HBlankCopy2bpp:
 	di
 	ld [wSPBuffer], sp
@@ -402,40 +371,24 @@ HBlankCopy2bpp:
 	ld sp, hl ; source
 	pop hl
 	ld sp, hl ; set source to sp
-	ld a, h ; save source high byte for later
 	ld h, d ; exchange hl and de
 	ld l, e
-; vram to vram copy check:
-	cp HIGH(vTiles0) ; is source in RAM?
-	jr c, .innerLoop
-	cp HIGH(STARTOF(VRAM) + SIZEOF(VRAM)) ; is source past VRAM
-	jr nc, .innerLoop
-	jr VRAMToVRAMCopy
-.outerLoop
+	lb bc, STAT_MODE, LOW(rSTAT) ; predefine for speed and size
+	jr .waitNoHBlank
+
+.outerLoop2
 	ldh a, [rLY]
 	cp $88
-	jmp nc, ContinueHBlankCopy
-.innerLoop
-	pop bc
-	pop de
+	jr nc, ContinueHBlankCopy
 .waitNoHBlank
-	ldh a, [rSTAT]
-	and STAT_MODE
+	ldh a, [c]
+	and b
 	jr z, .waitNoHBlank
 .waitHBlank
-	ldh a, [rSTAT]
-	and STAT_MODE
+	ldh a, [c]
+	and b
 	jr nz, .waitHBlank
-; preloads r us
-	ld a, c
-	ld [hli], a
-	ld a, b
-	ld [hli], a
-	ld a, e
-	ld [hli], a
-	ld a, d
-	ld [hli], a
-rept 6
+rept 8
 	pop de
 	ld a, e
 	ld [hli], a
@@ -445,5 +398,5 @@ endr
 	ldh a, [hNbTilesToCopy]
 	dec a
 	ldh [hNbTilesToCopy], a
-	jr nz, .outerLoop
-	jmp DoneHBlankCopy
+	jr nz, .outerLoop2
+	jr DoneHBlankCopy

--- a/home/video.asm
+++ b/home/video.asm
@@ -150,101 +150,37 @@ UpdateBGMap::
 ; Update the BG Map, in halves, from wTilemap and wAttrmap.
 
 	ldh a, [hBGMapMode]
-	and $7f
+	and a
 	ret z
 
-; BG Map 0
-	dec a ; 1
-	jr z, .DoTiles
-	dec a ; 2
-	jr z, .DoAttributes
-
-; BG Map 1
+	dec a
+_UpdateBGMap::
+	ldh [rVBK], a ; Load the appropriate VRAM bank (only bit 0 gets used).
+	ld [wSPBuffer], sp ; Since we're about to use the stack as the copy source, save it for restoring later.
+	ld sp, wTilemap
+	rra ; Bit 0 (now in carry) encodes which bank to use.
+	jr nc, :+
+	ld sp, wAttrmap
+:
+	rra ; Bit 1 (now in carry) encodes whether to use `hBGMapAddress` or vBGMap1.
 	ld hl, vBGMap1
-	dec a
-	jr z, .DoBGMap1Tiles
-	dec a
-	jr z, .DoBGMap1Attributes
-; Update from a specific row
-; does not update hBGMapHalf
-	dec a
-	bccoord 0, 0
-	jr z, .DoCustomSourceTiles
-	dec a
-	ret nz
-	bccoord 0, 0, wAttrmap
-	ld a, 1
-	ldh [rVBK], a
-	call .DoCustomSourceTiles
-	xor a
-	ldh [rVBK], a
-	ret
-
-.DoCustomSourceTiles
-	rst 0
-	jr _CopyTilemapRows
-
-.DoAttributes
-	ldh a, [hBGMapAddress + 1]
-	ld h, a
+	jr c, :+
 	ldh a, [hBGMapAddress]
 	ld l, a
-.DoBGMap1Attributes
-	ld a, 1
-	ldh [rVBK], a
-	call .CopyAttributes
-	xor a
-	ldh [rVBK], a
-	ret
-
-.CopyAttributes
-	ld [wSPBuffer], sp
-
-; Which half?
-	ldh a, [hBGMapHalf]
-	and a ; 0
-	jr z, .AttributeMapTop
-; bottom row
-	coord sp, 0, 9, wAttrmap
-	ld de, HALF_HEIGHT * TILEMAP_WIDTH
-	add hl, de
-; Next time: top half
-	xor a
-	jr .startCopy
-.AttributeMapTop
-	coord sp, 0, 0, wAttrmap
-; Next time: bottom half
-	jr .AttributeMapTopContinue
-
-.DoTiles::
 	ldh a, [hBGMapAddress + 1]
 	ld h, a
-	ldh a, [hBGMapAddress]
-	ld l, a
+:
 
-.DoBGMap1Tiles
-	ld [wSPBuffer], sp
-; Which half?
 	ldh a, [hBGMapHalf]
-	and a ; 0
-	jr z, .TileMapTop
-; bottom row
-	coord sp, 0, 9
-	ld de, HALF_HEIGHT * TILEMAP_WIDTH
-	add hl, de
-; Next time: top half
-	xor a
-	jr .startCopy
-.TileMapTop
-	coord sp, 0, 0
-; Next time: bottom half
-.AttributeMapTopContinue
-	inc a
-.startCopy
-; Which half to update next time
+	xor 1
+	jr nz, :+
+	; Bottom half!
+	add sp, 127 :: add sp, HALF_HEIGHT * SCREEN_WIDTH - 127 ; Source.
+	ld de, HALF_HEIGHT * TILEMAP_WIDTH :: add hl, de ; Destination.
+:
 	ldh [hBGMapHalf], a
-; Rows of tiles in a half
-	ld a, SCREEN_HEIGHT / 2
+
+	ld a, HALF_HEIGHT
 
 _CopyTilemapRows:
 ; Discrepancy between wTilemap and BGMap
@@ -270,6 +206,10 @@ endr
 	ld sp, wSPBuffer
 	pop hl
 	ld sp, hl
+
+	; Keep VRA0 loaded for the rest of the game, in case we just copied attributes.
+	xor a
+	ldh [rVBK], a
 	ret
 
 CopyTop3MapRows:: ; Called from `CopyTilemapAtOnce`.

--- a/home/video.asm
+++ b/home/video.asm
@@ -129,7 +129,7 @@ WaitTop::
 ; Wait until the top half of the BG Map is being updated.
 
 	ldh a, [hBGMapMode]
-	and a ; Warning: bit 7 is otherwise ignored...
+	and a
 	jr nz, .handleLoop
 	ret
 .loop
@@ -181,33 +181,8 @@ UpdateBGMap::
 	ret
 
 .DoCustomSourceTiles
-	ld [wSPBuffer], sp
-	xor a
-	ld h, a
-	ld d, a
-	ldh a, [hBGMapHalf] ; multiply by 20 to get the tilemap offset
-	ld l, a
-	ld e, a
-	add hl, hl ; hl = hl * 2
-	add hl, hl ; hl = hl * 4
-	add hl, de ; hl = (hl*4) + de
-	add hl, hl ; hl = (5*hl)*2
-	add hl, hl ; hl = (5*hl)*4
-	add hl, bc
-	ld sp, hl
-	ldh a, [hBGMapHalf] ; multiply by 32 to get the bg map offset
-	; assumes [hBGMapHalf] < 8
-	swap a
-	add a
-	ld l, a
-	ldh a, [hBGMapAddress]
-	add l
-	ld l, a
-	ldh a, [hBGMapAddress + 1]
-	adc 0
-	ld h, a
-	ldh a, [hBGMapCopyNRows]
-	jr .startCustomCopy
+	rst 0
+	jr _CopyTilemapRows
 
 .DoAttributes
 	ldh a, [hBGMapAddress + 1]
@@ -241,7 +216,7 @@ UpdateBGMap::
 ; Next time: bottom half
 	jr .AttributeMapTopContinue
 
-.DoTiles
+.DoTiles::
 	ldh a, [hBGMapAddress + 1]
 	ld h, a
 	ldh a, [hBGMapAddress]
@@ -270,7 +245,8 @@ UpdateBGMap::
 	ldh [hBGMapHalf], a
 ; Rows of tiles in a half
 	ld a, SCREEN_HEIGHT / 2
-.startCustomCopy
+
+_CopyTilemapRows:
 ; Discrepancy between wTilemap and BGMap
 	ld bc, TILEMAP_WIDTH - (SCREEN_WIDTH - 1)
 .row
@@ -295,6 +271,20 @@ endr
 	pop hl
 	ld sp, hl
 	ret
+
+CopyTop3MapRows:: ; Called from `CopyTilemapAtOnce`.
+	ld [wSPBuffer], sp
+	; Load the destination address, which is always at the top of the map.
+	ld sp, hBGMapAddress
+	pop de
+	; Load the source address...
+	ld sp, hl
+	; Transfer the destination to `hl`.
+	ld l, e
+	ld h, d
+	; The number of rows to be copied. For why 3, see this function's caller.
+	ld a, 3
+	jr _CopyTilemapRows
 
 LYOverrideStackCopy::
 	ldh a, [hLYOverrideStackCopyAmount]

--- a/ram/hram.asm
+++ b/ram/hram.asm
@@ -114,9 +114,9 @@ hSCY:: db
 hWX::  db
 hWY::  db
 
-hBGMapCopyNRows:: ; How many rows the `_OFS` modes (in hBGMapMode) ought to copy
-hNbRowsToCopy::   ; Temporary counter for `CopyTilemapInHBlank`
-hNbTilesToCopy::  ; Temporary counter for the `gfx.asm` functions
+hTilemapAtomicCopyFlags:: ; Copy of the flags passed to `*CopyTilemapAtOnce`
+hNbRowsToCopy::           ; Temporary counter for `CopyTilemapInHBlank`
+hNbTilesToCopy::          ; Temporary counter for the `Request*bpp` functions
 	db
 hBGMapMode::    db ; See `ram_constants.asm`
 hBGMapHalf::    db ; Either 0 (top half), or 1 (bottom half)


### PR DESCRIPTION
**This PR should be reviewed commit by commit**, as it performs both “simple” cleanups *and* more involved functionality changes, and they stack on top of each other. (I think it's also a better idea not to squash it, too.)

I haven't tested this *too* thoroughly, but I've confirmed that I can go through the title sequence and then into all of the START Menu's screens without any issues, which seems like it exercises all code touched by this PR.

This saves 169 bytes of ROM0 (from 77 to 246) without any changes to the rest of the codebase, while also making this code massively simpler and more maintainable.