### PR TITLE
Add configurable in-game clock speeds

### DIFF
--- a/constants/misc_constants.asm
+++ b/constants/misc_constants.asm
@@ -26,6 +26,9 @@ DEF EVE_HOUR  EQU 17 ; 5 PM - 9 PM (4 hours)
 DEF NITE_HOUR EQU 21 ; 9 PM - 5 AM (8 hours)
 DEF MAX_HOUR  EQU 24 ; 12 AM - 12 AM (24 hours)
 
+; FixDays wraps the RTC after 20 weeks, preserving the day of the week.
+DEF RTC_DAY_CYCLE EQU 20 * 7
+
 DEF NO_RTC_SPEEDUP EQU 6
 
 ; significant money values

--- a/constants/ram_constants.asm
+++ b/constants/ram_constants.asm
@@ -116,9 +116,9 @@ DEF LINK_OPTMASK EQU (1 << NATURES_OPT) | (1 << ABILITIES_OPT) | (1 << PERFECT_I
 ; wInitialOptions2::
 	const_def 2
 	const NO_EXP_OPT           ; 2
-	const RTC_OPT              ; 3
-	const EVOLVE_IN_BATTLE_OPT ; 4
-	const CLOCK_SPEED_OPT     ; 5; two bits
+	const CLOCK_OPT           ; 3; two bits
+	const_skip
+	const EVOLVE_IN_BATTLE_OPT ; 5
 	const_skip
 	const RESET_INIT_OPTS      ; 7
 
@@ -128,14 +128,12 @@ DEF LINK_OPTMASK EQU (1 << NATURES_OPT) | (1 << ABILITIES_OPT) | (1 << PERFECT_I
 	const EVS_OPT_MODERN   ; %10
 DEF EV_OPTMASK EQU %11
 
-; Keep the existing RTC flag and zero-valued ×6 speed compatible with old saves.
-DEF CLOCK_SPEED_MASK EQU %11 << CLOCK_SPEED_OPT
-DEF CLOCK_OPTMASK EQU (1 << RTC_OPT) | CLOCK_SPEED_MASK
-DEF CLOCK_RTC EQU 1 << RTC_OPT
-DEF CLOCK_6X EQU 0 << CLOCK_SPEED_OPT
-DEF CLOCK_12X EQU 1 << CLOCK_SPEED_OPT
-DEF CLOCK_24X EQU 2 << CLOCK_SPEED_OPT
-DEF NUM_CLOCK_OPTIONS EQU 4
+	const_def 0, 1 << CLOCK_OPT
+	const CLOCK_RTC  ; %00
+	const CLOCK_6X   ; %01
+	const CLOCK_12X  ; %10
+	const CLOCK_24X  ; %11
+DEF CLOCK_OPTMASK EQU %11 << CLOCK_OPT
 
 ; wOptionsMenuDescriptionState::
 	const_def

--- a/constants/ram_constants.asm
+++ b/constants/ram_constants.asm
@@ -118,7 +118,8 @@ DEF LINK_OPTMASK EQU (1 << NATURES_OPT) | (1 << ABILITIES_OPT) | (1 << PERFECT_I
 	const NO_EXP_OPT           ; 2
 	const RTC_OPT              ; 3
 	const EVOLVE_IN_BATTLE_OPT ; 4
-	const_skip 2
+	const CLOCK_SPEED_OPT     ; 5; two bits
+	const_skip
 	const RESET_INIT_OPTS      ; 7
 
 	const_def
@@ -126,6 +127,15 @@ DEF LINK_OPTMASK EQU (1 << NATURES_OPT) | (1 << ABILITIES_OPT) | (1 << PERFECT_I
 	const EVS_OPT_CLASSIC  ; %01
 	const EVS_OPT_MODERN   ; %10
 DEF EV_OPTMASK EQU %11
+
+; Keep the existing RTC flag and zero-valued ×6 speed compatible with old saves.
+DEF CLOCK_SPEED_MASK EQU %11 << CLOCK_SPEED_OPT
+DEF CLOCK_OPTMASK EQU (1 << RTC_OPT) | CLOCK_SPEED_MASK
+DEF CLOCK_RTC EQU 1 << RTC_OPT
+DEF CLOCK_6X EQU 0 << CLOCK_SPEED_OPT
+DEF CLOCK_12X EQU 1 << CLOCK_SPEED_OPT
+DEF CLOCK_24X EQU 2 << CLOCK_SPEED_OPT
+DEF NUM_CLOCK_OPTIONS EQU 4
 
 ; wOptionsMenuDescriptionState::
 	const_def

--- a/constants/ram_constants.asm
+++ b/constants/ram_constants.asm
@@ -116,8 +116,8 @@ DEF LINK_OPTMASK EQU (1 << NATURES_OPT) | (1 << ABILITIES_OPT) | (1 << PERFECT_I
 ; wInitialOptions2::
 	const_def 2
 	const NO_EXP_OPT           ; 2
-	const CLOCK_OPT           ; 3; two bits
-	const_skip
+	const CLOCK_OPT            ; 3 ; two bits
+	const_skip                 ; also used by CLOCK_OPT
 	const EVOLVE_IN_BATTLE_OPT ; 5
 	const_skip
 	const RESET_INIT_OPTS      ; 7
@@ -129,10 +129,10 @@ DEF LINK_OPTMASK EQU (1 << NATURES_OPT) | (1 << ABILITIES_OPT) | (1 << PERFECT_I
 DEF EV_OPTMASK EQU %11
 
 	const_def 0, 1 << CLOCK_OPT
-	const CLOCK_RTC  ; %00
-	const CLOCK_6X   ; %01
-	const CLOCK_12X  ; %10
-	const CLOCK_24X  ; %11
+	const CLOCK_RTC ; %000_00_000
+	const CLOCK_6X  ; %000_01_000
+	const CLOCK_12X ; %000_10_000
+	const CLOCK_24X ; %000_11_000
 DEF CLOCK_OPTMASK EQU %11 << CLOCK_OPT
 
 ; wOptionsMenuDescriptionState::

--- a/data/options/default_options.asm
+++ b/data/options/default_options.asm
@@ -18,4 +18,4 @@ endc
 ; wInitialOptions
 	db (1 << NATURES_OPT) | (1 << ABILITIES_OPT) | (1 << PSS_OPT) | (1 << COLOR_VARY_OPT)
 ; wInitialOptions2
-	db EVS_OPT_MODERN | (1 << RTC_OPT) | (1 << EVOLVE_IN_BATTLE_OPT)
+	db EVS_OPT_MODERN | CLOCK_RTC | (1 << EVOLVE_IN_BATTLE_OPT)

--- a/data/options/initial_option_names.asm
+++ b/data/options/initial_option_names.asm
@@ -26,7 +26,7 @@ InitialOptionNames:
 .Affection:
 	db "Affection bonus@"
 .RTC:
-	db "Real-time clock@"
+	db "In-game clock@"
 .PerfectStats:
 	db "Perfect stats@"
 .TradedMon:

--- a/data/options/initial_options_descriptions.asm
+++ b/data/options/initial_options_descriptions.asm
@@ -103,18 +103,21 @@ InitialOptionDescriptions:
 	prompt
 
 .RTC:
-	text "Use the Real-Time"
-	line "Clock function to"
-	cont "track the time."
+	text "RTC tracks real"
+	line "time, even while"
+	cont "the game is off."
 
-	para "If your cartridge"
-	line "or emulator does"
-	cont "not support RTC,"
+	para "×6, ×12, and ×24"
+	line "advance time only"
+	cont "while playing."
 
-	assert 24 % NO_RTC_SPEEDUP == 0
-	para "disable this to"
-	line "make each in-game"
-	cont STRFMT("day last %d hours.", 24 / NO_RTC_SPEEDUP) ; 24 / 6 == 4
+	para "Each in-game day"
+	line "lasts 4, 2, or 1"
+	cont "real-world hours."
+
+	para "Use these if your"
+	line "system does not"
+	cont "support RTC."
 	prompt
 
 .PerfectIVs:

--- a/engine/menus/initial_options_menu.asm
+++ b/engine/menus/initial_options_menu.asm
@@ -287,24 +287,60 @@ InitialOptions_AffectionBonus:
 	jmp OptionsShared_PlaceStringAtValueCoord
 
 InitialOptions_RTC:
-	ld hl, wInitialOptions2
+	ld a, [wInitialOptions2]
+	and CLOCK_OPTMASK
+	ld hl, .Values
+	ld c, 0
+.find_value
+	cp [hl]
+	jr z, .got_value
+	inc hl
+	inc c
+	bit 2, c
+	jr z, .find_value
+	ld c, 0 ; fall back to RTC for an invalid option value
+.got_value
 	ldh a, [hJoyPressed]
 	and PAD_LEFT | PAD_RIGHT
-	jr nz, .Toggle
-	bit RTC_OPT, [hl]
-	jr z, .SetNo
-	jr .SetYes
-.Toggle:
-	bit RTC_OPT, [hl]
-	jr z, .SetYes
-.SetNo:
-	res RTC_OPT, [hl]
-	ld de, NoString
+	jr z, .input_done
+	bit B_PAD_LEFT, a
+	jr nz, .left
+	inc c
+	jr .wrap
+.left
+	dec c
+.wrap
+	ld a, c
+	and NUM_CLOCK_OPTIONS - 1
+	ld c, a
+.input_done
+	ld b, 0
+	ld hl, .Values
+	add hl, bc
+	ld a, [wInitialOptions2]
+	and ~CLOCK_OPTMASK
+	or [hl]
+	ld [wInitialOptions2], a
+	ld hl, .Strings
+	add hl, bc
+	add hl, bc
+	ld a, [hli]
+	ld d, [hl]
+	ld e, a
 	jmp OptionsShared_PlaceStringAtValueCoord
-.SetYes:
-	set RTC_OPT, [hl]
-	ld de, YesString
-	jmp OptionsShared_PlaceStringAtValueCoord
+
+.Values:
+	db CLOCK_RTC, CLOCK_6X, CLOCK_12X, CLOCK_24X
+.Strings:
+	dw .RTC, .Six, .Twelve, .TwentyFour
+.RTC:
+	db "RTC@"
+.Six:
+	db "×6 @"
+.Twelve:
+	db "×12@"
+.TwentyFour:
+	db "×24@"
 
 InitialOptions_PerfectIVs:
 	ld hl, wInitialOptions

--- a/engine/menus/initial_options_menu.asm
+++ b/engine/menus/initial_options_menu.asm
@@ -305,20 +305,24 @@ InitialOptions_RTC:
 .input_done
 	ld a, [hl]
 	and CLOCK_OPTMASK
-	assert CLOCK_OPT == 3
+rept CLOCK_OPT - 1 ; shift the clock field down to a two-byte pointer offset
 	rrca
-	rrca ; shift the clock field down to a two-byte pointer offset
-	ld c, a
-	ld b, 0
-	ld hl, .Strings
-	add hl, bc
+endr
+	add LOW(.Strings)
+	ld l, a
+	adc HIGH(.Strings)
+	sub l
+	ld h, a
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
 	jmp OptionsShared_PlaceStringAtValueCoord
 
 .Strings:
-	dw .RTC, .Six, .Twelve, .TwentyFour
+	dw .RTC        ; CLOCK_RTC
+	dw .Six        ; CLOCK_6X
+	dw .Twelve     ; CLOCK_12X
+	dw .TwentyFour ; CLOCK_24X
 .RTC:
 	db "RTC@"
 .Six:

--- a/engine/menus/initial_options_menu.asm
+++ b/engine/menus/initial_options_menu.asm
@@ -287,50 +287,36 @@ InitialOptions_AffectionBonus:
 	jmp OptionsShared_PlaceStringAtValueCoord
 
 InitialOptions_RTC:
-	ld a, [wInitialOptions2]
-	and CLOCK_OPTMASK
-	ld hl, .Values
-	ld c, 0
-.find_value
-	cp [hl]
-	jr z, .got_value
-	inc hl
-	inc c
-	bit 2, c
-	jr z, .find_value
-	ld c, 0 ; fall back to RTC for an invalid option value
-.got_value
+	ld hl, wInitialOptions2
 	ldh a, [hJoyPressed]
 	and PAD_LEFT | PAD_RIGHT
 	jr z, .input_done
+	ld c, 1 << CLOCK_OPT
 	bit B_PAD_LEFT, a
-	jr nz, .left
-	inc c
-	jr .wrap
-.left
-	dec c
-.wrap
-	ld a, c
-	and NUM_CLOCK_OPTIONS - 1
-	ld c, a
+	jr z, .change
+	ld c, -(1 << CLOCK_OPT)
+.change
+	ld a, [hl]
+	add c
+	xor [hl]
+	and CLOCK_OPTMASK
+	xor [hl]
+	ld [hl], a
 .input_done
+	ld a, [hl]
+	and CLOCK_OPTMASK
+	assert CLOCK_OPT == 3
+	rrca
+	rrca ; shift the clock field down to a two-byte pointer offset
+	ld c, a
 	ld b, 0
-	ld hl, .Values
-	add hl, bc
-	ld a, [wInitialOptions2]
-	and ~CLOCK_OPTMASK
-	or [hl]
-	ld [wInitialOptions2], a
 	ld hl, .Strings
-	add hl, bc
 	add hl, bc
 	ld a, [hli]
 	ld d, [hl]
 	ld e, a
 	jmp OptionsShared_PlaceStringAtValueCoord
 
-.Values:
-	db CLOCK_RTC, CLOCK_6X, CLOCK_12X, CLOCK_24X
 .Strings:
 	dw .RTC, .Six, .Twelve, .TwentyFour
 .RTC:

--- a/engine/menus/main_menu.asm
+++ b/engine/menus/main_menu.asm
@@ -163,8 +163,8 @@ MainMenu_PrintCurrentTimeAndDay:
 ;; to get the main menu to show the correct time of the save,
 ;; we need to pull the backed-up RTC time from the save file
 	ld a, [wInitialOptions2]
-	and 1 << RTC_OPT
-	jr nz, .using_rtc
+	and CLOCK_OPTMASK
+	jr z, .using_rtc
 	ld a, BANK(sPlayerData)
 	call GetSRAMBank
 	ld hl, sPlayerData + wRTCDayHi - wPlayerData

--- a/engine/overworld/time.asm
+++ b/engine/overworld/time.asm
@@ -287,8 +287,8 @@ GetTimerTime:
 ; Phone and contest timers use real time, regardless of the clock speed.
 ; Return b:c:d:e = day:hour:minute:second, preserving hl.
 	ld a, [wInitialOptions2]
-	and 1 << RTC_OPT
-	jr z, .play_time
+	and CLOCK_OPTMASK
+	jr nz, .play_time
 	ld a, [wCurDay]
 	ld b, a
 	ldh a, [hHours]
@@ -347,9 +347,10 @@ _CalcMinsHoursDaysSince:
 	jr nc, .skip_hours
 	ld e, a
 	ld a, [wInitialOptions2]
-	bit RTC_OPT, a
+	and CLOCK_OPTMASK
+	scf ; restore the hour borrow cleared by and
 	ld a, e
-	jr z, .skip_hours ; hour byte wrapped at 256; carry still records the borrow
+	jr nz, .skip_hours ; hour byte already wrapped at 256
 	add 24
 .skip_hours
 	ld [wHoursSince], a

--- a/engine/overworld/time.asm
+++ b/engine/overworld/time.asm
@@ -18,30 +18,23 @@ NextCallReceiveDelay:
 .okay
 	ld e, a
 	ld d, 0
-	ld a, [wInitialOptions2]
-	and 1 << RTC_OPT
 	ld hl, .ReceiveCallDelays
-	jr nz, .using_rtc
-	ld hl, .ReceiveCallDelaysNoRTC
-.using_rtc
 	add hl, de
 	ld a, [hl]
 	ld hl, wReceiveCallDelay_MinsRemaining
 	ld [hl], a
 	call UpdateTime
+	call GetTimerTime
 	ld hl, wReceiveCallDelay_StartTime
-	ld a, [wCurDay]
+	ld a, b
 	ld [hli], a
-	ldh a, [hHours]
+	ld a, c
 	ld [hli], a
-	ldh a, [hMinutes]
-	ld [hli], a
+	ld [hl], d
 	ret
 
 .ReceiveCallDelays:
 	db 20, 10, 5, 3
-.ReceiveCallDelaysNoRTC:
-	db 20 * NO_RTC_SPEEDUP, 10 * NO_RTC_SPEEDUP, 5 * NO_RTC_SPEEDUP, 3 * NO_RTC_SPEEDUP
 
 CheckReceiveCallTimer:
 	call CheckReceiveCallDelay ; check timer
@@ -180,25 +173,20 @@ Special_SampleKenjiBreakCountdown:
 	ret
 
 StartBugContestTimer:
-	ld a, [wInitialOptions2]
-	and 1 << RTC_OPT
 	ld a, BUG_CONTEST_MINUTES
-	jr nz, .using_rtc
-	ld a, BUG_CONTEST_MINUTES * NO_RTC_SPEEDUP
-.using_rtc
 	ld [wBugContestMinsRemaining], a
 	xor a ; BUG_CONTEST_SECONDS
 	ld [wBugContestSecsRemaining], a
 	call UpdateTime
+	call GetTimerTime
 	ld hl, wBugContestStartTime
-	ld a, [wCurDay]
+	ld a, b
 	ld [hli], a
-	ldh a, [hHours]
+	ld a, c
 	ld [hli], a
-	ldh a, [hMinutes]
+	ld a, d
 	ld [hli], a
-	ldh a, [hSeconds]
-	ld [hli], a
+	ld [hl], e
 	ret
 
 CheckBugContestTimer::
@@ -295,49 +283,87 @@ CalcDaysSince:
 	xor a
 	jr _CalcDaysSince
 
+GetTimerTime:
+; Phone and contest timers use real time, regardless of the clock speed.
+; Return b:c:d:e = day:hour:minute:second, preserving hl.
+	ld a, [wInitialOptions2]
+	and 1 << RTC_OPT
+	jr z, .play_time
+	ld a, [wCurDay]
+	ld b, a
+	ldh a, [hHours]
+	ld c, a
+	ldh a, [hMinutes]
+	ld d, a
+	ldh a, [hSeconds]
+	ld e, a
+	ret
+.play_time
+; Treat the high hour byte as a "day" of 256 hours, avoiding division.
+	ld a, [wGameTimeHours]
+	ld b, a
+	ld a, [wGameTimeHours + 1]
+	ld c, a
+	ld a, [wGameTimeMinutes]
+	ld d, a
+	ld a, [wGameTimeSeconds]
+	ld e, a
+	ret
+
 CalcMinsHoursDaysSince:
+	call GetTimerTime
 	inc hl
 	inc hl
 	xor a
 	jr _CalcMinsHoursDaysSince
 
 CalcSecsMinsHoursDaysSince:
+	call GetTimerTime
 	inc hl
 	inc hl
 	inc hl
-	ldh a, [hSeconds]
-	ld c, a
+	ld a, e
 	sub [hl]
 	jr nc, .skip_seconds
 	add 60
 .skip_seconds
-	ld [hl], c ; current seconds
-	dec hl ; no-optimize *hl++|*hl-- = b|c|d|e
-	ld [wSecondsSince], a ; seconds since
+	ld [wSecondsSince], a
+	ld a, e
+	ld [hld], a
 	; fallthrough
 
 _CalcMinsHoursDaysSince:
-	ldh a, [hMinutes]
-	ld c, a
+	ld a, d
 	sbc [hl]
 	jr nc, .skip_minutes
 	add 60
 .skip_minutes
-	ld [hl], c ; current minutes
-	dec hl ; no-optimize *hl++|*hl-- = b|c|d|e
-	ld [wMinutesSince], a ; minutes since
+	ld [wMinutesSince], a
+	ld a, d
+	ld [hld], a
 
-; calc hours+days since
-	ldh a, [hHours]
-	ld c, a
+	ld a, c
 	sbc [hl]
 	jr nc, .skip_hours
+	ld e, a
+	ld a, [wInitialOptions2]
+	bit RTC_OPT, a
+	ld a, e
+	jr z, .skip_hours ; hour byte wrapped at 256; carry still records the borrow
 	add 24
 .skip_hours
-	ld [hl], c ; current hours
-	dec hl ; no-optimize *hl++|*hl-- = b|c|d|e
-	ld [wHoursSince], a ; hours since
-	; fallthrough
+	ld [wHoursSince], a
+	ld a, c
+	ld [hld], a
+
+	ld a, b
+	sbc [hl]
+	jr nc, .skip_days
+	add 20 * 7
+.skip_days
+	ld [hl], b
+	ld [wDaysSince], a
+	ret
 
 _CalcDaysSince:
 	ld a, [wCurDay]

--- a/engine/overworld/time.asm
+++ b/engine/overworld/time.asm
@@ -16,10 +16,11 @@ NextCallReceiveDelay:
 	ld a, 3
 
 .okay
-	ld e, a
-	ld d, 0
-	ld hl, .ReceiveCallDelays
-	add hl, de
+	add LOW(.ReceiveCallDelays)
+	ld l, a
+	adc HIGH(.ReceiveCallDelays)
+	sub l
+	ld h, a
 	ld a, [hl]
 	ld hl, wReceiveCallDelay_MinsRemaining
 	ld [hl], a
@@ -213,8 +214,10 @@ CheckBugContestTimer::
 	sbc b
 	ld [wBugContestMinsRemaining], a
 	jr c, .timed_out
-	and a
-	ret
+	ld b, a
+	ld a, [wBugContestSecsRemaining]
+	or b
+	ret nz
 
 .timed_out
 	xor a
@@ -360,7 +363,7 @@ _CalcMinsHoursDaysSince:
 	ld a, b
 	sbc [hl]
 	jr nc, .skip_days
-	add 20 * 7
+	add RTC_DAY_CYCLE
 .skip_days
 	ld [hl], b
 	ld [wDaysSince], a
@@ -371,7 +374,7 @@ _CalcDaysSince:
 	ld c, a
 	sbc [hl]
 	jr nc, .skip_days
-	add 20 * 7
+	add RTC_DAY_CYCLE
 .skip_days
 	ld [hl], c ; current days
 	ld [wDaysSince], a ; days since

--- a/engine/rtc/rtc.asm
+++ b/engine/rtc/rtc.asm
@@ -29,8 +29,8 @@ SaveRTC:
 
 ; do not talk to the RTC hardware in the no-RTC patch
 	ld a, [wInitialOptions2]
-	and 1 << RTC_OPT
-	jr z, .no_rtc
+	and CLOCK_OPTMASK
+	jr nz, .no_rtc
 	; pulse the RTC to get its value
 	call LatchClock
 	; set the MBC3 register to the RTC day high byte & status flags
@@ -60,8 +60,8 @@ StartClock::
 	; bit 6: Day count exceeds 255
 	call c, RecordRTCStatus
 	ld a, [wInitialOptions2]
-	and 1 << RTC_OPT
-	ret z
+	and CLOCK_OPTMASK
+	ret nz
 
 	; start the RTC hardware running
 	; it will continue to count time passing while the GameBoy is off

--- a/engine/rtc/rtc.asm
+++ b/engine/rtc/rtc.asm
@@ -162,7 +162,7 @@ _InitTime::
 	sbc [hl]
 	dec hl
 	jr nc, .ok_days
-	add 140
+	add RTC_DAY_CYCLE
 	ld c, 7
 	call SimpleDivide
 .ok_days

--- a/home/game_time.asm
+++ b/home/game_time.asm
@@ -1,7 +1,7 @@
 ; reset the number of hours the game has been played
 ; (not to be confused with the real-time clock, which either continues to
 ; increment when the GameBoy is switched off, or in the no-RTC patch, runs
-; at 6x speed while the game time remains real-time)
+; at the selected speed while the game time remains real-time)
 ResetGameTime::
 	xor a
 	ld [wGameTimeCap], a
@@ -59,15 +59,22 @@ UpdateGameTimer::
 	ld [hl], a
 
 ; kroc - no-RTC patch
-; the game timer has increased by 1 second; increase the "fake" RTC by 6 seconds
-; (24 in-game hours will pass in 4 real-world hours)
+; Increase the "fake" RTC by 6, 12, or 24 seconds per second played.
 ; this does not affect the rate of the "hours played", which remains real-time
 	ld a, [wInitialOptions2]
-	and 1 << RTC_OPT
+	bit RTC_OPT, a
 	jr nz, .using_rtc
-rept NO_RTC_SPEEDUP
-	call UpdateNoRTC
-endr
+	ld c, NO_RTC_SPEEDUP
+	and CLOCK_SPEED_MASK
+	jr z, .no_rtc_loop
+	ld c, NO_RTC_SPEEDUP * 2
+	bit CLOCK_SPEED_OPT + 1, a
+	jr z, .no_rtc_loop
+	ld c, NO_RTC_SPEEDUP * 4
+.no_rtc_loop
+	call UpdateNoRTC ; preserves c
+	dec c
+	jr nz, .no_rtc_loop
 .using_rtc
 
 ; +1 second

--- a/home/game_time.asm
+++ b/home/game_time.asm
@@ -62,13 +62,13 @@ UpdateGameTimer::
 ; Increase the "fake" RTC by 6, 12, or 24 seconds per second played.
 ; this does not affect the rate of the "hours played", which remains real-time
 	ld a, [wInitialOptions2]
-	bit RTC_OPT, a
-	jr nz, .using_rtc
+	and CLOCK_OPTMASK
+	jr z, .using_rtc
 	ld c, NO_RTC_SPEEDUP
-	and CLOCK_SPEED_MASK
+	cp CLOCK_6X
 	jr z, .no_rtc_loop
 	ld c, NO_RTC_SPEEDUP * 2
-	bit CLOCK_SPEED_OPT + 1, a
+	cp CLOCK_12X
 	jr z, .no_rtc_loop
 	ld c, NO_RTC_SPEEDUP * 4
 .no_rtc_loop

--- a/home/time.asm
+++ b/home/time.asm
@@ -79,12 +79,12 @@ FixDays::
 	inc hl
 	ld a, [hl] ; wRTCDayLo
 .modh
-	sub 140
+	sub RTC_DAY_CYCLE
 	jr nc, .modh
 .modl
-	sub 140
+	sub RTC_DAY_CYCLE
 	jr nc, .modl
-	add 140
+	add RTC_DAY_CYCLE
 
 ; update dl
 	ld [hl], a ; wRTCDayLo
@@ -97,14 +97,14 @@ FixDays::
 	inc hl
 ; quit if fewer than 140 days have passed
 	ld a, [hl] ; wRTCDayLo
-	cp 140
+	cp RTC_DAY_CYCLE
 	jr c, .quit
 
 ; mod 140
 .mod
-	sub 140
+	sub RTC_DAY_CYCLE
 	jr nc, .mod
-	add 140
+	add RTC_DAY_CYCLE
 
 ; update dl
 	ld [hl], a ; wRTCDayLo

--- a/home/time.asm
+++ b/home/time.asm
@@ -20,8 +20,8 @@ GetClock::
 ; store clock data in wRTCDayHi-wRTCSeconds
 
 	ld a, [wInitialOptions2]
-	and 1 << RTC_OPT
-	ret z
+	and CLOCK_OPTMASK
+	ret nz
 
 ; enable clock r/w
 	ld a, RAMG_SRAM_ENABLE
@@ -201,8 +201,8 @@ SetClock::
 
 ; do not talk to the RTC hardware in the no-RTC patch
 	ld a, [wInitialOptions2]
-	and 1 << RTC_OPT
-	ret z
+	and CLOCK_OPTMASK
+	ret nz
 
 ; enable clock r/w
 	ld a, RAMG_SRAM_ENABLE

--- a/ram/wram0.asm
+++ b/ram/wram0.asm
@@ -1462,7 +1462,7 @@ wInitialOptions2::
 ; bit 2: no exp on/off (cannot be set together with scaled exp)
 ; bit 3: use RTC
 ; bit 4: evolve in battle
-; bits 5-6: unused
+; bits 5-6: non-RTC speed (%00: ×6, %01: ×12, %10: ×24)
 ; bit 7: ask to reset at start
 	db
 wOptionsEnd::

--- a/ram/wram0.asm
+++ b/ram/wram0.asm
@@ -1460,9 +1460,9 @@ wInitialOptions2::
 ; - %01: classic EVs (no 510 cap)
 ; - %10: modern EVs (510 cap)
 ; bit 2: no exp on/off (cannot be set together with scaled exp)
-; bit 3: use RTC
-; bit 4: evolve in battle
-; bits 5-6: non-RTC speed (%00: ×6, %01: ×12, %10: ×24)
+; bits 3-4: in-game clock (%00: RTC, %01: ×6, %10: ×12, %11: ×24)
+; bit 5: evolve in battle
+; bit 6: unused
 ; bit 7: ask to reset at start
 	db
 wOptionsEnd::

--- a/ram/wramx.asm
+++ b/ram/wramx.asm
@@ -984,7 +984,7 @@ wMapReentryScriptAddress:: dw ; MemScriptAddr
 
 wTimeCyclesSinceLastCall:: db
 wReceiveCallDelay_MinsRemaining:: db
-wReceiveCallDelay_StartTime:: ds 3
+wReceiveCallDelay_StartTime:: ds 3 ; RTC day/hour/minute, or play time hours (big-endian)/minute
 
 wBugContestMinsRemaining:: db
 wBugContestSecsRemaining:: db
@@ -1427,7 +1427,7 @@ wCurHiddenGrotto:: db
 
 wLuckyNumberDayBuffer:: dw
 wSpecialPhoneCallID:: db
-wBugContestStartTime:: ds 4 ; day, hour, min, sec
+wBugContestStartTime:: ds 4 ; RTC day/hour/minute/second, or play time hours (big-endian)/minute/second
 
 wLastPocket:: db
 


### PR DESCRIPTION
Replace “Real-time clock: Yes/No” with “In-game clock: RTC/×6/×12/×24”, following Rangi42’s direction in #1206. The accelerated choices give an in-game day in 4, 2, or 1 hours of play; the play-time counter stays at normal speed.

Encode the four clock choices in bits 3–4 of `wInitialOptions2` (`00` RTC, `01` ×6, `10` ×12, `11` ×24), with evolve-in-battle moved to bit 5. The menu cycles the field directly, and hardware clock access checks the full field. This changes the previous save-option encoding.

Phone and Bug-Catching Contest timers use unaccelerated play time when RTC is disabled, preserving their durations without overflowing their byte-sized minute counters at ×24. The contest now signals timeout at exactly 0:00. `RTC_DAY_CYCLE` names the existing 140-day (20-week) wrap used by clock and elapsed-time routines.

Validation uses the local vibeEmu core to execute assembled ROM routines with injected state and timestamps; it does not automate playing the game. Standard and Faithful builds pass with RGBDS warnings enabled.

| System | Checked on both builds |
| --- | --- |
| Clock rates | Full in-game days take 4/2/1 hours of play at ×6/×12/×24; play time advances normally; paused game logic does not advance the clock. |
| Menu | 768 input/redraw cases verify wrapping, displayed tile characters, and unrelated option bits. |
| Save/reload | All four choices survive the actual option-save and load routines. |
| RTC access | Non-RTC modes preserve hardware time; RTC mode reads/writes it. |
| Phone | All four modes: 20/10/5/3-minute countdowns, clamped delay index, and Lightning Rod doubling (40 scenarios, checked minute by minute). |
| Contest | All four modes: active with 0:01 left at 19:59; timeout carry set at exactly 20:00, across RTC day and play-time hour-byte rollover. |
| Elapsed time | 2,997 second-borrow and 2,997 minute-borrow hour rollovers, plus RTC midnight/day wrap. |
| Daily clock | `FixDays` wraps day 140 to 0; elapsed time from day 139 to 0 is one day. |

Reviewed the [assembly optimization guide](https://github.com/pret/pokecrystal/wiki/Optimizing-assembly-code), including the requested pointer-lookup pattern. `python3 utils/optimize.py` reports zero findings; `git diff --check` passes.

Fixes #1206.
