### PR TITLE
[Needs optim] Have each ROM bank report its own bank number

### DIFF
--- a/constants/misc_constants.asm
+++ b/constants/misc_constants.asm
@@ -1,3 +1,7 @@
+; Each ROM bank self-reports its own bank ID at this address.
+; See engine/rom_bank_self_report.asm.
+DEF CurROMBank equ $7FFF
+
 ; Boolean checks
 DEF FALSE EQU 0
 DEF TRUE  EQU 1

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -8770,7 +8770,7 @@ CopyBackpic:
 	ldh [rWBK], a
 	ld hl, vTiles0
 	ld de, vTiles2 tile $31
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld b, a
 	ld c, 7 * 7
 	call Get2bpp

--- a/engine/gfx/load_pics.asm
+++ b/engine/gfx/load_pics.asm
@@ -46,7 +46,7 @@ _GetFrontpic:
 	call _PrepareFrontpic
 	call GetPaddedFrontpicAddress
 	ld c, 7 * 7
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld b, a
 	push hl
 	call Get2bpp
@@ -107,7 +107,7 @@ GetAnimatedFrontpic:
 	push hl
 	call GetPaddedFrontpicAddress
 	ld c, 7 * 7
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld b, a
 	call Get2bpp
 	pop hl
@@ -136,7 +136,7 @@ GetAnimatedFrontpic:
 	pop bc
 	pop hl
 	ld de, wDecompressScratch
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld b, a
 ; Improved routine by pfero
 ; https://gitgud.io/pfero/axyllagame/commit/486f4ed432ca49e5d1305b6402cc5540fe9d3aaa
@@ -152,7 +152,7 @@ GetAnimatedFrontpic:
 	; Then move up a bit and load the rest
 	ld de, wDecompressScratch + (127 - 7 * 7) tiles
 	ld hl, vTiles4
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld b, a
 	ld a, [wMonAnimationSize]
 	ld c, a
@@ -229,7 +229,7 @@ GetBackpic:
 	call FixBackpicAlignment
 	pop hl
 	ld de, wDecompressScratch
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld b, a
 	ld c, 6 * 6
 	call Get2bpp
@@ -269,7 +269,7 @@ _Decompress7x7Pic:
 	pop hl
 	ld de, wDecompressScratch
 	ld c, 7 * 7
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld b, a
 	call Get2bpp
 	pop af

--- a/engine/init.asm
+++ b/engine/init.asm
@@ -66,8 +66,6 @@ _Init::
 	ldh [hCGB], a
 	pop af
 	ldh [hCrashCode], a
-	ld a, BANK(@)
-	ldh [hROMBank], a
 
 	call ClearWRAM
 	ld a, 1

--- a/engine/pc/bills_pc_ui.asm
+++ b/engine/pc/bills_pc_ui.asm
@@ -473,7 +473,7 @@ _BillsPC_SetCursorMode:
 INCLUDE "gfx/pc/cursor.pal"
 
 BillsPC_SafeRequest1bppInWRA6::
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld b, a
 	call RunFunctionInWRA6
 .Function:
@@ -484,7 +484,7 @@ BillsPC_SafeRequest1bppInWRA6::
 	jr .Function
 
 BillsPC_SafeRequest2bppInWRA6::
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld b, a
 	call RunFunctionInWRA6
 

--- a/engine/pokedex/lcd.asm
+++ b/engine/pokedex/lcd.asm
@@ -643,7 +643,7 @@ Pokedex_UnsafeSetHBlankFunction:
 PHB_LCDCode:
 LOAD UNION "Misc 404", WRAM0
 wLCDPokedex::
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ldh [hPokedexROMBankBackup], a
 	ld a, BANK(PHB_LCDCode)
 	rst Bankswitch

--- a/engine/rom_bank_self_report.asm
+++ b/engine/rom_bank_self_report.asm
@@ -1,0 +1,9 @@
+; Each ROM bank self-reports its own bank ID at a fixed address.
+; This avoids the need to keep separately track of which ROM bank is being switched to;
+; additionally, it avoids the (admittedly small) race condition where the shadow is written to,
+; an int handler fires and restores the wrong bank, causing some emulators to raise a false-positive warning.
+
+FOR bank_id, 1, 128
+	SECTION "ROM bank {d:bank_id}'s ID", ROMX[CurROMBank],BANK[bank_id]
+		db bank_id
+ENDR

--- a/home/audio.asm
+++ b/home/audio.asm
@@ -7,7 +7,7 @@ InitSound::
 	push bc
 	push af
 
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	ld a, BANK(_InitSound)
 	rst Bankswitch
@@ -26,7 +26,7 @@ UpdateSound::
 	push bc
 	push af
 
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	ld a, BANK(_UpdateSound)
 	rst Bankswitch
@@ -71,7 +71,7 @@ _LoadMusicWord::
 CheckSpecialMapMusic:
 ; Returns z if the current map has a special music handler.
 
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	ld a, BANK(GetOvercastIndex)
 	rst Bankswitch
@@ -163,7 +163,7 @@ PlayMusic::
 	push bc
 	push af
 
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	ld a, BANK(_PlayMusic) ; and BANK(_InitSound)
 	rst Bankswitch
@@ -193,7 +193,7 @@ PlayMusic2::
 	push bc
 	push af
 
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 
 	ld a, BANK(_PlayMusic)
@@ -218,7 +218,7 @@ PlayCry::
 	push bc
 	push af
 
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 
 	ld a, BANK(PokemonCries)
@@ -256,7 +256,7 @@ PlaySFX::
 	jr c, .done
 
 .play
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	ld a, BANK(_PlaySFX)
 	rst Bankswitch

--- a/home/copy.asm
+++ b/home/copy.asm
@@ -81,7 +81,7 @@ GetFarWord::
 	; bankswitch to new bank
 	push bc
 	ld b, a
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld c, a
 	ld a, b
 	rst Bankswitch

--- a/home/farcall.asm
+++ b/home/farcall.asm
@@ -34,7 +34,7 @@ _RstFarCall::
 
 ; Write return bank to sp+10
 	ld hl, sp + 10
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld [hli], a
 
 ; Get function bank and address in a:de
@@ -108,7 +108,7 @@ _DoFarCall:
 ; +2 saved hl
 ; +0 saved af
 ; Write return bank to sp+0
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld hl, sp + 4
 	ld [hl], a
 	pop af
@@ -161,7 +161,7 @@ AnonBankPush::
 
 ; Write return bank to sp+10
 	ld hl, sp + 10
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld d, [hl] ; HIGH(return address)
 	ld [hld], a
 
@@ -211,7 +211,7 @@ StackCallInBankA:
 	ld hl, sp + 8
 	ld d, [hl]
 	ld e, a
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld [hld], a
 	ld a, e
 

--- a/home/gfx.asm
+++ b/home/gfx.asm
@@ -50,7 +50,7 @@ DecompressRequest2bpp::
 	; fallthrough
 
 Request2bppInWRA6::
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld b, a
 	call RunFunctionInWRA6
 

--- a/home/header.asm
+++ b/home/header.asm
@@ -16,7 +16,6 @@ SwitchToMapScriptsBank::
 
 SECTION "rst08 Bankswitch", ROM0[$0008]
 Bankswitch::
-	ldh [hROMBank], a
 	ld [rROMB], a
 	ret
 

--- a/home/joypad.asm
+++ b/home/joypad.asm
@@ -156,7 +156,7 @@ GetJoypad::
 ; A value of $ff will immediately end the stream.
 
 ; Read from the input stream.
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	ld a, [wAutoInputBank]
 	rst Bankswitch

--- a/home/map.asm
+++ b/home/map.asm
@@ -96,7 +96,7 @@ GetDestinationWarpNumber::
 	farcall CheckWarpCollision
 	ret nc
 
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 
 	call SwitchToMapScriptsBank
@@ -162,7 +162,7 @@ WarpCheck::
 	call GetDestinationWarpNumber
 	ret nc
 CopyWarpData::
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 
 	call SwitchToMapScriptsBank
@@ -790,7 +790,7 @@ CallScript::
 RunMapCallback::
 ; Will run the first callback found in the map header with execution index equal to a.
 	ld b, a
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	call SwitchToMapScriptsBank
 	call .FindCallback
@@ -855,7 +855,7 @@ ExecuteCallbackScript::
 	ret
 
 MapTextbox::
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 
 	ld a, b
@@ -879,7 +879,7 @@ MapTextbox::
 
 GetMovementData::
 ; Initialize the movement data for person c at b:hl
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	ld a, b
 	rst Bankswitch
@@ -897,7 +897,7 @@ GetScriptByte::
 
 	push hl
 	push bc
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld c, a
 	ldh a, [hScriptBank]
 	rst Bankswitch
@@ -926,7 +926,7 @@ GetScriptWord::
 ; Return word at hScriptBank:hScriptPos in hl.
 
 	push bc
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	ldh a, [hScriptBank]
 	rst Bankswitch
@@ -1454,7 +1454,7 @@ CheckFacingBGEvent::
 	ret z
 
 	ld c, a
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	call SwitchToMapScriptsBank
 	call CheckIfFacingTileCoordIsBGEvent
@@ -1520,7 +1520,7 @@ CheckCurrentMapCoordEvents::
 	ret z
 ; Copy the coord event count into c.
 	ld c, a
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	call SwitchToMapScriptsBank
 	call .CoordEventCheck
@@ -1618,7 +1618,7 @@ ReloadTilesetAndPalettes::
 	farcall RefreshSprites
 	call LoadStandardFont
 	call LoadFrame
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	call SwitchToMapAttributesBank
 	farcall UpdateTimeOfDayPal

--- a/home/map_objects.asm
+++ b/home/map_objects.asm
@@ -183,7 +183,7 @@ CopyPlayerObjectTemplate::
 LoadMovementDataPointer::
 ; Load the movement data pointer for person a.
 	ld [wMovementObject], a
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld [wMovementDataPointer], a
 	ld a, l
 	ld [wMovementDataPointer + 1], a
@@ -256,7 +256,7 @@ endr
 
 _GetMovementByte::
 ; Switch to the movement data bank
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	ld a, [hli]
 	rst Bankswitch

--- a/home/math.asm
+++ b/home/math.asm
@@ -36,7 +36,7 @@ MultiplyAndDivide::
 	push bc
 	ld b, a
 
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	ld a, BANK(Multiply)
 	rst Bankswitch

--- a/home/menu.asm
+++ b/home/menu.asm
@@ -214,7 +214,7 @@ CopyMenuHeader::
 	ld de, wMenuHeader
 	ld bc, wMenuHeaderEnd - wMenuHeader
 	rst CopyBytes
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld [wMenuDataBank], a
 	ret
 
@@ -697,7 +697,7 @@ PlayClickSFX::
 	ret
 
 _2DMenu::
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld [wMenuData_2DMenuItemStringsBank], a
 	farcall _2DMenu_
 	ld a, [wMenuCursorBuffer]

--- a/home/names.asm
+++ b/home/names.asm
@@ -152,7 +152,7 @@ GetName:
 	adc HIGH(.NamesPointers)
 	sub l
 	ld h, a
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	ld a, [hli]
 	ld b, a

--- a/home/palette_swap.asm
+++ b/home/palette_swap.asm
@@ -1,7 +1,7 @@
 InitializeSwappedPalette::
 	; wPaletteSwapAddress points to a `paletteswap` data struct inside
 	; the current map script, so we must be in the [wMapScriptsBank].
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	call SwitchToMapScriptsBank
 

--- a/home/print_text.asm
+++ b/home/print_text.asm
@@ -80,7 +80,7 @@ PrintNumFromReg::
 FarPrintText::
 	push de
 	ld d, a
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ld e, a
 	ld a, d
 	rst Bankswitch

--- a/home/queue_script.asm
+++ b/home/queue_script.asm
@@ -1,6 +1,6 @@
 QueueScript::
 ; Push pointer hl in the current bank to wQueuedScriptBank.
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 
 FarQueueScript::
 ; Push pointer a:hl to wQueuedScriptBank.

--- a/home/scrolling_menu.asm
+++ b/home/scrolling_menu.asm
@@ -1,6 +1,6 @@
 ScrollingMenu::
 	call CopyMenuData2
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 
 	ld a, BANK(_ScrollingMenu) ; aka BANK(_InitScrollingMenu)

--- a/home/stone_queue.asm
+++ b/home/stone_queue.asm
@@ -1,5 +1,5 @@
 HandleStoneTableAction::
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 
 	call SwitchToMapScriptsBank

--- a/home/string.asm
+++ b/home/string.asm
@@ -30,7 +30,7 @@ InitName::
 FarCopyRadioText::
 	inc hl ; skip '<FAR>'
 
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 
 	ld a, [hli]

--- a/home/text.asm
+++ b/home/text.asm
@@ -539,7 +539,7 @@ UnloadBlinkingCursor::
 
 FarString::
 	ld b, a
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	ld a, b
 	rst Bankswitch
@@ -629,7 +629,7 @@ TextCommand_FAR::
 	pop de
 
 .not_farjp
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 
 	ld a, [hli]

--- a/home/trainers.asm
+++ b/home/trainers.asm
@@ -1,6 +1,6 @@
 CheckTrainerBattle::
 ; Check if any trainer on the map sees the player and wants to battle.
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 
 	call SwitchToMapScriptsBank

--- a/home/vblank.asm
+++ b/home/vblank.asm
@@ -12,7 +12,7 @@ VBlank::
 	push bc
 	push af
 
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	ldh [hROMBankBackup], a
 
 	; Skip the .VBlanks table if [hVBlank] is just 7.
@@ -345,7 +345,7 @@ VBlank8:
 	; serial
 	; sound
 
-	ldh a, [hROMBank]
+	ld a, [CurROMBank] ; ??? seems redundant with caller
 	ldh [hROMBankBackup], a
 
 	call UpdateBGMap

--- a/home/window.asm
+++ b/home/window.asm
@@ -1,7 +1,7 @@
 Script_reanchormap::
 ReanchorMap::
 	call ClearWindowData
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	ld a, BANK(ReanchorBGMap_NoOAMUpdate) ; aka BANK(LoadFonts_NoOAMUpdate)
 	rst Bankswitch
@@ -61,7 +61,7 @@ OpenText::
 	ld hl, wWeatherFlags
 	set OW_WEATHER_DISABLED_F, [hl]
 	call ClearWindowData
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	ld a, BANK(ReanchorBGMap_NoOAMUpdate) ; aka BANK(LoadFonts_NoOAMUpdate)
 	rst Bankswitch

--- a/macros/rst.asm
+++ b/macros/rst.asm
@@ -19,7 +19,7 @@ MACRO? farjp ; bank, address
 ENDM
 
 MACRO? homecall ; bank, address
-	ldh a, [hROMBank]
+	ld a, [CurROMBank]
 	push af
 	if _NARG == 2
 		if STRFIND("\2", "[h") == 0 || STRFIND("\2", "[r") == 0

--- a/main.asm
+++ b/main.asm
@@ -1,3 +1,5 @@
+INCLUDE "engine/rom_bank_self_report.asm"
+
 SECTION "bank1", ROMX
 
 INCLUDE "engine/init.asm"

--- a/ram/hram.asm
+++ b/ram/hram.asm
@@ -2,7 +2,6 @@ SECTION "HRAM", HRAM
 
 hScriptVar:: dw
 
-hROMBank:: db
 hROMBankBackup:: db
 
 hScriptBank:: db

--- a/ram/wram0.asm
+++ b/ram/wram0.asm
@@ -265,7 +265,7 @@ SECTION UNION "Misc 404", WRAM0
 
 ; wLCDPokedex is defined in a LOAD UNION block in engine/pokedex/lcd.asm
 ; Reserve space for it at the beginning of this LOAD UNION
-	ds 15
+	ds 16
 	assert wLCDPokedexEnd - wLCDPokedex == @ - STARTOF("Misc 404")
 
 ; Battle data
@@ -885,7 +885,7 @@ wSummaryMoveSwap:: db
 
 ; Used to align window buffer for DMA copying
 ; Feel free to use or move data, an assert will fail if the memory becomes misaligned
-ds 9
+ds 8
 assert @ % 16 == 0
 
 wSummaryScreenWindowBuffer:: ds 32 * 10


### PR DESCRIPTION
The hope was that this would reduce the number of bankswitch instructions throughout the ROM, but it turns out that there are more *reads* (each one byte larger) than *writes* (two bytes shorter each).

Before:
```
ROM0: 16307 bytes used / 77 free
ROMX: 2049659 bytes used / 14725 free in 126 banks
```
After:
```
ROM0: 16352 bytes used / 32 free
ROMX: 2049791 bytes used / 14593 free in 126 banks
```

Thus, I'm expecting this PR to be rejected. Nonetheless, I want all the work and results to be available *somewhere*, so they can be referenced later should anyone else get a similar idea.