### PR TITLE
use exact color for HP bars

### DIFF
--- a/engine/battle/anim_hp_bar.asm
+++ b/engine/battle/anim_hp_bar.asm
@@ -176,9 +176,8 @@ HPBarAnim_UpdateTiles:
 	pop de
 .skip
 	call DrawBattleHPBar
-	; Animation HP values are little-endian. Use the displayed HP, including
-	; the exact final HP when a threshold changes without changing a pixel.
 	ld hl, wCurHPAnimMaxHP
+	; Get palette in d for the little-endian HP and max HP at hl.
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]
@@ -259,9 +258,9 @@ HPBarAnim_BGMapUpdate:
 	and STAT_MODE ; wait until mode 0
 	jr nz, .waithbl1
 	ld a, b
-	rept 7
+rept 7
 	ld [hli], a
-	endr
+endr
 	xor a
 	ldh [rVBK], a
 	ei

--- a/engine/battle/anim_hp_bar.asm
+++ b/engine/battle/anim_hp_bar.asm
@@ -176,8 +176,19 @@ HPBarAnim_UpdateTiles:
 	pop de
 .skip
 	call DrawBattleHPBar
-	ld hl, wCurHPAnimPal
-	call SetHPPal
+	; Animation HP values are little-endian. Use the displayed HP, including
+	; the exact final HP when a threshold changes without changing a pixel.
+	ld hl, wCurHPAnimMaxHP
+	ld a, [hli]
+	ld e, a
+	ld a, [hli]
+	ld d, a
+	ld a, [hli]
+	ld c, a
+	ld b, [hl]
+	call GetHPPalFromHP
+	ld a, d
+	ld [wCurHPAnimPal], a
 	ld c, d
 	farjp ApplyHPBarPals
 

--- a/engine/battle/core.asm
+++ b/engine/battle/core.asm
@@ -3915,10 +3915,12 @@ UpdateBattleHUDs:
 	push bc
 	call DrawPlayerHUD
 	ld hl, wPlayerHPPal
+	ld bc, wBattleMonHP
 	call SetHPPal
 	call CheckDanger
 	call DrawEnemyHUD
 	ld hl, wEnemyHPPal
+	ld bc, wEnemyMonHP
 	call SetHPPal
 	jmp PopBCDEHL
 
@@ -4243,17 +4245,20 @@ BattleAnimateHPBar:
 	ret
 
 UpdatePlayerHPPal:
+	ld bc, wBattleMonHP
 	ld hl, wPlayerHPPal
 	jr UpdateHPPal
 
 UpdateEnemyHPPal:
+	ld bc, wEnemyMonHP
 	ld hl, wEnemyHPPal
 	; fallthrough
 UpdateHPPal:
-	ld b, [hl]
-	call SetHPPal
 	ld a, [hl]
-	cp b
+	push af
+	call SetHPPal
+	pop af
+	cp [hl]
 	ret z
 	jmp FinishBattleAnim
 

--- a/engine/gfx/mon_icons.asm
+++ b/engine/gfx/mon_icons.asm
@@ -487,8 +487,8 @@ SetPartyMonMiniAnimSpeed:
 	bit MON_IS_EGG_F, [hl]
 	jr nz, .egg
 	ldh a, [hObjectStructIndexBuffer]
-	ld b, a
-	farcall PlacePartymonHPBar
+	ld hl, wPartyMon1HP
+	call GetPartyLocation
 	call GetHPPal
 .gotindex
 	ld e, d

--- a/engine/pokemon/health.asm
+++ b/engine/pokemon/health.asm
@@ -98,3 +98,29 @@ ComputeHPBarPixels:
 .zero
 	ld e, 0
 	ret
+
+GetHPPalFromHP:
+; Get palette in d for HP bc and max HP de, independently of bar pixels.
+; HP is at most 999, so multiplying by 5 fits in 16 bits.
+	ld h, b
+	ld l, c
+	add hl, hl
+	; Green when HP * 2 > max HP.
+	ld a, e
+	sub l
+	ld a, d
+	sbc h
+	ld a, HP_GREEN
+	jr c, .done
+	; Red when HP * 5 < max HP; yellow includes exactly 20% and 50%.
+	add hl, hl
+	add hl, bc
+	ld a, l
+	sub e
+	ld a, h
+	sbc d
+	ld a, HP_YELLOW
+	adc 0 ; HP_RED if carry
+.done
+	ld d, a
+	ret

--- a/engine/pokemon/party_menu.asm
+++ b/engine/pokemon/party_menu.asm
@@ -624,12 +624,17 @@ PlacePartyHPBar:
 	pop hl
 	ld d, 6
 	call DrawBattleHPBar
-	ld hl, wHPPals
 	ld a, [wHPPalIndex]
-	ld c, a
-	ld b, 0
-	add hl, bc
-	call SetHPPal
+	ld hl, wPartyMon1HP
+	call GetPartyLocation
+	call GetHPPal
+	ld a, [wHPPalIndex]
+	add LOW(wHPPals)
+	ld l, a
+	adc HIGH(wHPPals)
+	sub l
+	ld h, a
+	ld [hl], d
 	farcall ApplyPartyMenuHPPals ; updates wHPPalIndex
 .skip
 	ld hl, wHPPalIndex

--- a/engine/pokemon/summary_screen.asm
+++ b/engine/pokemon/summary_screen.asm
@@ -463,15 +463,7 @@ SummaryScreen_InitLayout:
 	ret
 
 .PlaceHPBar:
-	ld hl, wTempMonHP
-	ld a, [hli]
-	ld b, a
-	ld c, [hl]
-	ld hl, wTempMonMaxHP
-	ld a, [hli]
-	ld d, a
-	ld e, [hl]
-	farcall ComputeHPBarPixels
+	ld bc, wTempMonHP
 	ld hl, wCurHPPal
 	call SetHPPal
 	jmp DelayFrame

--- a/home/tilemap.asm
+++ b/home/tilemap.asm
@@ -50,5 +50,4 @@ GetHPPal::
 	ld a, [hli]
 	ld d, a
 	ld e, [hl]
-	farcall GetHPPalFromHP
-	ret
+	farjp GetHPPalFromHP

--- a/home/tilemap.asm
+++ b/home/tilemap.asm
@@ -32,19 +32,23 @@ endc
 	ret
 
 SetHPPal::
-; Set palette for hp bar pixel length e at hl.
+; Set palette at hl for the big-endian HP and max HP at bc.
+	push hl
+	ld h, b
+	ld l, c
 	call GetHPPal
+	pop hl
 	ld [hl], d
 	ret
 
 GetHPPal::
-; Get palette for hp bar pixel length e in d.
-	ld d, HP_GREEN
-	ld a, e
-	cp 25
-	ret nc
-	inc d ; HP_YELLOW
-	cp 10
-	ret nc
-	inc d ; HP_RED
+; Get palette in d for the big-endian HP and max HP at hl.
+	ld a, [hli]
+	ld b, a
+	ld a, [hli]
+	ld c, a
+	ld a, [hli]
+	ld d, a
+	ld e, [hl]
+	farcall GetHPPalFromHP
 	ret


### PR DESCRIPTION
HP bar colors were being picked based on rounded pixel width of the bar, which could make 51/100 hp show as yellow and 20/100 hp show as red.

Verified in game by modifying:
```
01:dcf8 wPartyMon1HP
01:dcfa wPartyMon1MaxHP
```

fixes #1543 