### PR TITLE
Fix shiny palettes for Pokédex list minis

### DIFF
--- a/engine/pokedex/pokedex.asm
+++ b/engine/pokedex/pokedex.asm
@@ -778,7 +778,7 @@ endc
 	and CAUGHT_MASK ; z = is not caught
 	push af
 	push hl
-	xor a
+	ld a, [wPokedex_Shiny]
 	farcall GetMonPalInBCDE
 	pop hl
 	pop af


### PR DESCRIPTION
The Pokédex list forced normal mini palettes by clearing `a` before calling `GetMonPalInBCDE`. Pass `wPokedex_Shiny` instead, matching the Bio tab and Rangi42's requested behavior. After toggling shiny mode in an entry and returning to the list, the minis now use shiny palettes alongside the frontpic. Seen-but-uncaught minis retain their existing transparency.

Validation:
- `make -j4` passed without warnings (RGBDS 1.0.0).
- Reviewed [Optimizing assembly code](https://github.com/pret/pokecrystal/wiki/Optimizing-assembly-code); repository-wide `python3 utils/optimize.py` reported zero instances.
- A temporary PyBoy harness executed the assembled list-palette code for 24 cases: Bulbasaur, Charizard, and Pikachu, normal/shiny, caught/seen-only, and the shared other-form flag clear/set. Palette bytes matched the source palettes and expected transparency. Restoring the original forced-normal instruction in emulator memory reproduced the shiny mismatch. This checks the palette routine, not a full interactive UI walkthrough.
- `git diff --check` passed. The fix adds two ROM bytes.

Fixes #1601.
