### PR TITLE
Refresh PC preview after depositing or withdrawing a Pokémon

### DIFF
--- a/engine/pc/bills_pc_ui.asm
+++ b/engine/pc/bills_pc_ui.asm
@@ -860,7 +860,10 @@ MoveCurMonToBox:
 	push bc
 	call BillsPC_PerformQuickAnim
 	pop bc
-	; fallthrough
+	call CheckPartyShift
+	; Refresh the portrait and details for the slot left under the cursor.
+	jmp GetCursorMon
+
 CheckPartyShift:
 ; Shifts entries around to ensure there are no blank party entries.
 ; This is a purely graphical effect, internal PC functions has already


### PR DESCRIPTION
Depositing a Pokémon leaves its portrait and details displayed even after the party shifts a different Pokémon under the cursor. Refresh the cursor's Pokémon after the transfer animation and party shift, using the same pattern as releasing a Pokémon. The shared withdrawal path also clears the preview for the newly empty box slot; unsuccessful transfers still return before any refresh.

Fixes #1542.

Validation:
- Clean standard and Faithful ROM builds passed with RGBDS v1.0.0.
- Reviewed the [assembly optimization guide](https://github.com/pret/pokecrystal/wiki/Optimizing-assembly-code); `python3 utils/optimize.py` reports 0 instances.
- A temporary PyBoy harness passed 12 compiled control-flow cases covering first/middle/last party deposits, withdrawal, failed transfers, and reproduction of the old missing refresh. Storage and rendering operations were stubbed; final screen appearance was not manually tested.
- `git diff --check` passed.
