### PR TITLE
Fix weather and hidden object palette allocation

### DIFF
--- a/engine/events/weather.asm
+++ b/engine/events/weather.asm
@@ -43,6 +43,8 @@ SetCurrentWeather::
 .skip_cooldown
 	ld a, b
 	ld [wCurWeather], a
+	; Move any object out of the fixed weather slot before overwriting it.
+	farcall CheckForUsedObjPals
 	farcall LoadWeatherPal
 	call LoadWeatherGraphics
 	xor a

--- a/engine/gfx/dynamic_pals.asm
+++ b/engine/gfx/dynamic_pals.asm
@@ -89,6 +89,13 @@ CheckForUsedObjPals::
 	ld [wNeededMonPalLight], a
 
 	call CheckDualObjectPals
+	; Weather OAM uses a fixed slot, including particles still clearing after
+	; the weather stops. Do not let an object overwrite that palette.
+	call CheckWeatherPalInUse
+	jr z, .weather_pal_reserved
+	ld hl, wUsedObjectPals
+	set PAL_OW_WEATHER, [hl]
+.weather_pal_reserved
 
 	; Scan for active objects first and mark those pals still in use.
 	ld hl, wPalFlags
@@ -120,6 +127,14 @@ ScanObjectStructPals:
 	ld a, [hl]
 	and a
 	jmp z, .skip
+	; Retained off-screen objects and script-hidden sprites need no palette.
+	ld hl, OBJECT_FLAGS1
+	add hl, de
+	bit INVISIBLE_F, [hl]
+	jmp nz, .skip
+	inc hl ; OBJECT_FLAGS2
+	bit OFF_SCREEN_F, [hl]
+	jmp nz, .skip
 
 	ld a, [wPalFlags]
 	bit SCAN_OBJECTS_FIRST_F, a
@@ -283,6 +298,14 @@ MarkUsedPal:
 	ld a, d
 	cp [hl]
 	jr nz, .not_loaded_here
+	; A previously loaded object palette may still occupy the weather slot
+	; before LoadWeatherPal runs. It must be reassigned, not matched here.
+	ld a, c
+	cp PAL_OW_WEATHER
+	jr nz, .check_loaded_type
+	call CheckWeatherPalInUse
+	jr nz, .not_loaded_here
+.check_loaded_type
 	; Palette index matches - also check type
 	ld a, [wLoadedObjPalType]
 	ld e, c
@@ -426,6 +449,15 @@ MarkUsedPal:
 .done
 	pop bc
 	pop de
+	ret
+
+CheckWeatherPalInUse:
+; Return nz while weather can still render using PAL_OW_WEATHER.
+	ld a, [wCurWeather]
+	and a
+	ret nz
+	ld a, [wOverworldWeatherCooldown]
+	and a
 	ret
 
 CheckDualObjectPals:

--- a/engine/gfx/sprite_palettes.asm
+++ b/engine/gfx/sprite_palettes.asm
@@ -6,6 +6,9 @@ LoadWeatherPal::
 	assert OW_WEATHER_NONE == 0
 	and a
 	ret z
+	; Weather replaces any previous two-color Pokémon palette in this slot.
+	ld hl, wLoadedObjPalType
+	res PAL_OW_WEATHER, [hl]
 	dec a
 	call StackJumpTable
 
@@ -38,15 +41,15 @@ LoadWeatherPal::
 	jr CopySpritePalHandler
 
 .snow
+	; Snow uses an all-white palette, not an indexed object palette. Update
+	; its identity before switching from object WRAM to palette WRAM.
+	ld a, NO_PAL_LOADED
+	ld [wLoadedObjPal{d:PAL_OW_WEATHER}], a
 	ldh a, [rWBK]
 	push af
 	ld a, BANK(wOBPals1)
 	ldh [rWBK], a
-	; we are not loading an official palette,
-	; so this tells dynamic pals to not associate this
-	; palette with a sprite.
 	ld a, NO_PAL_LOADED
-	ld [wLoadedObjPal7], a
 	ld hl, wOBPals1 palette PAL_OW_WEATHER
 if !DEF(MONOCHROME)
 	assert LOW(NO_PAL_LOADED) == $ff

--- a/engine/overworld/map_objects.asm
+++ b/engine/overworld/map_objects.asm
@@ -29,8 +29,21 @@ DeleteMapObject::
 	farjp CheckForUsedObjPals
 
 HandleObjectStep:
+	ld hl, OBJECT_FLAGS2
+	add hl, bc
+	ld a, [hl]
+	push af
 	call _CheckObjectStillVisible
+	pop de ; d = previous OBJECT_FLAGS2; preserve the deletion carry flag
 	ret c
+	ld hl, OBJECT_FLAGS2
+	add hl, bc
+	ld a, [hl]
+	xor d
+	and OFF_SCREEN
+	jr z, .visibility_unchanged
+	farcall CheckForUsedObjPals
+.visibility_unchanged
 	call _HandleStepType
 
 	ld hl, OBJECT_FLAGS1

--- a/engine/overworld/movement.asm
+++ b/engine/overworld/movement.asm
@@ -282,6 +282,12 @@ ObjectFlags1Step:
 	add hl, bc
 	ldh [hBitwiseFunctionOpcode], a
 	call hBitwiseFunction
+	; Refresh palette ownership when show_object/hide_object changes visibility.
+	and ~%01000000 ; treat set and res identically
+	cp $86 + 8 * INVISIBLE_F
+	jr nz, .done
+	farcall CheckForUsedObjPals
+.done
 	jmp ContinueReadingMovement
 
 HideEmote:


### PR DESCRIPTION
Fixes #1621.

On Rugged Road North, a ledge shadow could take OBJ palette 6 while slot 7 was free. Sandstorm uses fixed OBJ 6 and overwrote the shadow's gray palette on the next frame, also briefly rendering sand with the shadow palette. Reserve the weather slot during active weather and particle cooldown, exclude it from object palette matches, and reassign any existing owner before starting weather.

Exclude off-screen and script-hidden objects from palette allocation, refreshing ownership when they leave or return to visibility. The supplied save retained an off-screen fruit tree because of `WONT_DELETE`; its palette is now available to visible objects. Verified that the map's alternate hikers are already excluded by time masks and only one spawns at each time of day.

Keep weather palette metadata consistent when replacing a Pokémon palette. Snow now records its unindexed palette in OBJ 6's metadata before switching WRAM banks, instead of writing OBJ 7's address in palette WRAM.

Validation:
- Reproduced the supplied debug save in vibeEmu before the fix; verified 31 shadow frames remain black while sandstorm retains its palette after the fix.
- Local symbol-driven vibeEmu harness: 36 allocation fixtures covering all weather types, cooldown, existing OBJ 6 matches, repeated scans, and reclaiming the slot after weather. Additional checks cover weather startup, snow metadata, off-screen/reappearing trees, hide/show movement commands, and all four hiker time masks.
- Built standard, faithful, and debug ROMs, plus standard and faithful Virtual Console variants.
- Reviewed the [assembly optimization guide](https://github.com/pret/pokecrystal/wiki/Optimizing-assembly-code). Ran `python3 utils/optimize.py`: 0 instances. `git diff --check` passes.
