### PR TITLE
Color HP bars using exact HP ratios

### DIFF
--- a/engine/battle/anim_hp_bar.asm
+++ b/engine/battle/anim_hp_bar.asm
@@ -176,8 +176,19 @@ HPBarAnim_UpdateTiles:
 	pop de
 .skip
 	call DrawBattleHPBar
-	ld hl, wCurHPAnimPal
-	call SetHPPal
+	; Animation HP values are little-endian. Use the displayed HP, including
+	; the exact final HP when a threshold changes without changing a pixel.
+	ld hl, wCurHPAnimMaxHP
+	ld a, [hli]
+	ld e, a
+	ld a, [hli]
+	ld d, a
+	ld a, [hli]
+	ld c, a
+	ld b, [hl]
+	call GetHPPalFromHP
+	ld a, d
+	ld [wCurHPAnimPal], a
 	ld c, d
 	farjp ApplyHPBarPals
 

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -3915,10 +3915,12 @@ UpdateBattleHUDs:
 	push bc
 	call DrawPlayerHUD
 	ld hl, wPlayerHPPal
+	ld bc, wBattleMonHP
 	call SetHPPal
 	call CheckDanger
 	call DrawEnemyHUD
 	ld hl, wEnemyHPPal
+	ld bc, wEnemyMonHP
 	call SetHPPal
 	jmp PopBCDEHL
 
@@ -4243,17 +4245,20 @@ BattleAnimateHPBar:
 	ret
 
 UpdatePlayerHPPal:
+	ld bc, wBattleMonHP
 	ld hl, wPlayerHPPal
 	jr UpdateHPPal
 
 UpdateEnemyHPPal:
+	ld bc, wEnemyMonHP
 	ld hl, wEnemyHPPal
 	; fallthrough
 UpdateHPPal:
-	ld b, [hl]
-	call SetHPPal
 	ld a, [hl]
-	cp b
+	push af
+	call SetHPPal
+	pop af
+	cp [hl]
 	ret z
 	jmp FinishBattleAnim
 

--- a/engine/gfx/mon_icons.asm
+++ b/engine/gfx/mon_icons.asm
@@ -487,8 +487,8 @@ SetPartyMonMiniAnimSpeed:
 	bit MON_IS_EGG_F, [hl]
 	jr nz, .egg
 	ldh a, [hObjectStructIndexBuffer]
-	ld b, a
-	farcall PlacePartymonHPBar
+	ld hl, wPartyMon1HP
+	call GetPartyLocation
 	call GetHPPal
 .gotindex
 	ld e, d

--- a/engine/pokemon/health.asm
+++ b/engine/pokemon/health.asm
@@ -98,3 +98,31 @@ ComputeHPBarPixels:
 .zero
 	ld e, 0
 	ret
+
+GetHPPalFromHP:
+; Get palette in d for HP bc and max HP de, independently of bar pixels.
+; Preserve bc and hl. HP is at most 999, so multiplying by 5 fits in 16 bits.
+	push hl
+	ld h, b
+	ld l, c
+	add hl, hl
+	; Green when HP * 2 > max HP.
+	ld a, e
+	sub l
+	ld a, d
+	sbc h
+	ld a, HP_GREEN
+	jr c, .done
+	; Red when HP * 5 < max HP; yellow includes exactly 20% and 50%.
+	add hl, hl
+	add hl, bc
+	ld a, l
+	sub e
+	ld a, h
+	sbc d
+	ld a, HP_YELLOW
+	adc 0 ; HP_RED if carry
+.done
+	ld d, a
+	pop hl
+	ret

--- a/engine/pokemon/party_menu.asm
+++ b/engine/pokemon/party_menu.asm
@@ -624,12 +624,16 @@ PlacePartyHPBar:
 	pop hl
 	ld d, 6
 	call DrawBattleHPBar
+	ld a, [wHPPalIndex]
+	ld hl, wPartyMon1HP
+	call GetPartyLocation
+	call GetHPPal
 	ld hl, wHPPals
 	ld a, [wHPPalIndex]
 	ld c, a
 	ld b, 0
 	add hl, bc
-	call SetHPPal
+	ld [hl], d
 	farcall ApplyPartyMenuHPPals ; updates wHPPalIndex
 .skip
 	ld hl, wHPPalIndex

--- a/engine/pokemon/summary_screen.asm
+++ b/engine/pokemon/summary_screen.asm
@@ -463,15 +463,7 @@ SummaryScreen_InitLayout:
 	ret
 
 .PlaceHPBar:
-	ld hl, wTempMonHP
-	ld a, [hli]
-	ld b, a
-	ld c, [hl]
-	ld hl, wTempMonMaxHP
-	ld a, [hli]
-	ld d, a
-	ld e, [hl]
-	farcall ComputeHPBarPixels
+	ld bc, wTempMonHP
 	ld hl, wCurHPPal
 	call SetHPPal
 	jmp DelayFrame

--- a/home/tilemap.asm
+++ b/home/tilemap.asm
@@ -32,19 +32,28 @@ endc
 	ret
 
 SetHPPal::
-; Set palette for hp bar pixel length e at hl.
+; Set palette at hl for the big-endian HP and max HP at bc.
+	push hl
+	ld h, b
+	ld l, c
 	call GetHPPal
+	pop hl
 	ld [hl], d
 	ret
 
 GetHPPal::
-; Get palette for hp bar pixel length e in d.
-	ld d, HP_GREEN
-	ld a, e
-	cp 25
-	ret nc
-	inc d ; HP_YELLOW
-	cp 10
-	ret nc
-	inc d ; HP_RED
+; Get palette in d for the big-endian HP and max HP at hl.
+; Preserve bc and hl.
+	push bc
+	push hl
+	ld a, [hli]
+	ld b, a
+	ld a, [hli]
+	ld c, a
+	ld a, [hli]
+	ld d, a
+	ld e, [hl]
+	farcall GetHPPalFromHP
+	pop hl
+	pop bc
 	ret


### PR DESCRIPTION
HP bars can currently show yellow at 51/100 HP and red at 20/100 HP because their colors come from rounded pixel widths. Choose colors from exact current/max HP instead: green above 50%, yellow from 20% through 50%, and red below 20%.

Update battle HUDs, party bars, summary bars, and party icon animation speed to use the shared exact comparison. Animated bars use the displayed HP, including the exact final value when a threshold changes without changing the pixel width. Pixel-width calculations remain unchanged. The comparison uses 16-bit additions and subtraction in the existing health-code bank, avoiding division and additional WRAM.

Fixes #1543.

Implemented and tested by **Chatgpt Astra**.

### Before / after

The same injected party in both ROMs, with 51, 50, 20, 19, 1, and 0 HP out of 100. These are unaltered emulator screenshots; the first and third rows demonstrate the corrected colors.

| Before (`master`) | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/Rangi42/polishedcrystal/3b95207574110feb57ba88d0565c6b04b57bfa3f/before.png" width="320" alt="Before: 51/100 HP is yellow and 20/100 HP is red"> | <img src="https://raw.githubusercontent.com/Rangi42/polishedcrystal/3b95207574110feb57ba88d0565c6b04b57bfa3f/after.png" width="320" alt="After: 51/100 HP is green and 20/100 HP is yellow"> |

### Validation

- Standard ROM and combined Faithful/debug/Virtual Console builds passed (`make -j4`; isolated `make faithful debug vc -j4`).
- Executed the compiled comparison routine in PyBoy for all **500,499** current/max HP combinations with max HP 1–999; checked colors against exact rational fractions and verified preserved registers.
- Passed **112** battle palette, summary palette, and party icon caller cases. Display-delay/refresh routines were stubbed in these isolated caller checks.
- Passed **12** actual damage/healing animation cases, including same-pixel threshold crossings, zero/full HP, and HP above 255. Animation, tile drawing, and palette updates were not stubbed.
- Reviewed the [assembly optimization guide](https://github.com/pret/pokecrystal/wiki/Optimizing-assembly-code); repository-wide `python3 utils/optimize.py` reports **0 instances**. `git diff --check` passed.

[Screenshots, reproducible emulator harnesses, and test logs](https://github.com/Rangi42/polishedcrystal/tree/3b95207574110feb57ba88d0565c6b04b57bfa3f) are on a separate evidence branch. Test fixtures inject HP/party data and enter the relevant routines directly, without playing through the story.
