### PR TITLE
Fix link party corruption from unescaped trainer ID bytes

### DIFF
--- a/constants/serial_constants.asm
+++ b/constants/serial_constants.asm
@@ -58,9 +58,10 @@ else
 endc
 
 ; this game's link version
-DEF LINK_VERSION EQU 4
+DEF LINK_VERSION EQU 5
 ; This is the minimum link version allowed for trading
-DEF LINK_MIN_TRADE_VERSION EQU 3
+; Older versions use a different party patch-list origin.
+DEF LINK_MIN_TRADE_VERSION EQU 5
 
 ; PerformLinkChecks error codes
 	const_def

--- a/engine/link/link.asm
+++ b/engine/link/link.asm
@@ -79,7 +79,7 @@ Gen2ToGen2LinkComms:
 	ld hl, wOTPartyData
 	call Link_FindFirstNonControlCharacter_SkipZero
 	ld de, wLinkData
-	ld bc, NAME_LENGTH + 1 + PARTY_LENGTH + 1 + 2 + (PARTYMON_STRUCT_LENGTH + NAME_LENGTH * 2) * PARTY_LENGTH
+	ld bc, wLinkPlayerDataEnd - wLinkPlayerName
 	call Link_CopyOTData
 
 	ld de, wPlayerTrademon
@@ -391,7 +391,10 @@ FixDataForLinkTransfer:
 	dec b
 	jr nz, .loop1
 
-	ld hl, wLinkPlayerPartyMon1ID - 1
+	; The outgoing buffer still has its preamble. Patch the player ID as well
+	; as all party structs, using the same origin as the decoded patch lists.
+	assert wLinkPatchList1 == wLinkPlayerID
+	ld hl, wLinkPlayerID + SERIAL_PREAMBLE_LENGTH - 1
 	ld de, wLinkPlayerFixedPartyMon1ID
 	lb bc, 0, 0
 .loop2

--- a/ram/wram0.asm
+++ b/ram/wram0.asm
@@ -904,15 +904,14 @@ wLinkDataEnd::
 
 
 SECTION UNION "Misc 1300", WRAM0
-; link data members
+; decoded link data members (without the serial preamble)
 
 wLinkPlayerName:: ds NAME_LENGTH
 wLinkPartyCount:: db
-wLinkPartySpecies:: ds PARTY_LENGTH
-wLinkPartyEnd:: db ; older code doesn't check PartyCount
 
 UNION
 ; link player data
+wLinkPlayerID:: dw
 wLinkPlayerData::
 for n, 1, PARTY_LENGTH + 1
 wLinkPlayerPartyMon{d:n}:: party_struct wLinkPlayerPartyMon{d:n}


### PR DESCRIPTION
Rtas's attached save has trainer ID `$75FE`. The link encoder leaves the player ID unescaped, so `Link_CopyOTData` discards its `$FE` byte as “no data” and shifts the following party data. This reproduces in the official faithful 3.1.1 ROM and current master, even with an ideal byte transfer. The fixed ROM preserves the trainer ID, party, OT names and nicknames exactly.

Investigated and implemented by **Chatgpt Astra**.

Fixes #1179.

The patch scan starts seven bytes too late, missing both player-ID bytes and the first five bytes of the first Pokémon. Correct the decoded buffer layout by removing the obsolete party-species list and adding the actual player ID; use that ID as the patch origin, accounting for the outgoing preamble. Derive the decoded copy length from the layout. Bump both the link version and minimum trade version to 5 because the corrected patch offsets are incompatible with older builds. **Both games must use the updated protocol to link.**

| Before: unmodified master | After: fixed master |
| --- | --- |
| ![Corrupted received Rtas party](https://raw.githubusercontent.com/Rangi42/polishedcrystal/evidence/1179-link-party-id/before.png) | ![Received Rtas party matches exactly](https://raw.githubusercontent.com/Rangi42/polishedcrystal/evidence/1179-link-party-id/after.png) |

These are actual vibeEmu PPU captures at 4x nearest-neighbor scale. The ROM draws its trade screen from Rtas's local and decoded party data. The attached save's party order differs from the original issue screenshots. RAM setup skips the playthrough and selects normal font/instant text.

Validation:

- Reproduced on official faithful 3.1.1 and master `f27896d894`: 265 of 288 party bytes differ with the original Rtas payload.
- Changing **only** Rtas's in-memory player ID from `$75FE` to `$75FD` makes unmodified master pass; Pokémon OT IDs remain unchanged. Kido's attached save also passes before the fix.
- Fixed faithful and clean non-faithful builds pass exact round trips for both valid attached saves, plus 290 independent `$FE` injections covering every player-ID/party byte and both patch-list boundaries.
- ROM version checks reject peers using versions 3/4 and accept version 5 for both trades and battles.
- `make -j4 faithful`, clean `make -j4`, `git diff --check`, and `python3 utils/optimize.py` pass; the optimizer reports zero findings. Reviewed the requested assembly optimization guide.

The [reproduction scripts, logs and investigation notes](https://github.com/Rangi42/polishedcrystal/tree/evidence/1179-link-party-id) describe the exact setup. This tests real ROM serialization/deserialization and rendering routines with an ideal transfer; it does **not** test a two-console cable session, completed trade, mail, or summary navigation. It does not diagnose or fix the separate `rSC` fast-clock desync.

Rtas and Kido both have valid primary/backup v9 checksums (`$DAA5` and `$B777`). `PCFAITHFUL.dmp` has erased player-data/checksum regions and is unusable as a control. I also reviewed the [save patcher's relevant conversion code](https://github.com/fellowship-of-the-roms/polished-save-patcher/blob/b3f39c95b2603016bd01a1e38246bcd9799ed2c6/src/patching/PatchVersion8to9.cpp) without modifying it: the trainer ID is preserved. There is no evidence that the patcher caused this failure; the original affected save reproduces it without running the patcher.
