### PR TITLE
Prevent TM and HM reuse from restoring PP

### DIFF
--- a/engine/items/tmhm2.asm
+++ b/engine/items/tmhm2.asm
@@ -370,8 +370,6 @@ AskTeachTMHM:
 	ld a, [hl]
 	push af
 	res NO_TEXT_SCROLL, [hl]
-	ld hl, wForgettingMove
-	set LEARNING_TM_F, [hl]
 	ld a, [wCurTMHM]
 	ld [wTempTMHM], a
 	farcall GetTMHMMove
@@ -381,12 +379,9 @@ AskTeachTMHM:
 	call CopyName1
 	ld hl, Text_BootedTM ; Booted up a TM
 	ld a, [wCurTMHM]
-	cp HM01 + 1 ; off by one error?
+	cp HM01
 	jr c, .TM
 
-	; allow full PP restore for HMs
-	ld hl, wForgettingMove
-	res LEARNING_TM_F, [hl]
 	ld hl, Text_BootedHM ; Booted up an HM
 .TM:
 	call PrintText
@@ -399,8 +394,6 @@ AskTeachTMHM:
 	pop bc
 	ld a, b
 	ld [wOptions1], a
-	ld hl, wForgettingMove
-	res LEARNING_TM_F, [hl]
 	ret
 
 ChooseMonToLearnTMHM:
@@ -484,7 +477,17 @@ TeachTMHM:
 	call KnowsMove
 	jr c, .nope
 
+; Keep the TM flag set while learning, but allow full PP for HMs.
+	ld hl, wForgettingMove
+	set LEARNING_TM_F, [hl]
+	ld a, [wCurTMHM]
+	cp HM01
+	jr c, .learn
+	res LEARNING_TM_F, [hl]
+.learn
 	farcall LearnMove
+	ld hl, wForgettingMove
+	res LEARNING_TM_F, [hl]
 	ld a, b
 	and a
 	jr z, .nope

--- a/engine/items/tmhm2.asm
+++ b/engine/items/tmhm2.asm
@@ -379,7 +379,7 @@ AskTeachTMHM:
 	call CopyName1
 	ld hl, Text_BootedTM ; Booted up a TM
 	ld a, [wCurTMHM]
-	cp HM01
+	cp HM01 + 1
 	jr c, .TM
 
 	ld hl, Text_BootedHM ; Booted up an HM

--- a/engine/items/tmhm2.asm
+++ b/engine/items/tmhm2.asm
@@ -477,14 +477,9 @@ TeachTMHM:
 	call KnowsMove
 	jr c, .nope
 
-; Keep the TM flag set while learning, but allow full PP for HMs.
+; Keep the TM flag set while learning either a TM or HM.
 	ld hl, wForgettingMove
 	set LEARNING_TM_F, [hl]
-	ld a, [wCurTMHM]
-	cp HM01
-	jr c, .learn
-	res LEARNING_TM_F, [hl]
-.learn
 	farcall LearnMove
 	ld hl, wForgettingMove
 	res LEARNING_TM_F, [hl]

--- a/engine/pokemon/learn.asm
+++ b/engine/pokemon/learn.asm
@@ -92,6 +92,7 @@ LearnMove:
 	jr nz, .pp_ok
 ; Is the old move's current PP less than the new move's PP?
 	ld a, [hl]
+	and PP_MASK
 	cp b
 	jr nc, .pp_ok
 ; TMs won't give free PP

--- a/engine/pokemon/learn.asm
+++ b/engine/pokemon/learn.asm
@@ -95,7 +95,7 @@ LearnMove:
 	and PP_MASK
 	cp b
 	jr nc, .pp_ok
-; TMs won't give free PP
+; TMs and HMs won't give free PP
 	ld b, a
 .pp_ok
 	ld [hl], b


### PR DESCRIPTION
Fixes #1577.

Keep `LEARNING_TM` set around `LearnMove` for both TMs and HMs, then clear it on success or cancellation. Previously, `AskTeachTMHM` cleared it before move learning began, so replacing Hyper Beam at 4 PP with Curse restored Curse to 10 PP. The replacement now keeps 4 PP, capped at the new move's base PP.

Mask out PP Up bits before comparing the old PP. Following Rangi42's review, HMs use the same PP cap as TMs; field use does not depend on remaining PP. Empty move slots and moves learned outside TM/HM teaching, including level-up and evolution, still receive full PP. Also use the actual `HM01` boundary for the boot-up message.

Validation on the revised branch, including the latest `master` commits:
- Reviewed the [assembly optimization guide](https://github.com/pret/pokecrystal/wiki/Optimizing-assembly-code).
- `python3 utils/optimize.py`: zero instances.
- `make -B -j8` and `make -B -j8 faithful`.
- Temporary RGBDS/PyBoy harness executed the source's PP-selection block for 512 combinations of learning flags, current PP, PP Ups, and base PP; all passed. Six TM/HM flag-lifetime cases passed with `LearnMove` stubbed for success/cancellation, requiring the PP-limiting flag for both TMs and HMs and checking cleanup afterward.

Emulator validation covers the assembly blocks; a full interactive playthrough was not performed.
