### PR TITLE
Show TM/HM move properties with Select in the Bag

### DIFF
--- a/engine/items/tmhm2.asm
+++ b/engine/items/tmhm2.asm
@@ -1,4 +1,7 @@
 TMHMPocket:
+	; Start with descriptions whenever entering the pocket.
+	xor a
+	ld [wTMHMShowMoveInfo], a
 	ld a, TRUE
 	ldh [hInMenu], a
 	call TMHM_PocketLoop
@@ -35,7 +38,7 @@ TMHM_PocketLoop:
 	ld [w2DMenuFlags2], a
 	ld a, $20
 	ld [w2DMenuCursorOffsets], a
-	ld a, PAD_A | PAD_B | PAD_START | PAD_CTRL_PAD
+	ld a, PAD_A | PAD_B | PAD_SELECT | PAD_START | PAD_CTRL_PAD
 	ld [wMenuJoypadFilter], a
 	ld a, [wTMHMPocketCursor]
 	and $7f
@@ -71,9 +74,14 @@ TMHM_JoypadLoop:
 	bit B_PAD_A, a
 	jr nz, TMHM_ChooseTMorHM
 	bit B_PAD_B, a
-	jr nz, TMHM_ExitPack
+	jmp nz, TMHM_ExitPack
 	and PAD_RIGHT | PAD_LEFT
 	ret nz
+	bit B_PAD_SELECT, b
+	jr z, TMHM_ShowTMMoveDescription
+	ld a, [wTMHMShowMoveInfo]
+	xor 1
+	ld [wTMHMShowMoveInfo], a
 TMHM_ShowTMMoveDescription:
 	call TMHM_GetCurrentTMHM
 	hlcoord 0, 12
@@ -88,14 +96,21 @@ TMHM_ShowTMMoveDescription:
 	call SetDefaultBGPAndOBP
 	ld a, [wTempTMHM]
 	ld [wCurMove], a
+	ld a, [wTMHMShowMoveInfo]
+	and a
+	jr nz, .MoveInfo
 	hlcoord 1, 14
 	call PrintMoveDesc
+	jr .Icon
+.MoveInfo:
+	call TMHM_PrintMoveInfo
+.Icon:
 	farcall LoadTMHMIcon
-	jr TMHM_JoypadLoop
+	jmp TMHM_JoypadLoop
 
 .Cancel:
 	farcall ClearTMHMIcon
-	jr TMHM_JoypadLoop
+	jmp TMHM_JoypadLoop
 
 TMHM_SortMenu:
 	or 1
@@ -337,6 +352,68 @@ InnerCheckTMHM:
 	pop bc
 	and a
 	ret
+
+TMHM_PrintMoveInfo:
+	ld hl, Moves + MOVE_TYPE
+	call GetCurMoveProperty
+	ld [wNamedObjectIndex], a
+	farcall GetTypeName
+	hlcoord 1, 14
+	ld de, wStringBuffer1
+	rst PlaceString
+	call GetCurMoveFixedCategory
+	ld hl, .Categories
+	ld bc, 9
+	rst AddNTimes
+	ld d, h
+	ld e, l
+	hlcoord 10, 14
+	rst PlaceString
+	hlcoord 1, 16
+	ld de, .PowAccPP
+	rst PlaceString
+	ld hl, Moves + MOVE_POWER
+	call GetCurMoveProperty
+	hlcoord 1, 16
+	cp 2
+	jr nc, .Power
+	ld de, .NA
+	rst PlaceString
+	jr .Accuracy
+.Power:
+	call .PrintStat
+.Accuracy:
+	ld hl, Moves + MOVE_ACC
+	call GetCurMoveProperty
+	hlcoord 6, 16
+	cp -1
+	jr nz, .PrintAccuracy
+	ld de, .NA
+	rst PlaceString
+	jr .PP
+.PrintAccuracy:
+	call .PrintStat
+.PP:
+	ld hl, Moves + MOVE_PP
+	call GetCurMoveProperty
+	hlcoord 13, 16
+.PrintStat:
+	ld [wTextDecimalByte], a
+	ld de, wTextDecimalByte
+	lb bc, 1, 3
+	jmp PrintNum
+
+.Categories:
+	assert PHYSICAL == 0 && SPECIAL == 1 && STATUS == 2
+	table_width 9
+	db "Physical@"
+	db "Special@@"
+	db "Status@@@"
+	assert_table_length NUM_CATEGORIES
+.PowAccPP:
+	db "   <BOLDP>/   % PP   @"
+.NA:
+	db "---@"
 
 PrintMoveDesc:
 	push hl

--- a/engine/items/tmhm2.asm
+++ b/engine/items/tmhm2.asm
@@ -5,6 +5,9 @@ TMHMPocket:
 	ld a, TRUE
 	ldh [hInMenu], a
 	call TMHM_PocketLoop
+	push af
+	call TMHM_ClearMoveIcons
+	pop af
 	ld a, FALSE ; no-optimize a = 0
 	ldh [hInMenu], a
 	ret nc
@@ -83,6 +86,7 @@ TMHM_JoypadLoop:
 	xor 1
 	ld [wTMHMShowMoveInfo], a
 TMHM_ShowTMMoveDescription:
+	call TMHM_ClearMoveIcons
 	call TMHM_GetCurrentTMHM
 	hlcoord 0, 12
 	lb bc, 4, SCREEN_WIDTH - 2
@@ -353,22 +357,71 @@ InnerCheckTMHM:
 	and a
 	ret
 
+TMHM_ClearMoveIcons:
+	call ClearSprites
+	; fallthrough
+TMHM_UpdateMoveIcons:
+	; Transfer sprites during VBlank even while the menu suppresses OAM.
+	ldh a, [hOAMUpdate]
+	push af
+	xor a
+	ldh [hOAMUpdate], a
+	call DelayFrame
+	pop af
+	ldh [hOAMUpdate], a
+	ret
+
 TMHM_PrintMoveInfo:
-	ld hl, Moves + MOVE_TYPE
-	call GetCurMoveProperty
-	ld [wNamedObjectIndex], a
-	farcall GetTypeName
-	hlcoord 1, 14
-	ld de, wStringBuffer1
-	rst PlaceString
+	; The Bag uses all eight BG palettes. Use OBJ palette 0 for the
+	; battle icons so the pocket tabs, text, and TM disc keep their colors.
 	call GetCurMoveFixedCategory
-	ld hl, .Categories
-	ld bc, 9
+	push af
+	ld hl, CategoryIconGFX
+	ld bc, 2 tiles
 	rst AddNTimes
 	ld d, h
 	ld e, l
-	hlcoord 10, 14
-	rst PlaceString
+	ld hl, vTiles0
+	lb bc, BANK(CategoryIconGFX), 2
+	call Request2bpp
+	ld hl, Moves + MOVE_TYPE
+	call GetCurMoveProperty
+	pop bc
+	ld c, a
+	push af
+	ld de, wOBPals1 palette 0 + 2
+	farcall LoadCategoryAndTypePals
+	call SetDefaultBGPAndOBP
+	pop af
+	ld hl, TypeIconGFX
+	ld bc, 4 * TILE_1BPP_SIZE
+	rst AddNTimes
+	ld d, h
+	ld e, l
+	ld hl, vTiles0 tile 2
+	lb bc, BANK(TypeIconGFX), 4
+	call Request1bpp
+
+	; Six 8x8 sprites at textbox coordinates (1, 14) through (6, 14).
+	ld hl, wShadowOAM
+	lb bc, 6, 0
+	ld d, 1 * TILE_WIDTH + 8
+.Icons:
+	ld a, 14 * TILE_WIDTH + 16
+	ld [hli], a
+	ld a, d
+	ld [hli], a
+	ld a, c
+	ld [hli], a
+	xor a ; OBJ palette 0
+	ld [hli], a
+	inc c
+	ld a, TILE_WIDTH
+	add d
+	ld d, a
+	dec b
+	jr nz, .Icons
+	call TMHM_UpdateMoveIcons
 	hlcoord 1, 16
 	ld de, .PowAccPP
 	rst PlaceString
@@ -403,13 +456,6 @@ TMHM_PrintMoveInfo:
 	lb bc, 1, 3
 	jmp PrintNum
 
-.Categories:
-	assert PHYSICAL == 0 && SPECIAL == 1 && STATUS == 2
-	table_width 9
-	db "Physical@"
-	db "Special@@"
-	db "Status@@@"
-	assert_table_length NUM_CATEGORIES
 .PowAccPP:
 	db "   <BOLDP>/   % PP   @"
 .NA:

--- a/engine/items/tmhm2.asm
+++ b/engine/items/tmhm2.asm
@@ -110,7 +110,7 @@ TMHM_ShowTMMoveDescription:
 	call TMHM_PrintMoveInfo
 .Icon:
 	farcall LoadTMHMIcon
-	jmp TMHM_JoypadLoop
+	jr TMHM_JoypadLoop
 
 .Cancel:
 	farcall ClearTMHMIcon

--- a/ram/wram0.asm
+++ b/ram/wram0.asm
@@ -1166,6 +1166,7 @@ NEXTU
 ; pack
 wCurPocket:: db
 wPackUsedItem:: db
+wTMHMShowMoveInfo:: db
 
 NEXTU
 ; trainer card badges


### PR DESCRIPTION
Implemented and tested by **Chatgpt Astra**, using @vulcandth's account.

Fixes #1112, following [Rangi42's agreement with the requested behavior](https://github.com/Rangi42/polishedcrystal/issues/1112#issuecomment-2925534688).

Pressing **Select** in the TM/HM pocket now toggles the description area between the move description and its **colored battle type/category icons**, power, accuracy, and base PP. The selected view follows the cursor while scrolling. Reentering the pocket starts with descriptions. Move properties come from the existing move table and respect the physical/special split option; unavailable power/accuracy use the existing `---` convention.

The existing battle icon graphics and palettes are rendered as six sprites inside the textbox. The Bag already uses all eight background palettes, so a dedicated OBJ palette preserves the pocket tabs, text, and TM disc colors. Sprite transfers happen during VBlank, and the icons clear when returning to descriptions, selecting Cancel, or leaving the pocket.

Validation:

- Built standard and faithful ROMs successfully.
- Reviewed the [assembly optimization guide](https://github.com/pret/pokecrystal/wiki/Optimizing-assembly-code); `python3 utils/optimize.py` reported **0 findings** before and after. `git diff --check` passed.
- In vibeEmu, verified all **81 TMs/HMs** in both builds with the physical/special split on and off, then again after alphabetical sorting.
- Verified the six icon tiles and their colors against the battle assets, shadow/actual OAM positions, and unchanged Bag background palettes.
- Verified exact description restoration, scrolling, Select on Cancel/empty inventory, the Use/Quit submenu, pocket switching, and B exit. Both runs completed without crashes.
- Injected the inventory and entered the real Bag directly through a temporary emulator setup; no story playthrough or player save changes were needed.

Screenshots are actual vibeEmu framebuffer captures. The first three show the same move and cursor position across two Select presses:

| Description | Select → properties | Select → description |
| --- | --- | --- |
| <img src="https://raw.githubusercontent.com/Rangi42/polishedcrystal/ffe1a858e374b10e165427b4988144e0894319e6/standard/description.png" width="320" alt="DynamicPunch description before pressing Select"> | <img src="https://raw.githubusercontent.com/Rangi42/polishedcrystal/ffe1a858e374b10e165427b4988144e0894319e6/standard/physical.png" width="320" alt="DynamicPunch Fighting Physical 100 power 50 percent accuracy 5 PP"> | <img src="https://raw.githubusercontent.com/Rangi42/polishedcrystal/ffe1a858e374b10e165427b4988144e0894319e6/standard/description-restored.png" width="320" alt="Original DynamicPunch description restored after pressing Select again"> |

| Status move | HM |
| --- | --- |
| <img src="https://raw.githubusercontent.com/Rangi42/polishedcrystal/ffe1a858e374b10e165427b4988144e0894319e6/standard/status.png" width="320" alt="Curse Ghost Status with unavailable power and accuracy and 10 PP"> | <img src="https://raw.githubusercontent.com/Rangi42/polishedcrystal/ffe1a858e374b10e165427b4988144e0894319e6/standard/surf.png" width="320" alt="Surf Water Special 90 power 100 percent accuracy 15 PP"> |

[Full screenshots and test transcripts](https://github.com/Rangi42/polishedcrystal/tree/ffe1a858e374b10e165427b4988144e0894319e6) are on a separate evidence branch, keeping the code PR limited to the implementation.
